### PR TITLE
Add humio pod restart and upgrade functionality

### DIFF
--- a/deploy/crds/core.humio.com_humioclusters_crd.yaml
+++ b/deploy/crds/core.humio.com_humioclusters_crd.yaml
@@ -3695,7 +3695,8 @@ spec:
                 type: array
               state:
                 description: State will be empty before the cluster is bootstrapped.
-                  From there it can be "Bootstrapping" or "Running"
+                  From there it can be "Bootstrapping", "Running", "Upgrading" or
+                  "Restarting"
                 type: string
               version:
                 description: Version is the version of humio running

--- a/pkg/apis/core/v1alpha1/humiocluster_types.go
+++ b/pkg/apis/core/v1alpha1/humiocluster_types.go
@@ -10,6 +10,10 @@ const (
 	HumioClusterStateBoostrapping = "Bootstrapping"
 	// HumioClusterStateRunning is the Running state of the cluster
 	HumioClusterStateRunning = "Running"
+	// HumioClusterStateRestarting is the state of the cluster when Humio pods are being restarted
+	HumioClusterStateRestarting = "Restarting"
+	// HumioClusterStateUpgrading is the state of the cluster when Humio pods are being upgraded
+	HumioClusterStateUpgrading = "Upgrading"
 )
 
 // HumioClusterSpec defines the desired state of HumioCluster
