### PR TITLE
 Bump helper version to 0.0.6

### DIFF
--- a/.github/workflows/release-container-helperimage.yaml
+++ b/.github/workflows/release-container-helperimage.yaml
@@ -31,7 +31,7 @@ jobs:
         RH_SCAN_OSPID: ${{ secrets.RH_SCAN_HUMIO_OPERATOR_HELPER_OSPID }}
       run:  echo $RH_SCAN_KEY | docker login -u unused scan.connect.redhat.com --password-stdin
     - name: redhat scan tag
-      run: docker tag humio/humio-operator-helper:${{ env.RELEASE_VERSION }} scan.connect.redhat.com/${{ env.RH_SCAN_OSPID }}/humio-operator-helper:${{ env.RELEASE_VERSION }}
+      run: docker tag humio/humio-operator-helper:${{ env.RELEASE_VERSION }} scan.connect.redhat.com/$RH_SCAN_OSPID/humio-operator-helper:${{ env.RELEASE_VERSION }}
     - name: redhat scan push
-      run: docker push scan.connect.redhat.com/${{ env.RH_SCAN_OPSID }}/humio-operator-helper:${{ env.RELEASE_VERSION }}
+      run: docker push scan.connect.redhat.com/$RH_SCAN_OSPID/humio-operator-helper:${{ env.RELEASE_VERSION }}
 

--- a/.github/workflows/release-container-image.yaml
+++ b/.github/workflows/release-container-image.yaml
@@ -33,9 +33,9 @@ jobs:
         RH_SCAN_OSPID: ${{ secrets.RH_SCAN_HUMIO_OPERATOR_OSPID }}
       run:  echo $RH_SCAN_KEY | docker login -u unused scan.connect.redhat.com --password-stdin
     - name: redhat scan tag
-      run: docker tag humio/humio-operator:${{ env.RELEASE_VERSION }} scan.connect.redhat.com/${{ env.RH_SCAN_OSPID }}/humio-operator:${{ env.RELEASE_VERSION }}
+      run: docker tag humio/humio-operator:${{ env.RELEASE_VERSION }} scan.connect.redhat.com/$RH_SCAN_OSPID/humio-operator:${{ env.RELEASE_VERSION }}
     - name: redhat scan push
-      run: docker push scan.connect.redhat.com/${{ env.RH_SCAN_OPSID }}/humio-operator:${{ env.RELEASE_VERSION }}
+      run: docker push scan.connect.redhat.com/$RH_SCAN_OSPID/humio-operator:${{ env.RELEASE_VERSION }}
     - name: operator-courier push
       env:
         GO111MODULE: "on"

--- a/images/helper/version.go
+++ b/images/helper/version.go
@@ -1,5 +1,5 @@
 package main
 
 var (
-	Version = "0.0.5"
+	Version = "0.0.6"
 )


### PR DESCRIPTION
Changes RH_SCAN references to fix env var usage.