### PR TITLE
Add chart repo install instructions

### DIFF
--- a/charts/humio-operator/README.md
+++ b/charts/humio-operator/README.md
@@ -27,6 +27,8 @@ kubectl apply -f https://raw.githubusercontent.com/humio/humio-operator/humio-op
 To install the chart with the release name `humio-operator`:
 
 ```bash
+helm repo add humio-operator https://humio.github.io/humio-operator
+
 # Helm v3+
 helm install humio-operator humio-operator/humio-operator --namespace humio-operator -f values.yaml
 


### PR DESCRIPTION
When trying to setup the operator I couldn't get the installation instructions in this readme to work as the chart repo was unknown.

This adds the `helm repo add` command to the installation instructions, which fixed it for me.

It is done the same way as described in https://github.com/humio/humio-operator/blob/master/docs/README.md#optional-prepare-an-installation-of-kafka-and-zookeeper