### PR TITLE
Refactor e2e tests

### DIFF
--- a/pkg/controller/humiocluster/pods.go
+++ b/pkg/controller/humiocluster/pods.go
@@ -35,7 +35,7 @@ while true; do
 		sleep 5
 		continue
 	fi
-	TOKEN=$(jq -r ".users.${USER_ID}.entity.apiToken" $SNAPSHOT_FILE)
+	TOKEN=$(jq -r ".users.\"${USER_ID}\".entity.apiToken" $SNAPSHOT_FILE)
 	if [ "${TOKEN}" == "null" ]; then
 		echo "waiting on token"
 		sleep 5

--- a/test/e2e/bootstrap_test.go
+++ b/test/e2e/bootstrap_test.go
@@ -1,0 +1,71 @@
+package e2e
+
+import (
+	goctx "context"
+	"fmt"
+	corev1alpha1 "github.com/humio/humio-operator/pkg/apis/core/v1alpha1"
+	"github.com/humio/humio-operator/pkg/kubernetes"
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"time"
+)
+
+type bootstrapTest struct {
+	cluster *corev1alpha1.HumioCluster
+}
+
+func newBootstrapTest(clusterName string, namespace string) humioClusterTest {
+	return &bootstrapTest{
+		cluster: &corev1alpha1.HumioCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterName,
+				Namespace: namespace,
+			},
+			Spec: corev1alpha1.HumioClusterSpec{
+				NodeCount: 1,
+				EnvironmentVariables: []corev1.EnvVar{
+					{
+						Name:  "ZOOKEEPER_URL",
+						Value: "humio-cp-zookeeper-0.humio-cp-zookeeper-headless.default:2181",
+					},
+					{
+						Name:  "KAFKA_SERVERS",
+						Value: "humio-cp-kafka-0.humio-cp-kafka-headless.default:9092",
+					},
+				},
+			},
+		},
+	}
+}
+
+func (b *bootstrapTest) Start(f *framework.Framework, ctx *framework.Context) error {
+	return f.Client.Create(goctx.TODO(), b.cluster, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+}
+
+func (b *bootstrapTest) Wait(f *framework.Framework) error {
+	for start := time.Now(); time.Since(start) < timeout; {
+		err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: b.cluster.ObjectMeta.Name, Namespace: b.cluster.ObjectMeta.Namespace}, b.cluster)
+		if err != nil {
+			fmt.Printf("could not get humio cluster: %s", err)
+		}
+		if b.cluster.Status.State == corev1alpha1.HumioClusterStateRunning {
+			return nil
+		}
+
+		if foundPodList, err := kubernetes.ListPods(
+			f.Client.Client,
+			b.cluster.Namespace,
+			kubernetes.MatchingLabelsForHumio(b.cluster.Name),
+		); err != nil {
+			for _, pod := range foundPodList {
+				fmt.Println(fmt.Sprintf("pod %s status: %#v", pod.Name, pod.Status))
+			}
+		}
+
+		time.Sleep(time.Second * 10)
+	}
+
+	return fmt.Errorf("timed out waiting for cluster state to become: %s", corev1alpha1.HumioClusterStateRunning)
+}

