### PR TITLE
Additional logging and fix race with bootstrapping pods

### DIFF
--- a/pkg/controller/humiocluster/humiocluster_controller_test.go
+++ b/pkg/controller/humiocluster/humiocluster_controller_test.go
@@ -685,7 +685,7 @@ func TestReconcileHumioCluster_Reconcile_persistent_volumes(t *testing.T) {
 			}
 
 			// Simulate creating pods
-			for nodeCount := 1; nodeCount <= tt.humioCluster.Spec.NodeCount; nodeCount++ {
+			for nodeCount := 1; nodeCount < tt.humioCluster.Spec.NodeCount; nodeCount++ {
 				foundPodList, err := kubernetes.ListPods(r.client, tt.humioCluster.Namespace, kubernetes.MatchingLabelsForHumio(tt.humioCluster.Name))
 				if err != nil {
 					t.Errorf("failed to list pods: %s", err)
@@ -702,9 +702,12 @@ func TestReconcileHumioCluster_Reconcile_persistent_volumes(t *testing.T) {
 				}
 
 				// Reconcile again so Reconcile() checks pods and updates the HumioCluster resources' Status.
-				_, err = r.Reconcile(req)
+				res, err := r.Reconcile(req)
 				if err != nil {
 					t.Errorf("reconcile: (%v)", err)
+				}
+				if res != (reconcile.Result{Requeue: true}) {
+					t.Errorf("reconcile: (%v)", res)
 				}
 			}
 

--- a/pkg/controller/humiocluster/status.go
+++ b/pkg/controller/humiocluster/status.go
@@ -12,6 +12,7 @@ import (
 // setState is used to change the cluster state
 // TODO: we use this to determine if we should have a delay between startup of humio pods during bootstrap vs starting up pods during an image update
 func (r *ReconcileHumioCluster) setState(ctx context.Context, state string, hc *corev1alpha1.HumioCluster) error {
+	r.logger.Infof("setting cluster state to %s", state)
 	hc.Status.State = state
 	err := r.client.Status().Update(ctx, hc)
 	if err != nil {
@@ -21,6 +22,7 @@ func (r *ReconcileHumioCluster) setState(ctx context.Context, state string, hc *
 }
 
 func (r *ReconcileHumioCluster) setVersion(ctx context.Context, version string, hc *corev1alpha1.HumioCluster) {
+	r.logger.Infof("setting cluster version to %s", version)
 	hc.Status.Version = version
 	err := r.client.Status().Update(ctx, hc)
 	if err != nil {
@@ -29,6 +31,7 @@ func (r *ReconcileHumioCluster) setVersion(ctx context.Context, version string, 
 }
 
 func (r *ReconcileHumioCluster) setNodeCount(ctx context.Context, nodeCount int, hc *corev1alpha1.HumioCluster) {
+	r.logger.Infof("setting cluster node count to %d", nodeCount)
 	hc.Status.NodeCount = nodeCount
 	err := r.client.Status().Update(ctx, hc)
 	if err != nil {
@@ -37,6 +40,7 @@ func (r *ReconcileHumioCluster) setNodeCount(ctx context.Context, nodeCount int,
 }
 
 func (r *ReconcileHumioCluster) setPod(ctx context.Context, hc *corev1alpha1.HumioCluster) {
+	r.logger.Info("setting cluster pod status")
 	var pvcs []corev1.PersistentVolumeClaim
 	pods, err := kubernetes.ListPods(r.client, hc.Namespace, kubernetes.MatchingLabelsForHumio(hc.Name))
 	if err != nil {

--- a/test/e2e/humiocluster_with_pvcs_test.go
+++ b/test/e2e/humiocluster_with_pvcs_test.go
@@ -86,7 +86,15 @@ func (h *humioClusterWithPVCsTest) Wait(f *framework.Framework) error {
 				}
 			}
 
-			if pvcCount < h.cluster.Spec.NodeCount {
+			if h.cluster.Status.NodeCount != h.cluster.Spec.NodeCount {
+				return fmt.Errorf("expected to find node count of %d instead got %d", h.cluster.Spec.NodeCount, h.cluster.Status.NodeCount)
+			}
+
+			if len(foundPodList) != h.cluster.Spec.NodeCount {
+				return fmt.Errorf("expected to find %d pods instead got %d", h.cluster.Spec.NodeCount, len(foundPodList))
+			}
+
+			if pvcCount != h.cluster.Spec.NodeCount {
 				return fmt.Errorf("expected to find %d pods with attached pvcs but instead got %d", h.cluster.Spec.NodeCount, pvcCount)
 			}
 			return nil


### PR DESCRIPTION
This appears to fix the race. When testing, it logged:

```
{"level":"info","ts":1594250994.9888318,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250995.989429,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 1","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
```

Note that it appears to take a second or so at least in some cases. With this same change but without the sleep/timeout in the loop, we end up with the same issue, e.g.
```
{"level":"info","ts":1594250448.2666128,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2666986,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.266727,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2667594,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2668045,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2668362,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2668836,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2669036,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2669182,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2669926,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2670166,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.267037,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2670655,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2671099,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2671835,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2673075,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2674143,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2675178,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2675772,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.267597,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2676318,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2676969,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2677195,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2677486,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2677712,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2678487,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2678733,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2679405,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.268024,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2681317,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 0","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2682474,"caller":"humiocluster/humiocluster_controller.go:107","msg":"Reconciling HumioCluster","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2685513,"caller":"humiocluster/humiocluster_controller.go:821","msg":"ensuring service","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2685905,"caller":"humiocluster/humiocluster_controller.go:387","msg":"ensuring pod permissions","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2687776,"caller":"humiocluster/humiocluster_controller.go:1087","msg":"ensuring pvcs","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2688713,"caller":"humiocluster/humiocluster_controller.go:930","msg":"ensuring pods are bootstrapped","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.2697792,"caller":"humiocluster/humiocluster_controller.go:990","msg":"creating pod example-humiocluster-pvc-core-nnxswj","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.564797,"caller":"humiocluster/humiocluster_controller.go:996","msg":"successfully created pod example-humiocluster-pvc-core-nnxswj for HumioCluster example-humiocluster-pvc","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
{"level":"info","ts":1594250448.6649034,"caller":"humiocluster/humiocluster_controller.go:1020","msg":"validating new pod was created. expected pod count 1, current pod count 2","Request.Namespace":"humio-operator","Request.Name":"example-humiocluster-pvc","Request.Type":"ReconcileHumioCluster"}
```