### PR TITLE
Refactor helm chart to allow watching a single, multiple or all namespaces

### DIFF
--- a/charts/humio-operator/README.md
+++ b/charts/humio-operator/README.md
@@ -64,6 +64,7 @@ Parameter | Description | Default
 `operator.image.repository` | operator container image repository | `humio/humio-operator`
 `operator.image.tag` | operator container image tag | `v0.0.3`
 `operator.rbac.create` | automatically create operator RBAC resources | `true`
+`operator.watchNamespaces` | list of namespaces the operator will watch for resources (if empty, it watches all namespaces) | `[]`
 `installCRDs` | automatically install CRDs. NB: if this is set to true, custom resources will be removed if the Helm chart is uninstalled | `false`
 `openshift` | install additional RBAC resources specific to OpenShift | `false`
 

--- a/charts/humio-operator/templates/operator-deployment.yaml
+++ b/charts/humio-operator/templates/operator-deployment.yaml
@@ -51,11 +51,8 @@ spec:
         command:
         - humio-operator
         env:
-        # TODO: Perhaps we just need to leave out this thing we the operator should watch any namespace? How about multiple explicitly listed namespaces?
         - name: WATCH_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          value: {{ .Values.operator.watchNamespaces | join "," | quote }}
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/charts/humio-operator/templates/operator-rbac.yaml
+++ b/charts/humio-operator/templates/operator-rbac.yaml
@@ -4,8 +4,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}
-  namespace: {{ default "default" .Release.Namespace }}
+  name: '{{ .Release.Name }}'
+  namespace: '{{ default "default" .Release.Namespace }}'
   labels:
     app: '{{ .Chart.Name }}'
     app.kubernetes.io/name: '{{ .Chart.Name }}'
@@ -14,19 +14,19 @@ metadata:
     helm.sh/chart: '{{ template "humio.chart" . }}'
     operator-sdk-test-scope: 'per-test'
 
+{{- range .Values.operator.watchNamespaces }}
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Release.Name }}
-  namespace: {{ default "default" .Release.Namespace }}
+  name: '{{ $.Release.Name }}'
+  namespace: '{{ . }}'
   labels:
-    app: '{{ .Chart.Name }}'
-    app.kubernetes.io/name: '{{ .Chart.Name }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    helm.sh/chart: '{{ template "humio.chart" . }}'
+    app: '{{ $.Chart.Name }}'
+    app.kubernetes.io/name: '{{ $.Chart.Name }}'
+    app.kubernetes.io/instance: '{{ $.Release.Name }}'
+    app.kubernetes.io/managed-by: '{{ $.Release.Service }}'
+    helm.sh/chart: '{{ template "humio.chart" $ }}'
     operator-sdk-test-scope: 'per-test'
 rules:
 - apiGroups:
@@ -124,33 +124,33 @@ rules:
   - watch
 
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Release.Name }}
-  namespace: {{ default "default" .Release.Namespace }}
+  name: '{{ $.Release.Name }}'
+  namespace: '{{ . }}'
   labels:
-    app: '{{ .Chart.Name }}'
-    app.kubernetes.io/name: '{{ .Chart.Name }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    helm.sh/chart: '{{ template "humio.chart" . }}'
+    app: '{{ $.Chart.Name }}'
+    app.kubernetes.io/name: '{{ $.Chart.Name }}'
+    app.kubernetes.io/instance: '{{ $.Release.Name }}'
+    app.kubernetes.io/managed-by: '{{ $.Release.Service }}'
+    helm.sh/chart: '{{ template "humio.chart" $ }}'
     operator-sdk-test-scope: 'per-test'
 subjects:
 - kind: ServiceAccount
-  name: {{ .Release.Name }}
+  name: '{{ $.Release.Name }}'
+  namespace: '{{ default "default" $.Release.Namespace }}'
 roleRef:
   kind: Role
-  name: {{ .Release.Name }}
+  name: '{{ $.Release.Name }}'
   apiGroup: rbac.authorization.k8s.io
 
+{{- end }}
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ default "default" .Release.Namespace }}-{{ .Release.Name }}
+  name: '{{ default "default" .Release.Namespace }}-{{ .Release.Name }}'
   labels:
     app: '{{ .Chart.Name }}'
     app.kubernetes.io/name: '{{ .Chart.Name }}'
@@ -159,6 +159,101 @@ metadata:
     helm.sh/chart: '{{ template "humio.chart" . }}'
     operator-sdk-test-scope: 'per-operator'
 rules:
