### PR TITLE
Refactor naming of k8s resources created for a HumioCluster.

### DIFF
--- a/pkg/controller/humiocluster/defaults.go
+++ b/pkg/controller/humiocluster/defaults.go
@@ -10,27 +10,31 @@ import (
 )
 
 const (
-	image                          = "humio/humio-core:1.12.0"
-	targetReplicationFactor        = 2
-	storagePartitionsCount         = 24
-	digestPartitionsCount          = 24
-	nodeCount                      = 3
-	humioPort                      = 8080
-	elasticPort                    = 9200
-	humioServiceAccountName        = "humio-service-account"
-	initServiceAccountName         = "init-service-account"
-	initServiceAccountSecretName   = "init-service-account"
-	initClusterRolePrefix          = "init-cluster-role"
-	initClusterRoleBindingPrefix   = "init-cluster-role-binding"
-	authServiceAccountName         = "auth-service-account"
-	authServiceAccountSecretName   = "auth-service-account"
-	authRolePrefix                 = "auth-role"
-	authRoleBindingPrefix          = "auth-role-binding"
-	extraKafkaConfigsConfigmapName = "extra-kafka-configs-configmap"
-	idpCertificateSecretName       = "idp-certificate-secret"
-	idpCertificateFilename         = "idp-certificate.pem"
-	extraKafkaPropertiesFilename   = "extra-kafka-properties.properties"
-	podHashAnnotation              = "humio_pod_hash"
+	image                        = "humio/humio-core:1.12.0"
+	targetReplicationFactor      = 2
+	storagePartitionsCount       = 24
+	digestPartitionsCount        = 24
+	nodeCount                    = 3
+	humioPort                    = 8080
+	elasticPort                  = 9200
+	idpCertificateFilename       = "idp-certificate.pem"
+	extraKafkaPropertiesFilename = "extra-kafka-properties.properties"
+	podHashAnnotation            = "humio_pod_hash"
+
+	// cluster-wide resources:
+	initClusterRoleSuffix        = "init"
+	initClusterRoleBindingSuffix = "init"
+
+	// namespaced resources:
+	humioServiceAccountNameSuffix        = "humio"
+	initServiceAccountNameSuffix         = "init"
+	initServiceAccountSecretNameSuffix   = "init"
+	authServiceAccountNameSuffix         = "auth"
+	authServiceAccountSecretNameSuffix   = "auth"
+	authRoleSuffix                       = "auth"
+	authRoleBindingSuffix                = "auth"
+	extraKafkaConfigsConfigMapNameSuffix = "extra-kafka-configs"
+	idpCertificateSecretNameSuffix       = "idp-certificate"
 )
 
 func setDefaults(hc *humioClusterv1alpha1.HumioCluster) {
@@ -113,48 +117,60 @@ func humioServiceAccountNameOrDefault(hc *humioClusterv1alpha1.HumioCluster) str
 	if hc.Spec.HumioServiceAccountName != "" {
 		return hc.Spec.HumioServiceAccountName
 	}
-	return humioServiceAccountName
+	return fmt.Sprintf("%s-%s", hc.Name, humioServiceAccountNameSuffix)
 }
 
 func initServiceAccountNameOrDefault(hc *humioClusterv1alpha1.HumioCluster) string {
 	if hc.Spec.InitServiceAccountName != "" {
 		return hc.Spec.InitServiceAccountName
 	}
-	return initServiceAccountName
+	return fmt.Sprintf("%s-%s", hc.Name, initServiceAccountNameSuffix)
+}
+
+func initServiceAccountSecretName(hc *humioClusterv1alpha1.HumioCluster) string {
+	return fmt.Sprintf("%s-%s", hc.Name, initServiceAccountSecretNameSuffix)
 }
 
 func authServiceAccountNameOrDefault(hc *humioClusterv1alpha1.HumioCluster) string {
 	if hc.Spec.AuthServiceAccountName != "" {
 		return hc.Spec.AuthServiceAccountName
 	}
-	return authServiceAccountName
+	return fmt.Sprintf("%s-%s", hc.Name, authServiceAccountNameSuffix)
+}
+
+func authServiceAccountSecretName(hc *humioClusterv1alpha1.HumioCluster) string {
+	return fmt.Sprintf("%s-%s", hc.Name, authServiceAccountSecretNameSuffix)
 }
 
 func extraKafkaConfigsOrDefault(hc *humioClusterv1alpha1.HumioCluster) string {
 	return hc.Spec.ExtraKafkaConfigs
 }
 