--- a/test/e2e/humiocluster_test.go
+++ b/test/e2e/humiocluster_test.go
@@ -1,51 +1,44 @@
 package e2e
 
 import (
-	goctx "context"
-	"fmt"
+	"k8s.io/apimachinery/pkg/runtime"
 	"testing"
 	"time"
-
+	"os/exec"
+	"fmt"
 	"github.com/humio/humio-operator/pkg/apis"
 	corev1alpha1 "github.com/humio/humio-operator/pkg/apis/core/v1alpha1"
-	"github.com/humio/humio-operator/pkg/kubernetes"
-
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
-var (
+const (
 	retryInterval        = time.Second * 5
 	timeout              = time.Second * 300
 	cleanupRetryInterval = time.Second * 1
 	cleanupTimeout       = time.Second * 5
 )
 
+type humioClusterTest interface {
+	Start(f *framework.Framework, ctx *framework.Context) error
+	Wait(f *framework.Framework) error
+}
+
 func TestHumioCluster(t *testing.T) {
-	HumioClusterList := &corev1alpha1.HumioClusterList{}
-	err := framework.AddToFrameworkScheme(apis.AddToScheme, HumioClusterList)
-	if err != nil {
-		t.Fatalf("failed to add custom resource scheme to framework: %v", err)
+	schemes := []runtime.Object{
+		&corev1alpha1.HumioClusterList{},
+		&corev1alpha1.HumioIngestTokenList{},
+		&corev1alpha1.HumioParserList{},
+		&corev1alpha1.HumioRepositoryList{},
 	}
-	HumioIngestTokenList := &corev1alpha1.HumioIngestTokenList{}
-	err = framework.AddToFrameworkScheme(apis.AddToScheme, HumioIngestTokenList)
-	if err != nil {
-		t.Fatalf("failed to add custom resource scheme to framework: %v", err)
+
+	for _, scheme := range schemes {
+		err := framework.AddToFrameworkScheme(apis.AddToScheme, scheme)
+		if err != nil {
+			t.Fatalf("failed to add custom resource scheme to framework: %v", err)
+		}
 	}
-	HumioParserList := &corev1alpha1.HumioParserList{}
-	err = framework.AddToFrameworkScheme(apis.AddToScheme, HumioParserList)
-	if err != nil {
-		t.Fatalf("failed to add custom resource scheme to framework: %v", err)
-	}
-	HumioRepositoryList := &corev1alpha1.HumioRepositoryList{}
-	err = framework.AddToFrameworkScheme(apis.AddToScheme, HumioRepositoryList)
-	if err != nil {
-		t.Fatalf("failed to add custom resource scheme to framework: %v", err)
-	}
-	// run subtests
+
 	t.Run("humiocluster-group", func(t *testing.T) {
 		t.Run("cluster", HumioCluster)
 	})
@@ -53,7 +46,7 @@ func TestHumioCluster(t *testing.T) {
 
 func HumioCluster(t *testing.T) {
 	t.Parallel()
-	ctx := framework.NewTestCtx(t)
+	ctx := framework.NewContext(t)
 	defer ctx.Cleanup()
 	err := ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
@@ -72,191 +65,43 @@ func HumioCluster(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// run the tests
 	clusterName := "example-humiocluster"
-	if err = HumioClusterBootstrapTest(t, f, ctx, clusterName); err != nil {
-		t.Fatal(err)
+	tests := []humioClusterTest{
+		newBootstrapTest(clusterName, namespace),
+		newIngestTokenTest(clusterName, namespace),
+		newParserTest(clusterName, namespace),
+		newRepositoryTest(clusterName, namespace),
 	}
-	if err = HumioIngestTokenTest(t, f, ctx, clusterName); err != nil {
-		t.Fatal(err)
+
+	go printKubectlcommands(t, namespace)
+
+	for _, test := range tests {
+		if err = test.Start(f, ctx); err != nil {
+			t.Fatal(err)
+		}
 	}
-	if err = HumioParserTest(t, f, ctx, clusterName); err != nil {
-		t.Fatal(err)
-	}
-	if err = HumioRepositoryTest(t, f, ctx, clusterName); err != nil {
-		t.Fatal(err)
+	for _, test := range tests {
+		if err = test.Wait(f); err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 
-func HumioClusterBootstrapTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, clusterName string) error {
-	namespace, _ := ctx.GetWatchNamespace()
-
-	// create HumioCluster custom resource
-	exampleHumioCluster := &corev1alpha1.HumioCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterName,
-			Namespace: namespace,
-		},
-		Spec: corev1alpha1.HumioClusterSpec{
-			NodeCount: 1,
-			EnvironmentVariables: []corev1.EnvVar{
-				{
-					Name:  "ZOOKEEPER_URL",
-					Value: "humio-cp-zookeeper-0.humio-cp-zookeeper-headless.default:2181",
-				},
-				{
-					Name:  "KAFKA_SERVERS",
-					Value: "humio-cp-kafka-0.humio-cp-kafka-headless.default:9092",
-				},
-			},
-		},
-	}
-	// use TestCtx's create helper to create the object and add a cleanup function for the new object
-	err := f.Client.Create(goctx.TODO(), exampleHumioCluster, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
-	if err != nil {
-		return err
+func printKubectlcommands(t *testing.T, namespace string) {
+	commands := []string{
+		"kubectl get pods -A",
+		fmt.Sprintf("kubectl describe pods -n %s", namespace),
+		fmt.Sprintf("kubectl logs deploy/humio-operator -n %s", namespace),
 	}
 
-	for i := 0; i < 30; i++ {
-		err = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: exampleHumioCluster.ObjectMeta.Name, Namespace: namespace}, exampleHumioCluster)
-		if err != nil {
-			fmt.Printf("could not get humio cluster: %s", err)
+	ticker := time.NewTicker(time.Second * 5)
+	for _ = range ticker.C {
+		for _, command := range commands {
+			cmd := exec.Command("bash", "-c", command)
+			stdoutStderr, err := cmd.CombinedOutput()
+			t.Log(fmt.Sprintf("%s, %s\n", stdoutStderr, err))
 		}
-		if exampleHumioCluster.Status.State == corev1alpha1.HumioClusterStateRunning {
-			return nil
-		}
-
-		if foundPodList, err := kubernetes.ListPods(
-			f.Client.Client,
-			exampleHumioCluster.Namespace,
-			kubernetes.MatchingLabelsForHumio(exampleHumioCluster.Name),
-		); err != nil {
-			for _, pod := range foundPodList {
-				fmt.Println(fmt.Sprintf("pod %s status: %#v", pod.Name, pod.Status))
-			}
-		}
-
-		time.Sleep(time.Second * 10)
 	}
-
-	return fmt.Errorf("timed out waiting for cluster state to become: %s", corev1alpha1.HumioClusterStateRunning)
-}
-
-func HumioIngestTokenTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, clusterName string) error {
-	namespace, _ := ctx.GetWatchNamespace()
-
-	// create HumioIngestToken custom resource
-	exampleHumioIngestToken := &corev1alpha1.HumioIngestToken{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-humioingesttoken",
-			Namespace: namespace,
-		},
-		Spec: corev1alpha1.HumioIngestTokenSpec{
-			ManagedClusterName: clusterName,
-			Name:               "example-humioingesttoken",
-			RepositoryName:     "humio",
-			TokenSecretName:    "ingest-token-secret",
-		},
-	}
-	// use TestCtx's create helper to create the object and add a cleanup function for the new object
-	err := f.Client.Create(goctx.TODO(), exampleHumioIngestToken, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
-	if err != nil {
-		return err
-	}
-
-	for i := 0; i < 5; i++ {
-		err = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: exampleHumioIngestToken.ObjectMeta.Name, Namespace: namespace}, exampleHumioIngestToken)
-		if err != nil {
-			fmt.Printf("could not get humio ingest token: %s", err)
-		}
-
-		if exampleHumioIngestToken.Status.State == corev1alpha1.HumioIngestTokenStateExists {
-			return nil
-		}
-
-		time.Sleep(time.Second * 2)
-	}
-
-	return fmt.Errorf("timed out waiting for ingest token state to become: %s", corev1alpha1.HumioIngestTokenStateExists)
-}
-
-func HumioParserTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, clusterName string) error {
-	namespace, _ := ctx.GetWatchNamespace()
-
-	// create HumioParser custom resource
-	exampleHumioParser := &corev1alpha1.HumioParser{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-parser",
-			Namespace: namespace,
-		},
-		Spec: corev1alpha1.HumioParserSpec{
-			ManagedClusterName: clusterName,
-			Name:               "example-parser",
-			RepositoryName:     "humio",
-			ParserScript:       "kvParse()",
-			TagFields:          []string{"@somefield"},
-			TestData:           []string{"testdata"},
-		},
-	}
-	// use TestCtx's create helper to create the object and add a cleanup function for the new object
-	err := f.Client.Create(goctx.TODO(), exampleHumioParser, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
-	if err != nil {
-		return err
-	}
-
-	for i := 0; i < 5; i++ {
-		err = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: exampleHumioParser.ObjectMeta.Name, Namespace: namespace}, exampleHumioParser)
-		if err != nil {
-			fmt.Printf("could not get humio parser: %s", err)
-		}
-
-		if exampleHumioParser.Status.State == corev1alpha1.HumioParserStateExists {
-			return nil
-		}
-
-		time.Sleep(time.Second * 2)
-	}
-
-	return fmt.Errorf("timed out waiting for parser state to become: %s", corev1alpha1.HumioParserStateExists)
-}
-
-func HumioRepositoryTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, clusterName string) error {
-	namespace, _ := ctx.GetWatchNamespace()
-
-	// create HumioParser custom resource
-	exampleHumioRepository := &corev1alpha1.HumioRepository{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-repository",
-			Namespace: namespace,
-		},
-		Spec: corev1alpha1.HumioRepositorySpec{
-			ManagedClusterName: clusterName,
-			Name:               "example-repository",
-			Description:        "this is an important message",
-			Retention: corev1alpha1.HumioRetention{
-				IngestSizeInGB:  5,
-				StorageSizeInGB: 1,
-				TimeInDays:      7,
-			},
-		},
-	}
-	// use TestCtx's create helper to create the object and add a cleanup function for the new object
-	err := f.Client.Create(goctx.TODO(), exampleHumioRepository, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
-	if err != nil {
-		return err
-	}
-
-	for i := 0; i < 5; i++ {
-		err = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: exampleHumioRepository.ObjectMeta.Name, Namespace: namespace}, exampleHumioRepository)
-		if err != nil {
-			fmt.Printf("could not get humio repository: %s", err)
-		}
-
-		if exampleHumioRepository.Status.State == corev1alpha1.HumioRepositoryStateExists {
-			return nil
-		}
-
-		time.Sleep(time.Second * 2)
-	}
-
-	return fmt.Errorf("timed out waiting for repository state to become: %s", corev1alpha1.HumioRepositoryStateExists)
 }

--- a/test/e2e/ingest_token_test.go
+++ b/test/e2e/ingest_token_test.go
@@ -1,0 +1,51 @@
+package e2e
+
+import (
+	goctx "context"
+	"fmt"
+	corev1alpha1 "github.com/humio/humio-operator/pkg/apis/core/v1alpha1"
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"time"
+)
+
+type ingestTokenTest struct {
+	ingestToken *corev1alpha1.HumioIngestToken
+}
+
+func newIngestTokenTest(clusterName string, namespace string) humioClusterTest {
+	return &ingestTokenTest{
+		ingestToken: &corev1alpha1.HumioIngestToken{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example-humioingesttoken",
+				Namespace: namespace,
+			},
+			Spec: corev1alpha1.HumioIngestTokenSpec{
+				ManagedClusterName: clusterName,
+				Name:               "example-humioingesttoken",
+				RepositoryName:     "humio",
+				TokenSecretName:    "ingest-token-secret",
+			},
+		},
+	}
+}
+
+func (i *ingestTokenTest) Start(f *framework.Framework, ctx *framework.Context) error {
+	return f.Client.Create(goctx.TODO(), i.ingestToken, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+}
+
+func (i *ingestTokenTest) Wait(f *framework.Framework) error {
+	for start := time.Now(); time.Since(start) < timeout; {
+		err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: i.ingestToken.ObjectMeta.Name, Namespace: i.ingestToken.ObjectMeta.Namespace}, i.ingestToken)
+		if err != nil {
+			fmt.Printf("could not get humio ingest token: %s", err)
+		}
+		if i.ingestToken.Status.State == corev1alpha1.HumioIngestTokenStateExists {
+			return nil
+		}
+		time.Sleep(time.Second * 2)
+	}
+
+	return fmt.Errorf("timed out waiting for ingest token state to become: %s", corev1alpha1.HumioIngestTokenStateExists)
+}

--- a/test/e2e/parser_test.go
+++ b/test/e2e/parser_test.go
@@ -1,0 +1,52 @@
+package e2e
+
+import (
+	goctx "context"
+	"fmt"
+	corev1alpha1 "github.com/humio/humio-operator/pkg/apis/core/v1alpha1"
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"time"
+)
+
+type parserTest struct {
+	parser *corev1alpha1.HumioParser
+}
+
+func newParserTest(clusterName string, namespace string) humioClusterTest {
+	return &parserTest{
+		parser: &corev1alpha1.HumioParser{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example-parser",
+				Namespace: namespace,
+			},
+			Spec: corev1alpha1.HumioParserSpec{
+				ManagedClusterName: clusterName,
+				Name:               "example-parser",
+				RepositoryName:     "humio",
+				ParserScript:       "kvParse()",
+				TagFields:          []string{"@somefield"},
+				TestData:           []string{"testdata"},
+			},
+		},
+	}
+}
+
+func (p *parserTest) Start(f *framework.Framework, ctx *framework.Context) error {
+	return f.Client.Create(goctx.TODO(), p.parser, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+}
+
+func (p *parserTest) Wait(f *framework.Framework) error {
+	for start := time.Now(); time.Since(start) < timeout; {
+		err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: p.parser.ObjectMeta.Name, Namespace: p.parser.ObjectMeta.Namespace}, p.parser)
+		if err != nil {
+			fmt.Printf("could not get humio parser: %s", err)
+		}
+		if p.parser.Status.State == corev1alpha1.HumioParserStateExists {
+			return nil
+		}
+		time.Sleep(time.Second * 2)
+	}
+	return fmt.Errorf("timed out waiting for parser state to become: %s", corev1alpha1.HumioParserStateExists)
+}