+{{- if not .Values.operator.watchNamespaces }}
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - services/finalizers
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - get
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - humio-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - core.humio.com
+  resources:
+  - humioclusters
+  - humioclusters/finalizers
+  - humioclusters/status
+  - humioparsers
+  - humioparsers/finalizers
+  - humioparsers/status
+  - humioingesttokens
+  - humioingesttokens/finalizers
+  - humioingesttokens/status
+  - humiorepositories
+  - humiorepositories/finalizers
+  - humiorepositories/status
+  - humioexternalclusters
+  - humioexternalclusters/finalizers
+  - humioexternalclusters/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+{{- end }}
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -184,7 +279,7 @@ rules:
 - apiGroups:
   - security.openshift.io
   resourceNames:
-  - {{ default "default" .Release.Namespace }}-{{ .Release.Name }}
+  - '{{ default "default" .Release.Namespace }}-{{ .Release.Name }}'
   resources:
   - securitycontextconstraints
   verbs:
@@ -196,7 +291,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ default "default" .Release.Namespace }}-{{ .Release.Name }}
+  name: '{{ default "default" .Release.Namespace }}-{{ .Release.Name }}'
   labels:
     app: '{{ .Chart.Name }}'
     app.kubernetes.io/name: '{{ .Chart.Name }}'
@@ -206,11 +301,11 @@ metadata:
     operator-sdk-test-scope: 'per-operator'
 subjects:
 - kind: ServiceAccount
-  name: {{ .Release.Name }}
-  namespace: {{ default "default" .Release.Namespace }}
+  name: '{{ .Release.Name }}'
+  namespace: '{{ default "default" .Release.Namespace }}'
 roleRef:
   kind: ClusterRole
-  name: {{ default "default" .Release.Namespace }}-{{ .Release.Name }}
+  name: '{{ default "default" .Release.Namespace }}-{{ .Release.Name }}'
   apiGroup: rbac.authorization.k8s.io
 
 {{- if .Values.openshift }}

--- a/charts/humio-operator/values.yaml
+++ b/charts/humio-operator/values.yaml
@@ -4,5 +4,6 @@ operator:
     tag: v0.0.3
   rbac:
     create: true
+  watchNamespaces: []
 installCRDs: false
 openshift: false

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -41,6 +42,7 @@ import (
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
@@ -94,11 +96,23 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Create a new Cmd to provide shared dependencies and start components
-	mgr, err := manager.New(cfg, manager.Options{
+	// Set default manager options
+	options := manager.Options{
 		Namespace:          namespace,
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
-	})
+	}
+
+	// Add support for MultiNamespace set in WATCH_NAMESPACE (e.g ns1,ns2)
+	// Note that this is not intended to be used for excluding namespaces, this is better done via a Predicate
+	// Also note that you may face performance issues when using this with a high number of namespaces.
+	// More Info: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/cache#MultiNamespacedCacheBuilder
+	if strings.Contains(namespace, ",") {
+		options.Namespace = ""
+		options.NewCache = cache.MultiNamespacedCacheBuilder(strings.Split(namespace, ","))
+	}
+
+	// Create a new Cmd to provide shared dependencies and start components
+	mgr, err := manager.New(cfg, options)
 	if err != nil {
 		logger.Error(err, "")
 		os.Exit(1)


### PR DESCRIPTION
This builds on top of https://github.com/humio/humio-operator/pull/97 and moves us yet another step closer to closing #92

~I was hoping it was as simple as creating a pair of `Role` & `RoleBinding` resources for each namespace we want to watch and then set the `WATCH_NAMESPACE` for the Humio operator to be a comma-separated list, but that doesn't seem like the case. The operator doesn't accept a comma-separated list in `WATCH_NAMESPACE`. Here's an example of the output when trying to pass on multiple namespaces:~

~`
E0611 13:09:04.316750       1 reflector.go:123] pkg/mod/k8s.io/client-go@v0.0.0-20191016111102-bec269661e48/tools/cache/reflector.go:96: Failed to list *v1alpha1.HumioExternalCluster: humioexternalclusters.core.humio.com is forbidden: User "system:serviceaccount:default:humio-operator" cannot list resource "humioexternalclusters" in API group "core.humio.com" in the namespace "default,flafgnyf"
`~

~@jswoods @schofield Do you think we even need the ability to watch multiple namespaces? If not/unknown, I will not pursue this right now.~

Scratch that, the PR now includes support for single, multiple and all namespaces.