### PR TITLE
Reduce labels and selector matchLabels that the operator deployment uses

### DIFF
--- a/charts/humio-operator/templates/operator-deployment.yaml
+++ b/charts/humio-operator/templates/operator-deployment.yaml
@@ -20,9 +20,9 @@ spec:
     type: Recreate
   selector:
     matchLabels:
+      app: '{{ .Chart.Name }}'
       app.kubernetes.io/name: '{{ .Chart.Name }}'
       app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/managed-by: '{{ .Release.Service }}'
   template:
     metadata:
       annotations:


### PR DESCRIPTION
When using spinnaker, it sets the label `"app.kubernetes.io/managed-by"`, which then causes the deployment to break due to:

```
Deploy failed: The Deployment "humio-operator" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"app":"humio-operator", "app.kubernetes.io/instance":"humio-operator", "app.kubernetes.io/managed-by":"spinnaker", "app.kubernetes.io/name":"humio-operator"}: selector does not match template labels
```

Once the managed-by label is removed, it works as the selector is no longer using the label, thus it no longer needs to match. I don't think any of these are necessary on the operator deployment? The downside of changing these labels is the deployment will need to be deleted prior to updating to the version of the operator that contains this change.