@@ -91,7 +95,8 @@ type HumioPodStatus struct {
 
 // HumioClusterStatus defines the observed state of HumioCluster
 type HumioClusterStatus struct {
-	// State will be empty before the cluster is bootstrapped. From there it can be "Bootstrapping" or "Running"
+	// State will be empty before the cluster is bootstrapped. From there it can be "Bootstrapping", "Running",
+	// "Upgrading" or "Restarting"
 	State string `json:"state,omitempty"`
 	// Version is the version of humio running
 	Version string `json:"version,omitempty"`

--- a/pkg/controller/humiocluster/annotations.go
+++ b/pkg/controller/humiocluster/annotations.go
@@ -1,0 +1,73 @@
+package humiocluster
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+
+	corev1alpha1 "github.com/humio/humio-operator/pkg/apis/core/v1alpha1"
+)
+
+const (
+	podHashAnnotation          = "humio.com/pod-hash"
+	podRevisionAnnotation      = "humio.com/pod-revision"
+	podRestartPolicyAnnotation = "humio.com/pod-restart-policy"
+	PodRestartPolicyRolling    = "rolling"
+	PodRestartPolicyRecreate   = "recreate"
+)
+
+func (r *ReconcileHumioCluster) incrementHumioClusterPodRevision(ctx context.Context, hc *corev1alpha1.HumioCluster, restartPolicy string) (int, error) {
+	newRevision, err := r.getHumioClusterPodRevision(hc)
+	if err != nil {
+		return -1, err
+	}
+	newRevision++
+	r.logger.Infof("setting cluster pod revision to %d", newRevision)
+	hc.Annotations[podRevisionAnnotation] = strconv.Itoa(newRevision)
+
+	r.setRestartPolicy(hc, restartPolicy)
+
+	err = r.client.Update(ctx, hc)
+	if err != nil {
+		return -1, fmt.Errorf("unable to set annotation %s on HumioCluster: %s", podRevisionAnnotation, err)
+	}
+	return newRevision, nil
+}
+
+func (r *ReconcileHumioCluster) getHumioClusterPodRevision(hc *corev1alpha1.HumioCluster) (int, error) {
+	if hc.Annotations == nil {
+		hc.Annotations = map[string]string{}
+	}
+	revision, ok := hc.Annotations[podRevisionAnnotation]
+	if !ok {
+		revision = "0"
+	}
+	existingRevision, err := strconv.Atoi(revision)
+	if err != nil {
+		return -1, fmt.Errorf("unable to read annotation %s on HumioCluster: %s", podRevisionAnnotation, err)
+	}
+	return existingRevision, nil
+}
+
+func (r *ReconcileHumioCluster) getHumioClusterPodRestartPolicy(hc *corev1alpha1.HumioCluster) string {
+	if hc.Annotations == nil {
+		hc.Annotations = map[string]string{}
+	}
+	existingPolicy, ok := hc.Annotations[podRestartPolicyAnnotation]
+	if !ok {
+		existingPolicy = PodRestartPolicyRecreate
+	}
+	return existingPolicy
+}
+
+func (r *ReconcileHumioCluster) setPodRevision(pod *corev1.Pod, newRevision int) error {
+	pod.Annotations[podRevisionAnnotation] = strconv.Itoa(newRevision)
+	return nil
+}
+
+func (r *ReconcileHumioCluster) setRestartPolicy(hc *corev1alpha1.HumioCluster, policy string) {
+	r.logger.Infof("setting HumioCluster annotation %s to %s", podRestartPolicyAnnotation, policy)
+	hc.Annotations[podRestartPolicyAnnotation] = policy
+}

--- a/pkg/controller/humiocluster/defaults.go
+++ b/pkg/controller/humiocluster/defaults.go
@@ -19,7 +19,6 @@ const (
 	elasticPort                  = 9200
 	idpCertificateFilename       = "idp-certificate.pem"
 	extraKafkaPropertiesFilename = "extra-kafka-properties.properties"
-	podHashAnnotation            = "humio_pod_hash"
 
 	// cluster-wide resources:
 	initClusterRoleSuffix        = "init"

--- a/pkg/controller/humiocluster/pods.go
+++ b/pkg/controller/humiocluster/pods.go
@@ -1,9 +1,13 @@
 package humiocluster
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/humio/humio-operator/pkg/helpers"
 
@@ -23,6 +27,12 @@ const (
 	sharedPath       = "/shared"
 	tmpPath          = "/tmp"
 )
+
+type podLifecycleState struct {
+	pod           corev1.Pod
+	restartPolicy string
+	delete        bool
+}
 
 func constructPod(hc *corev1alpha1.HumioCluster, dataVolumeSource corev1.VolumeSource) (*corev1.Pod, error) {
 	var pod corev1.Pod
@@ -416,4 +426,177 @@ func podSpecAsSHA256(hc *corev1alpha1.HumioCluster, pod corev1.Pod) string {
 	}
 	pod.Spec.Volumes = sanitizedVolumes
 	return helpers.AsSHA256(pod.Spec)
+}
+
+func (r *ReconcileHumioCluster) createPod(ctx context.Context, hc *corev1alpha1.HumioCluster, foundPodList []corev1.Pod) error {
+	pvcList, err := r.pvcList(hc)
+	if err != nil {
+		r.logger.Errorf("problem getting pvc list: %s", err)
+		return err
+	}
+	r.logger.Debugf("attempting to get volume source, pvc count is %d, pod count is %d", len(pvcList), len(foundPodList))
+	volumeSource, err := volumeSource(hc, foundPodList, pvcList)
+	if err != nil {
+		r.logger.Errorf("unable to construct data volume source for HumioCluster: %s", err)
+		return err
+
+	}
+	pod, err := constructPod(hc, volumeSource)
+	if err != nil {
+		r.logger.Errorf("unable to construct pod for HumioCluster: %s", err)
+		return err
+	}
+	r.logger.Debugf("pod %s will use volume source %+v", pod.Name, volumeSource)
+	pod.Annotations[podHashAnnotation] = podSpecAsSHA256(hc, *pod)
+	if err := controllerutil.SetControllerReference(hc, pod, r.scheme); err != nil {
+		r.logger.Errorf("could not set controller reference: %s", err)
+		return err
+	}
+
+	podRevision, err := r.getHumioClusterPodRevision(hc)
+	if err != nil {
+		return err
+	}
+	r.logger.Infof("setting pod %s revision to %d", pod.Name, podRevision)
+	err = r.setPodRevision(pod, podRevision)
+	if err != nil {
+		return err
+	}
+
+	r.logger.Infof("creating pod %s", pod.Name)
+	err = r.client.Create(ctx, pod)
+	if err != nil {
+		return err
+	}
+	r.logger.Infof("successfully created pod %s for HumioCluster %s", pod.Name, hc.Name)
+	return nil
+}
+
+func (r *ReconcileHumioCluster) waitForNewPod(hc *corev1alpha1.HumioCluster, expectedPodCount int) error {
+	for i := 0; i < 30; i++ {
+		latestPodList, err := kubernetes.ListPods(r.client, hc.Namespace, kubernetes.MatchingLabelsForHumio(hc.Name))
+		if err != nil {
+			return err
+		}
+		r.logger.Infof("validating new pod was created. expected pod count %d, current pod count %d", expectedPodCount, len(latestPodList))
+		if len(latestPodList) >= expectedPodCount {
+			return nil
+		}
+		time.Sleep(time.Second * 1)
+	}
+	return fmt.Errorf("timed out waiting to validate new pod was created")
+}
+
+func (r *ReconcileHumioCluster) podsMatch(hc *corev1alpha1.HumioCluster, pod corev1.Pod, desiredPod corev1.Pod) (bool, error) {
+	if _, ok := pod.Annotations[podHashAnnotation]; !ok {
+		r.logger.Errorf("did not find annotation with pod hash")
+		return false, fmt.Errorf("did not find annotation with pod hash")
+	}
+	if _, ok := pod.Annotations[podRevisionAnnotation]; !ok {
+		r.logger.Errorf("did not find annotation with pod revision")
+		return false, fmt.Errorf("did not find annotation with pod revision")
+	}
+	var specMatches bool
+	var revisionMatches bool
+
+	desiredPodHash := podSpecAsSHA256(hc, desiredPod)
+	existingPodRevision, err := r.getHumioClusterPodRevision(hc)
+	if err != nil {
+		return false, err
+	}
+	err = r.setPodRevision(&desiredPod, existingPodRevision)
+	if err != nil {
+		return false, err
+	}
+	if pod.Annotations[podHashAnnotation] == desiredPodHash {
+		specMatches = true
+	}
+	if pod.Annotations[podRevisionAnnotation] == desiredPod.Annotations[podRevisionAnnotation] {
+		revisionMatches = true
+	}
+	if !specMatches {
+		r.logger.Infof("pod annotation %s does not match desired pod: got %+v, expected %+v", podHashAnnotation, pod.Annotations[podHashAnnotation], desiredPod.Annotations[podHashAnnotation])
+		return false, nil
+	}
+	if !revisionMatches {
+		r.logger.Infof("pod annotation %s does not match desired pod: got %+v, expected %+v", podRevisionAnnotation, pod.Annotations[podRevisionAnnotation], desiredPod.Annotations[podRevisionAnnotation])
+		return false, nil
+	}
+	return true, nil
+}
+
+func (r *ReconcileHumioCluster) getRestartPolicyFromPodInspection(pod, desiredPod corev1.Pod) (string, error) {
+	humioContainerIdx, err := kubernetes.GetContainerIndexByName(pod, "humio")
+	if err != nil {
+		return "", err
+	}
+	desiredHumioContainerIdx, err := kubernetes.GetContainerIndexByName(desiredPod, "humio")
+	if err != nil {
+		return "", err
+	}
+	if pod.Spec.Containers[humioContainerIdx].Image != desiredPod.Spec.Containers[desiredHumioContainerIdx].Image {
+		return PodRestartPolicyRecreate, nil
+	}
+	return PodRestartPolicyRolling, nil
+}
+
+func (r *ReconcileHumioCluster) podsReady(foundPodList []corev1.Pod) (int, int) {
+	var podsReadyCount int
+	var podsNotReadyCount int
+	for _, pod := range foundPodList {
+		podsNotReadyCount++
+		// pods that were just deleted may still have a status of Ready, but we should not consider them ready
+		if pod.DeletionTimestamp == nil {
+			for _, condition := range pod.Status.Conditions {
+				if condition.Type == "Ready" {
+					if condition.Status == "True" {
+						r.logger.Debugf("pod %s is ready", pod.Name)
+						podsReadyCount++
+						podsNotReadyCount--
+					} else {
+						r.logger.Debugf("pod %s is not ready", pod.Name)
+					}
+				}
+			}
+		}
+	}
+	return podsReadyCount, podsNotReadyCount
+}
+
+func (r *ReconcileHumioCluster) getPodDesiredLifecyleState(hc *corev1alpha1.HumioCluster, foundPodList []corev1.Pod) (podLifecycleState, error) {
+	for _, pod := range foundPodList {
+		// only consider pods not already being deleted
+		if pod.DeletionTimestamp == nil {
+			// if pod spec differs, we want to delete it
+			// use dataVolumeSourceOrDefault() to get either the volume source or an empty volume source in the case
+			// we are using pvcs. this is to avoid doing the pvc lookup and we do not compare pvcs when doing a sha256
+			// hash of the pod spec
+			desiredPod, err := constructPod(hc, dataVolumeSourceOrDefault(hc))
+			if err != nil {
+				r.logger.Errorf("could not construct pod: %s", err)
+				return podLifecycleState{}, err
+			}
+
+			podsMatchTest, err := r.podsMatch(hc, pod, *desiredPod)
+			if err != nil {
+				r.logger.Errorf("failed to check if pods match %s", err)
+			}
+			if !podsMatchTest {
+				// TODO: figure out if we should only allow upgrades and not downgrades
+				restartPolicy, err := r.getRestartPolicyFromPodInspection(pod, *desiredPod)
+				if err != nil {
+					r.logger.Errorf("could not get restart policy for HumioCluster: %s", err)
+					return podLifecycleState{}, err
+				}
+				return podLifecycleState{
+					pod:           pod,
+					restartPolicy: restartPolicy,
+					delete:        true,
+				}, err
+			}
+		} else {
+			return podLifecycleState{}, nil
+		}
+	}
+	return podLifecycleState{}, nil
 }

--- a/test/e2e/humiocluster_restart_test.go
+++ b/test/e2e/humiocluster_restart_test.go
@@ -1,0 +1,158 @@
+package e2e
+
+import (
+	goctx "context"
+	"fmt"
+	"time"
+
+	corev1alpha1 "github.com/humio/humio-operator/pkg/apis/core/v1alpha1"
+	"github.com/humio/humio-operator/pkg/kubernetes"
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	podRevisionAnnotation = "humio.com/pod-revision"
+)
+
+type restartTest struct {
+	cluster   *corev1alpha1.HumioCluster
+	bootstrap testState
+	restart   testState
+}
+
+type testState struct {
+	initiated bool
+	passed    bool
+}
+
+func newHumioClusterWithRestartTest(clusterName string, namespace string) humioClusterTest {
+	return &restartTest{
+		cluster: &corev1alpha1.HumioCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterName,
+				Namespace: namespace,
+			},
+			Spec: corev1alpha1.HumioClusterSpec{
+				NodeCount: 1,
+				EnvironmentVariables: []corev1.EnvVar{
+					{
+						Name:  "ZOOKEEPER_URL",
+						Value: "humio-cp-zookeeper-0.humio-cp-zookeeper-headless.default:2181",
+					},
+					{
+						Name:  "KAFKA_SERVERS",
+						Value: "humio-cp-kafka-0.humio-cp-kafka-headless.default:9092",
+					},
+				},
+			},
+		},
+	}
+}
+
+func (b *restartTest) Start(f *framework.Framework, ctx *framework.Context) error {
+	b.bootstrap.initiated = true
+	return f.Client.Create(goctx.TODO(), b.cluster, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+}
+
+func (b *restartTest) Wait(f *framework.Framework) error {
+	var gotRestarted bool
+	var podsSimultaneouslyShutdown bool
+
+	for start := time.Now(); time.Since(start) < timeout; {
+		// return after all tests have completed
+		if b.bootstrap.passed && b.restart.passed {
+			return nil
+		}
+
+		err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: b.cluster.ObjectMeta.Name, Namespace: b.cluster.ObjectMeta.Namespace}, b.cluster)
+		if err != nil {
+			fmt.Printf("could not get humio cluster: %s", err)
+		}
+
+		clusterState := b.cluster.Status.State
+		clusterPodRevision := b.cluster.Annotations[podRevisionAnnotation]
+
+		if clusterState == corev1alpha1.HumioClusterStateRunning {
+			b.bootstrap.passed = true
+
+		}
+
+		foundPodList, err := kubernetes.ListPods(
+			f.Client.Client,
+			b.cluster.Namespace,
+			kubernetes.MatchingLabelsForHumio(b.cluster.Name),
+		)
+		if err != nil {
+			for _, pod := range foundPodList {
+				fmt.Println(fmt.Sprintf("pod %s status: %#v", pod.Name, pod.Status))
+			}
+		}
+
+		if b.restart.initiated {
+			if !b.restart.passed {
+
+				if clusterState == corev1alpha1.HumioClusterStateRestarting {
+					gotRestarted = true
+					numPodsShutdown := 0
+					for _, pod := range foundPodList {
+						if pod.DeletionTimestamp == nil {
+							for _, condition := range pod.Status.Conditions {
+								if condition.Type == "Ready" {
+									if condition.Status != "True" {
+										numPodsShutdown++
+									}
+								}
+							}
+						} else {
+							numPodsShutdown++
+						}
+					}
+					if numPodsShutdown == b.cluster.Spec.NodeCount {
+						podsSimultaneouslyShutdown = true
+					}
+				}
+				if clusterState == corev1alpha1.HumioClusterStateRunning {
+					if !gotRestarted {
+						return fmt.Errorf("never went into restarting state")
+					}
+					if podsSimultaneouslyShutdown {
+						return fmt.Errorf("pods were shut down at the same time")
+					}
+					if clusterPodRevision != "2" {
+						return fmt.Errorf("got wrong cluster pod revision when restarting: expected: 2 got: %s", clusterPodRevision)
+					}
+					for _, pod := range foundPodList {
+						if pod.Annotations[podRevisionAnnotation] != clusterPodRevision {
+							if pod.Annotations[podRevisionAnnotation] != clusterPodRevision {
+								return fmt.Errorf("got wrong pod revision when restarting: expected: %s got: %s", clusterPodRevision, pod.Annotations[podRevisionAnnotation])
+							}
+						}
+					}
+					b.restart.passed = true
+				}
+			}
+		} else {
+			if b.bootstrap.passed {
+				if clusterPodRevision != "1" {
+					return fmt.Errorf("got wrong cluster pod revision before restarting: expected: 1 got: %s", clusterPodRevision)
+				}
+
+				b.cluster.Spec.EnvironmentVariables = append(b.cluster.Spec.EnvironmentVariables, corev1.EnvVar{
+					Name:  "SOME_ENV_VAR",
+					Value: "some value",
+				})
+				f.Client.Update(goctx.TODO(), b.cluster)
+				b.restart.initiated = true
+			}
+		}
+
+		time.Sleep(time.Second * 10)
+	}
+	if !b.bootstrap.passed {
+		return fmt.Errorf("timed out waiting for cluster state to become: %s", corev1alpha1.HumioClusterStateRunning)
+	}
+	return fmt.Errorf("timed out waiting for cluster to upgrade")
+}