+func extraKafkaConfigsConfigMapName(hc *humioClusterv1alpha1.HumioCluster) string {
+	return fmt.Sprintf("%s-%s", hc.Name, extraKafkaConfigsConfigMapNameSuffix)
+}
+
 func idpCertificateSecretNameOrDefault(hc *humioClusterv1alpha1.HumioCluster) string {
 	if hc.Spec.IdpCertificateSecretName != "" {
 		return hc.Spec.IdpCertificateSecretName
 	}
-	return idpCertificateSecretName
+	return fmt.Sprintf("%s-%s", hc.Name, idpCertificateSecretNameSuffix)
 }
 
 func initClusterRoleName(hc *humioClusterv1alpha1.HumioCluster) string {
-	return fmt.Sprintf("%s-%s-%s", initClusterRolePrefix, hc.Namespace, hc.Name)
+	return fmt.Sprintf("%s-%s-%s", hc.Namespace, hc.Name, initClusterRoleSuffix)
 }
 
 func initClusterRoleBindingName(hc *humioClusterv1alpha1.HumioCluster) string {
-	return fmt.Sprintf("%s-%s-%s", initClusterRoleBindingPrefix, hc.Namespace, hc.Name)
+	return fmt.Sprintf("%s-%s-%s", hc.Namespace, hc.Name, initClusterRoleBindingSuffix)
 }
 
 func authRoleName(hc *humioClusterv1alpha1.HumioCluster) string {
-	return fmt.Sprintf("%s-%s-%s", authRolePrefix, hc.Namespace, hc.Name)
+	return fmt.Sprintf("%s-%s", hc.Name, authRoleSuffix)
 }
 
 func authRoleBindingName(hc *humioClusterv1alpha1.HumioCluster) string {
-	return fmt.Sprintf("%s-%s-%s", authRoleBindingPrefix, hc.Namespace, hc.Name)
+	return fmt.Sprintf("%s-%s", hc.Name, authRoleBindingSuffix)
 }
 
 func podResourcesOrDefault(hc *humioClusterv1alpha1.HumioCluster) corev1.ResourceRequirements {

--- a/pkg/controller/humiocluster/humiocluster_controller_test.go
+++ b/pkg/controller/humiocluster/humiocluster_controller_test.go
@@ -98,7 +98,7 @@ func TestReconcileHumioCluster_Reconcile(t *testing.T) {
 			}
 
 			// Check that the init service account, secret, cluster role and cluster role binding are created
-			secret, err := kubernetes.GetSecret(context.TODO(), r.client, initServiceAccountSecretName, updatedHumioCluster.Namespace)
+			secret, err := kubernetes.GetSecret(context.TODO(), r.client, initServiceAccountSecretName(updatedHumioCluster), updatedHumioCluster.Namespace)
 			if err != nil {
 				t.Errorf("get init service account secret: (%v). %+v", err, secret)
 			}
@@ -116,7 +116,7 @@ func TestReconcileHumioCluster_Reconcile(t *testing.T) {
 			}
 
 			// Check that the auth service account, secret, role and role binding are created
-			secret, err = kubernetes.GetSecret(context.TODO(), r.client, authServiceAccountSecretName, updatedHumioCluster.Namespace)
+			secret, err = kubernetes.GetSecret(context.TODO(), r.client, authServiceAccountSecretName(updatedHumioCluster), updatedHumioCluster.Namespace)
 			if err != nil {
 				t.Errorf("get auth service account secret: (%v). %+v", err, secret)
 			}
@@ -498,7 +498,7 @@ func TestReconcileHumioCluster_Reconcile_extra_kafka_configs_configmap(t *testin
 		humioCluster                   *corev1alpha1.HumioCluster
 		humioClient                    *humio.MockClientConfig
 		version                        string
-		wantExtraKafkaConfigsConfigmap bool
+		wantExtraKafkaConfigsConfigMap bool
 	}{
 		{
 			"test cluster reconciliation with no extra kafka configs",
@@ -538,17 +538,16 @@ func TestReconcileHumioCluster_Reconcile_extra_kafka_configs_configmap(t *testin
 			if err != nil {
 				t.Errorf("reconcile: (%v)", err)
 			}
-
-			configmap, err := kubernetes.GetConfigmap(context.TODO(), r.client, extraKafkaConfigsConfigmapName, tt.humioCluster.Namespace)
-			if (err != nil) == tt.wantExtraKafkaConfigsConfigmap {
-				t.Errorf("failed to check extra kafka configs configmap: %s", err)
+			configMap, err := kubernetes.GetConfigMap(context.TODO(), r.client, extraKafkaConfigsConfigMapName(tt.humioCluster), tt.humioCluster.Namespace)
+			if (err != nil) == tt.wantExtraKafkaConfigsConfigMap {
+				t.Errorf("failed to check extra kafka configs configMap: %s", err)
 			}
-			if reflect.DeepEqual(configmap, &corev1.ConfigMap{}) == tt.wantExtraKafkaConfigsConfigmap {
-				t.Errorf("failed to compare extra kafka configs configmap: %s, wantExtraKafkaConfigsConfigmap: %v", configmap, tt.wantExtraKafkaConfigsConfigmap)
+			if reflect.DeepEqual(configMap, &corev1.ConfigMap{}) == tt.wantExtraKafkaConfigsConfigMap {
+				t.Errorf("failed to compare extra kafka configs configMap: %s, wantExtraKafkaConfigsConfigMap: %v", configMap, tt.wantExtraKafkaConfigsConfigMap)
 			}
 			foundEnvVar := false
 			foundVolumeMount := false
-			if tt.wantExtraKafkaConfigsConfigmap {
+			if tt.wantExtraKafkaConfigsConfigMap {
 				foundPodList, err := kubernetes.ListPods(r.client, tt.humioCluster.Namespace, kubernetes.MatchingLabelsForHumio(tt.humioCluster.Name))
 				if err != nil {
 					t.Errorf("failed to list pods %s", err)
@@ -572,11 +571,11 @@ func TestReconcileHumioCluster_Reconcile_extra_kafka_configs_configmap(t *testin
 
 				}
 			}
-			if tt.wantExtraKafkaConfigsConfigmap && !foundEnvVar {
-				t.Errorf("failed to validate extra kafka configs env var, want: %v, got %v", tt.wantExtraKafkaConfigsConfigmap, foundEnvVar)
+			if tt.wantExtraKafkaConfigsConfigMap && !foundEnvVar {
+				t.Errorf("failed to validate extra kafka configs env var, want: %v, got %v", tt.wantExtraKafkaConfigsConfigMap, foundEnvVar)
 			}
-			if tt.wantExtraKafkaConfigsConfigmap && !foundVolumeMount {
-				t.Errorf("failed to validate extra kafka configs volume mount, want: %v, got %v", tt.wantExtraKafkaConfigsConfigmap, foundVolumeMount)
+			if tt.wantExtraKafkaConfigsConfigMap && !foundVolumeMount {
+				t.Errorf("failed to validate extra kafka configs volume mount, want: %v, got %v", tt.wantExtraKafkaConfigsConfigMap, foundVolumeMount)
 			}
 		})
 	}

--- a/pkg/controller/humiocluster/pods.go
+++ b/pkg/controller/humiocluster/pods.go
@@ -218,7 +218,7 @@ done`
 					Name: "init-service-account-secret",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName:  initServiceAccountSecretName,
+							SecretName:  initServiceAccountSecretName(hc),
 							DefaultMode: &mode,
 						},
 					},
@@ -227,7 +227,7 @@ done`
 					Name: "auth-service-account-secret",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName:  authServiceAccountSecretName,
+							SecretName:  authServiceAccountSecretName(hc),
 							DefaultMode: &mode,
 						},
 					},
@@ -290,7 +290,7 @@ done`
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: extraKafkaConfigsConfigmapName,
+						Name: extraKafkaConfigsConfigMapName(hc),
 					},
 					DefaultMode: &mode,
 				},

--- a/pkg/kubernetes/configmaps.go
+++ b/pkg/kubernetes/configmaps.go
@@ -10,23 +10,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ConstructExtraKafkaConfigsConfigmap(extraKafkaConfigsConfigmapName, extraKafkaPropertiesFilename, extraKafkaConfigsConfigmapData, humioClusterName, humioClusterNamespace string) *corev1.ConfigMap {
+func ConstructExtraKafkaConfigsConfigMap(extraKafkaConfigsConfigMapName, extraKafkaPropertiesFilename, extraKafkaConfigsConfigMapData, humioClusterName, humioClusterNamespace string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      extraKafkaConfigsConfigmapName,
+			Name:      extraKafkaConfigsConfigMapName,
 			Namespace: humioClusterNamespace,
 			Labels:    LabelsForHumio(humioClusterName),
 		},
-		Data: map[string]string{extraKafkaPropertiesFilename: extraKafkaConfigsConfigmapData},
+		Data: map[string]string{extraKafkaPropertiesFilename: extraKafkaConfigsConfigMapData},
 	}
 }
 
-// GetConfigmap returns the configmap for the given configmap name if it exists
-func GetConfigmap(ctx context.Context, c client.Client, configmapName, humioClusterNamespace string) (*corev1.ConfigMap, error) {
-	var existingConfigmap corev1.ConfigMap
+// GetConfigMap returns the configmap for the given configmap name if it exists
+func GetConfigMap(ctx context.Context, c client.Client, configMapName, humioClusterNamespace string) (*corev1.ConfigMap, error) {
+	var existingConfigMap corev1.ConfigMap
 	err := c.Get(ctx, types.NamespacedName{
 		Namespace: humioClusterNamespace,
-		Name:      configmapName,
-	}, &existingConfigmap)
-	return &existingConfigmap, err
+		Name:      configMapName,
+	}, &existingConfigMap)
+	return &existingConfigMap, err
 }


### PR DESCRIPTION
This moves us one step closer to closing https://github.com/humio/humio-operator/issues/92

This fixes the problems with resource name conflicts when handling
multiple HumioCluster resources in the same namespace.

This breaks the `crc` cluster things for now, because we cannot pre-populate the service account names in the `users` property in the `SecurityContextConstraint` resource, because service accounts are now named based on the CR names. I'm thinking we should just merge this anyway because #92 already contains a step to fix the SCC issues. Let me know if you think the SCC changes needs to be done in this PR, then I'll update it, if not, then I will take a look at this in a followup PR.