### PR TITLE
Adjust release process.

### DIFF
--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -1,7 +1,5 @@
-name: Lint Charts
-
 on: pull_request
-
+name: Lint Helm Charts
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -28,19 +28,3 @@ jobs:
       run:  echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
     - name: docker push
       run: docker push humio/humio-operator:master
-  chart:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout master
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Setup
-        shell: bash
-        run: |
-          git config --global user.name "$GITHUB_ACTOR"
-          git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.0.0-rc.2
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release-container-image.yaml
+++ b/.github/workflows/release-container-image.yaml
@@ -1,8 +1,10 @@
 on:
   push:
-    tags:
-      - 'v*'
-name: Publish Release
+    branches:
+    - master
+    paths:
+    - version/version.go
+name: Publish Container Image Release
 jobs:
   build-and-publish:
     name: Build and Publish
@@ -11,9 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Get release version
       id: get_version
-      run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
-    - name: Get quay release version
-      run: echo ::set-env name=QUAY_RELEASE_VERSION::$(echo ${GITHUB_REF:10} | sed 's/v//g')
+      run: echo ::set-env name=RELEASE_VERSION::$(grep "Version =" version/version.go | awk -F'"' '{print $2}')
     - name: docker login
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
@@ -34,21 +34,22 @@ jobs:
         QUAY_NAMESPACE: ${{ secrets.QUAY_NAMESPACE }}
       uses: ./.github/action/operator-sdk
       with:
-        args: operator-courier push deploy/olm-catalog/humio-operator ${{ env.QUAY_NAMESPACE }} humio-operator ${{ env.QUAY_RELEASE_VERSION }} "basic ${{ env.QUAY_ACCESS_TOKEN }}"
-  release:
-    name: Create Release
+        args: operator-courier push deploy/olm-catalog/humio-operator ${{ env.QUAY_NAMESPACE }} humio-operator ${{ env.RELEASE_VERSION }} "basic ${{ env.QUAY_ACCESS_TOKEN }}"
+  gh-release:
+    name: Create GitHub Release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Get release version
         id: get_version
-        run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
+        run: echo ::set-env name=RELEASE_VERSION::$(grep "Version =" version/version.go | awk -F'"' '{print $2}')
       - uses: actions/create-release@latest
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ env.RELEASE_VERSION }}
-          release_name: Release ${{ env.RELEASE_VERSION }}
-          body: Release ${{ env.RELEASE_VERSION }}
+          tag_name: operator-${{ env.RELEASE_VERSION }}
+          release_name: Operator Release ${{ env.RELEASE_VERSION }}
+          body: |
+            **Image:** `humio/humio-operator:${{ env.RELEASE_VERSION }}`
           prerelease: true

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -1,0 +1,24 @@
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - charts/humio-operator/Chart.yaml
+name: Publish Helm Chart Release
+jobs:
+  chart:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup
+        shell: bash
+        run: |
+          git config --global user.name "$GITHUB_ACTOR"
+          git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.0.0-rc.2
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -78,3 +78,8 @@ To stop the `crc` cluster again, execute:
 ```bash
 hack/stop-crc.sh
 ```
+
+## Publishing new releases
+
+- Container image: Bump the version defined in [version/version.go](version/version.go).
+- Helm chart: Bump the version defined in [charts/humio-operator/Chart.yaml](charts/humio-operator/Chart.yaml).


### PR DESCRIPTION
Fixes #89 

- Trigger release processes based on version number changes instead of git tags
- Drop `v` prefix from version numbers of container images
- Use git tag prefix `operator-` related to releasing container images
- Git tag prefix for releases of helm charts remains to be the name of the chart
- Add container image reference to github release when publishing a new container image