--- a/test/e2e/humiocluster_test.go
+++ b/test/e2e/humiocluster_test.go
@@ -46,7 +46,6 @@ func TestHumioCluster(t *testing.T) {
 		t.Run("pvc-cluster", HumioClusterWithPVCs)
 		t.Run("cluster-restart", HumioClusterRestart)
 		t.Run("cluster-upgrade", HumioClusterUpgrade)
-
 	})
 }
 

--- a/test/e2e/humiocluster_upgrade_test.go
+++ b/test/e2e/humiocluster_upgrade_test.go
@@ -1,0 +1,144 @@
+package e2e
+
+import (
+	goctx "context"
+	"fmt"
+	"time"
+
+	corev1alpha1 "github.com/humio/humio-operator/pkg/apis/core/v1alpha1"
+	"github.com/humio/humio-operator/pkg/kubernetes"
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type upgradeTest struct {
+	cluster   *corev1alpha1.HumioCluster
+	bootstrap testState
+	upgrade   testState
+}
+
+func newHumioClusterWithUpgradeTest(clusterName string, namespace string) humioClusterTest {
+	return &upgradeTest{
+		cluster: &corev1alpha1.HumioCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterName,
+				Namespace: namespace,
+			},
+			Spec: corev1alpha1.HumioClusterSpec{
+				NodeCount: 2,
+				EnvironmentVariables: []corev1.EnvVar{
+					{
+						Name:  "ZOOKEEPER_URL",
+						Value: "humio-cp-zookeeper-0.humio-cp-zookeeper-headless.default:2181",
+					},
+					{
+						Name:  "KAFKA_SERVERS",
+						Value: "humio-cp-kafka-0.humio-cp-kafka-headless.default:9092",
+					},
+				},
+			},
+		},
+	}
+}
+
+func (b *upgradeTest) Start(f *framework.Framework, ctx *framework.Context) error {
+	b.bootstrap.initiated = true
+	return f.Client.Create(goctx.TODO(), b.cluster, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+}
+
+func (b *upgradeTest) Wait(f *framework.Framework) error {
+	var gotUpgraded bool
+	var podsSimultaneouslyShutdown bool
+
+	for start := time.Now(); time.Since(start) < timeout; {
+		// return after all tests have completed
+		if b.bootstrap.passed && b.upgrade.passed {
+			return nil
+		}
+
+		err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: b.cluster.ObjectMeta.Name, Namespace: b.cluster.ObjectMeta.Namespace}, b.cluster)
+		if err != nil {
+			fmt.Printf("could not get humio cluster: %s", err)
+		}
+
+		clusterState := b.cluster.Status.State
+		clusterPodRevision := b.cluster.Annotations[podRevisionAnnotation]
+
+		if clusterState == corev1alpha1.HumioClusterStateRunning {
+			b.bootstrap.passed = true
+		}
+
+		foundPodList, err := kubernetes.ListPods(
+			f.Client.Client,
+			b.cluster.Namespace,
+			kubernetes.MatchingLabelsForHumio(b.cluster.Name),
+		)
+		if err != nil {
+			for _, pod := range foundPodList {
+				fmt.Println(fmt.Sprintf("pod %s status: %#v", pod.Name, pod.Status))
+			}
+		}
+
+		if b.upgrade.initiated {
+			if !b.upgrade.passed {
+				if clusterState == corev1alpha1.HumioClusterStateUpgrading {
+					gotUpgraded = true
+					numPodsShutdown := 0
+					for _, pod := range foundPodList {
+						if pod.DeletionTimestamp == nil {
+							for _, condition := range pod.Status.Conditions {
+								if condition.Type == "Ready" {
+									if condition.Status != "True" {
+										numPodsShutdown++
+									}
+								}
+							}
+						} else {
+							numPodsShutdown++
+						}
+					}
+					if numPodsShutdown == b.cluster.Spec.NodeCount {
+						podsSimultaneouslyShutdown = true
+					}
+				}
+				if clusterState == corev1alpha1.HumioClusterStateRunning {
+					if !gotUpgraded {
+						return fmt.Errorf("never went into upgrading state")
+					}
+					if !podsSimultaneouslyShutdown {
+						return fmt.Errorf("pods were not shut down at the same time")
+					}
+					if clusterPodRevision != "2" {
+						return fmt.Errorf("got wrong cluster pod revision when upgrading: expected: 2 got: %s", clusterPodRevision)
+					}
+					for _, pod := range foundPodList {
+						if pod.Annotations[podRevisionAnnotation] != clusterPodRevision {
+							if pod.Annotations[podRevisionAnnotation] != clusterPodRevision {
+								return fmt.Errorf("got wrong pod revision when upgrading: expected: %s got: %s", clusterPodRevision, pod.Annotations[podRevisionAnnotation])
+							}
+						}
+					}
+					b.upgrade.passed = true
+				}
+			}
+		} else {
+			if b.bootstrap.passed {
+				if clusterPodRevision != "1" {
+					return fmt.Errorf("got wrong cluster pod revision before upgrading: expected: 1 got: %s", clusterPodRevision)
+				}
+
+				b.cluster.Spec.Image = "humio/humio-core:1.13.0"
+				f.Client.Update(goctx.TODO(), b.cluster)
+				b.upgrade.initiated = true
+			}
+		}
+
+		time.Sleep(time.Second * 10)
+	}
+	if !b.bootstrap.passed {
+		return fmt.Errorf("timed out waiting for cluster state to become: %s", corev1alpha1.HumioClusterStateRunning)
+	}
+	return fmt.Errorf("timed out waiting for cluster to upgrade")
+}


### PR DESCRIPTION
This adds support for two ways of restarting pods: Restarting and Upgrading. It also introduces the idea of a "pod revision", which allows us to trigger restarts of Humio pods without changing the HumioCluster spec.

When the HumioCluster Spec is changed such that the Humio image is updated, then we change to a cluster state of Upgrading and take down all pods until there are none running, then start them all back up mostly at the same time.

When the HumioCluster Spec is changed in any other way other than updating the image, we change to a cluster state of Restarting and take down one pod at a time, wait for it to become Ready and then move on to the next pod (similar to basic deployments).

If we want to trigger a restart of Humio without changing the spec, we can increment the revision in the annotation `humio.com/pod-revision`. We can control whether the pods are restarting in a rolling or non-rolling (recreate) fashion by setting the annotation `humio.com/pod-restart-policy` to either `restart` or `recreate`.

I'm thinking we will want at least two e2e tests for this, one for rolling and another for recreating, but I am holding off on that for now as I know you are refactoring those a bit.