--- a/test/e2e/repository_test.go
+++ b/test/e2e/repository_test.go
@@ -1,0 +1,53 @@
+package e2e
+
+import (
+	goctx "context"
+	"fmt"
+	corev1alpha1 "github.com/humio/humio-operator/pkg/apis/core/v1alpha1"
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"time"
+)
+
+type repositoryTest struct {
+	repository *corev1alpha1.HumioRepository
+}
+
+func newRepositoryTest(clusterName string, namespace string) humioClusterTest {
+	return &repositoryTest{
+		repository: &corev1alpha1.HumioRepository{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example-repository",
+				Namespace: namespace,
+			},
+			Spec: corev1alpha1.HumioRepositorySpec{
+				ManagedClusterName: clusterName,
+				Name:               "example-repository",
+				Description:        "this is an important message",
+				Retention: corev1alpha1.HumioRetention{
+					IngestSizeInGB:  5,
+					StorageSizeInGB: 1,
+					TimeInDays:      7,
+				},
+			},
+		},
+	}
+}
+
+func (r *repositoryTest) Start(f *framework.Framework, ctx *framework.Context) error {
+	return f.Client.Create(goctx.TODO(), r.repository, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+}
+func (r *repositoryTest) Wait(f *framework.Framework) error {
+	for start := time.Now(); time.Since(start) < timeout; {
+		err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: r.repository.ObjectMeta.Name, Namespace: r.repository.ObjectMeta.Namespace}, r.repository)
+		if err != nil {
+			fmt.Printf("could not get humio repository: %s", err)
+		}
+		if r.repository.Status.State == corev1alpha1.HumioRepositoryStateExists {
+			return nil
+		}
+		time.Sleep(time.Second * 2)
+	}
+	return fmt.Errorf("timed out waiting for repository state to become: %s", corev1alpha1.HumioRepositoryStateExists)
+}


### PR DESCRIPTION
I was trying to structure this a little more, while also making tests not run serially. There is probably more we can do on that front especially as we add tests for other clusters.

I'm not sure how we want to handle timeouts. Right now we're using the global timeout of 5 minutes for each test Wait(). But I'm thinking we could probably wait indefinitely in each one so long as it is clear where it timed out.

Not really sure if this is what we want which is why I have it as draft status.