### PR TITLE
Define only one logger on Reconciler structs

### DIFF
--- a/controllers/humiocluster_annotations.go
+++ b/controllers/humiocluster_annotations.go
@@ -40,7 +40,7 @@ func (r *HumioClusterReconciler) incrementHumioClusterPodRevision(ctx context.Co
 		return -1, err
 	}
 	newRevision++
-	r.logger.Infof("setting cluster pod revision to %d", newRevision)
+	r.Log.Info(fmt.Sprintf("setting cluster pod revision to %d", newRevision))
 	hc.Annotations[podRevisionAnnotation] = strconv.Itoa(newRevision)
 
 	r.setRestartPolicy(hc, restartPolicy)
@@ -84,6 +84,6 @@ func (r *HumioClusterReconciler) setPodRevision(pod *corev1.Pod, newRevision int
 }
 
 func (r *HumioClusterReconciler) setRestartPolicy(hc *humiov1alpha1.HumioCluster, policy string) {
-	r.logger.Infof("setting HumioCluster annotation %s to %s", podRestartPolicyAnnotation, policy)
+	r.Log.Info(fmt.Sprintf("setting HumioCluster annotation %s to %s", podRestartPolicyAnnotation, policy))
 	hc.Annotations[podRestartPolicyAnnotation] = policy
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/go-logr/logr v0.1.0
+	github.com/go-logr/zapr v0.1.1
 	github.com/google/martian v2.1.0+incompatible
 	github.com/humio/cli v0.27.0
 	github.com/jetstack/cert-manager v0.16.1

--- a/main.go
+++ b/main.go
@@ -19,6 +19,8 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
 	humioapi "github.com/humio/cli/api"
 	"github.com/humio/humio-operator/pkg/helpers"
 	"github.com/humio/humio-operator/pkg/humio"
@@ -100,50 +102,47 @@ func main() {
 		cmapi.AddToScheme(mgr.GetScheme())
 	}
 
-	logger, _ := uberzap.NewProduction()
-	defer logger.Sync()
+	var log logr.Logger
+	zapLog, _ := uberzap.NewProduction(uberzap.AddCaller(), uberzap.AddCallerSkip(1))
+	defer zapLog.Sync()
+	log = zapr.NewLogger(zapLog)
 
 	if err = (&controllers.HumioExternalClusterReconciler{
 		Client:      mgr.GetClient(),
-		Log:         ctrl.Log.WithName("controllers").WithName("HumioExternalCluster"),
 		Scheme:      mgr.GetScheme(),
-		HumioClient: humio.NewClient(logger.Sugar(), &humioapi.Config{}),
+		HumioClient: humio.NewClient(log, &humioapi.Config{}),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "HumioExternalCluster")
 		os.Exit(1)
 	}
 	if err = (&controllers.HumioClusterReconciler{
 		Client:      mgr.GetClient(),
-		Log:         ctrl.Log.WithName("controllers").WithName("HumioCluster"),
 		Scheme:      mgr.GetScheme(),
-		HumioClient: humio.NewClient(logger.Sugar(), &humioapi.Config{}),
+		HumioClient: humio.NewClient(log, &humioapi.Config{}),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "HumioCluster")
 		os.Exit(1)
 	}
 	if err = (&controllers.HumioIngestTokenReconciler{
 		Client:      mgr.GetClient(),
-		Log:         ctrl.Log.WithName("controllers").WithName("HumioIngestToken"),
 		Scheme:      mgr.GetScheme(),
-		HumioClient: humio.NewClient(logger.Sugar(), &humioapi.Config{}),
+		HumioClient: humio.NewClient(log, &humioapi.Config{}),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "HumioIngestToken")
 		os.Exit(1)
 	}
 	if err = (&controllers.HumioParserReconciler{
 		Client:      mgr.GetClient(),
-		Log:         ctrl.Log.WithName("controllers").WithName("HumioParser"),
 		Scheme:      mgr.GetScheme(),
-		HumioClient: humio.NewClient(logger.Sugar(), &humioapi.Config{}),
+		HumioClient: humio.NewClient(log, &humioapi.Config{}),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "HumioParser")
 		os.Exit(1)
 	}
 	if err = (&controllers.HumioRepositoryReconciler{
 		Client:      mgr.GetClient(),
-		Log:         ctrl.Log.WithName("controllers").WithName("HumioRepository"),
 		Scheme:      mgr.GetScheme(),
-		HumioClient: humio.NewClient(logger.Sugar(), &humioapi.Config{}),
+		HumioClient: humio.NewClient(log, &humioapi.Config{}),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "HumioRepository")
 		os.Exit(1)

--- a/pkg/humio/client.go
+++ b/pkg/humio/client.go
@@ -18,11 +18,11 @@ package humio
 
 import (
 	"fmt"
+	"github.com/go-logr/logr"
 
 	humioapi "github.com/humio/cli/api"
 	humiov1alpha1 "github.com/humio/humio-operator/api/v1alpha1"
 	"github.com/humio/humio-operator/pkg/helpers"
-	"go.uber.org/zap"
 )
 
 // Client is the interface that can be mocked
@@ -73,14 +73,14 @@ type RepositoriesClient interface {
 // ClientConfig stores our Humio api client
 type ClientConfig struct {
 	apiClient *humioapi.Client
-	logger    *zap.SugaredLogger
+	logger    logr.Logger
 }
 
 // NewClient returns a ClientConfig
-func NewClient(logger *zap.SugaredLogger, config *humioapi.Config) *ClientConfig {
+func NewClient(logger logr.Logger, config *humioapi.Config) *ClientConfig {
 	client, err := humioapi.NewClient(*config)
 	if err != nil {
-		logger.Infof("could not create humio client: %s", err)
+		logger.Error(err, "could not create humio client")
 	}
 	return &ClientConfig{
 		apiClient: client,
@@ -111,7 +111,7 @@ func (h *ClientConfig) Authenticate(config *humioapi.Config) error {
 func (h *ClientConfig) Status() (humioapi.StatusResponse, error) {
 	status, err := h.apiClient.Status()
 	if err != nil {
-		h.logger.Errorf("could not get status: %s", err)
+		h.logger.Error(err, "could not get status")
 		return humioapi.StatusResponse{}, err
 	}
 	return *status, err
@@ -121,7 +121,7 @@ func (h *ClientConfig) Status() (humioapi.StatusResponse, error) {
 func (h *ClientConfig) GetClusters() (humioapi.Cluster, error) {
 	clusters, err := h.apiClient.Clusters().Get()
 	if err != nil {
-		h.logger.Errorf("could not get cluster information: %s", err)
+		h.logger.Error(err, "could not get cluster information")
 	}
 	return clusters, err
 }
@@ -130,7 +130,7 @@ func (h *ClientConfig) GetClusters() (humioapi.Cluster, error) {
 func (h *ClientConfig) UpdateStoragePartitionScheme(spi []humioapi.StoragePartitionInput) error {
 	err := h.apiClient.Clusters().UpdateStoragePartitionScheme(spi)
 	if err != nil {
-		h.logger.Errorf("could not update storage partition scheme cluster information: %s", err)
+		h.logger.Error(err, "could not update storage partition scheme cluster information")
 	}
 	return err
 }
@@ -139,7 +139,7 @@ func (h *ClientConfig) UpdateStoragePartitionScheme(spi []humioapi.StoragePartit
 func (h *ClientConfig) UpdateIngestPartitionScheme(ipi []humioapi.IngestPartitionInput) error {
 	err := h.apiClient.Clusters().UpdateIngestPartitionScheme(ipi)
 	if err != nil {
-		h.logger.Errorf("could not update ingest partition scheme cluster information: %s", err)
+		h.logger.Error(err, "could not update ingest partition scheme cluster information")
 	}
 	return err
 }

--- a/pkg/humio/cluster.go
+++ b/pkg/humio/cluster.go
@@ -18,21 +18,21 @@ package humio
 
 import (
 	"fmt"
+	"github.com/go-logr/logr"
 
 	humioapi "github.com/humio/cli/api"
 	humiov1alpha1 "github.com/humio/humio-operator/api/v1alpha1"
 	"github.com/shurcooL/graphql"
-	"go.uber.org/zap"
 )
 
 // ClusterController holds our client
 type ClusterController struct {
 	client Client
-	logger *zap.SugaredLogger
+	logger logr.Logger
 }
 
 // NewClusterController returns a ClusterController
-func NewClusterController(logger *zap.SugaredLogger, client Client) *ClusterController {
+func NewClusterController(logger logr.Logger, client Client) *ClusterController {
 	return &ClusterController{
 		client: client,
 		logger: logger,
@@ -134,7 +134,7 @@ func (c *ClusterController) AreStoragePartitionsBalanced(hc *humiov1alpha1.Humio
 	var min, max int
 	for i, partitionCount := range nodeToPartitionCount {
 		if partitionCount == 0 {
-			c.logger.Infof("node id %d does not contain any storage partitions", i)
+			c.logger.Info(fmt.Sprintf("node id %d does not contain any storage partitions", i))
 			return false, nil
 		}
 		if min == 0 {
@@ -152,11 +152,11 @@ func (c *ClusterController) AreStoragePartitionsBalanced(hc *humiov1alpha1.Humio
 	}
 
 	if max-min > 1 {
-		c.logger.Infof("the difference in number of storage partitions assigned per storage node is greater than 1, min=%d, max=%d", min, max)
+		c.logger.Info(fmt.Sprintf("the difference in number of storage partitions assigned per storage node is greater than 1, min=%d, max=%d", min, max))
 		return false, nil
 	}
 
-	c.logger.Infof("storage partitions are balanced min=%d, max=%d", min, max)
+	c.logger.Info(fmt.Sprintf("storage partitions are balanced min=%d, max=%d", min, max))
 	return true, nil
 }
 
@@ -221,7 +221,7 @@ func (c *ClusterController) AreIngestPartitionsBalanced(hc *humiov1alpha1.HumioC
 	var min, max int
 	for i, partitionCount := range nodeToPartitionCount {
 		if partitionCount == 0 {
-			c.logger.Infof("node id %d does not contain any ingest partitions", i)
+			c.logger.Info(fmt.Sprintf("node id %d does not contain any ingest partitions", i))
 			return false, nil
 		}
 		if min == 0 {
@@ -239,11 +239,11 @@ func (c *ClusterController) AreIngestPartitionsBalanced(hc *humiov1alpha1.HumioC
 	}
 
 	if max-min > 1 {
-		c.logger.Infof("the difference in number of ingest partitions assigned per storage node is greater than 1, min=%d, max=%d", min, max)
+		c.logger.Info(fmt.Sprintf("the difference in number of ingest partitions assigned per storage node is greater than 1, min=%d, max=%d", min, max))
 		return false, nil
 	}
 
-	c.logger.Infof("ingest partitions are balanced min=%d, max=%d", min, max)
+	c.logger.Info(fmt.Sprintf("ingest partitions are balanced min=%d, max=%d", min, max))
 	return true, nil
 }
 
@@ -292,7 +292,7 @@ func (c *ClusterController) StartDataRedistribution(hc *humiov1alpha1.HumioClust
 
 // MoveStorageRouteAwayFromNode notifies the Humio cluster that a node ID should be removed from handling any storage partitions
 func (c *ClusterController) MoveStorageRouteAwayFromNode(hc *humiov1alpha1.HumioCluster, nodeID int) error {
-	c.logger.Infof("moving storage route away from node %d", nodeID)
+	c.logger.Info(fmt.Sprintf("moving storage route away from node %d", nodeID))
 
 	if err := c.client.ClusterMoveStorageRouteAwayFromNode(nodeID); err != nil {
 		return fmt.Errorf("could not move storage route away from node: %s", err)
@@ -302,7 +302,7 @@ func (c *ClusterController) MoveStorageRouteAwayFromNode(hc *humiov1alpha1.Humio
 
 // MoveIngestRoutesAwayFromNode notifies the Humio cluster that a node ID should be removed from handling any ingest partitions
 func (c *ClusterController) MoveIngestRoutesAwayFromNode(hc *humiov1alpha1.HumioCluster, nodeID int) error {
-	c.logger.Infof("moving ingest routes away from node %d", nodeID)
+	c.logger.Info(fmt.Sprintf("moving ingest routes away from node %d", nodeID))
 
 	if err := c.client.ClusterMoveIngestRoutesAwayFromNode(nodeID); err != nil {
 		return fmt.Errorf("could not move ingest routes away from node: %s", err)
@@ -312,7 +312,7 @@ func (c *ClusterController) MoveIngestRoutesAwayFromNode(hc *humiov1alpha1.Humio
 
 // ClusterUnregisterNode tells the Humio cluster that we want to unregister a node
 func (c *ClusterController) ClusterUnregisterNode(hc *humiov1alpha1.HumioCluster, nodeID int) error {
-	c.logger.Infof("unregistering node with id %d", nodeID)
+	c.logger.Info(fmt.Sprintf("unregistering node with id %d", nodeID))
 
 	err := c.client.Unregister(nodeID)
 	if err != nil {

--- a/pkg/humio/cluster_test.go
+++ b/pkg/humio/cluster_test.go
@@ -17,12 +17,13 @@ limitations under the License.
 package humio
 
 import (
+	"github.com/go-logr/zapr"
+	uberzap "go.uber.org/zap"
 	"reflect"
 	"testing"
 
 	humioapi "github.com/humio/cli/api"
 	humiov1alpha1 "github.com/humio/humio-operator/api/v1alpha1"
-	"go.uber.org/zap"
 )
 
 func TestClusterController_AreAllRegisteredNodesAvailable(t *testing.T) {
@@ -462,12 +463,12 @@ func TestClusterController_IsStoragePartitionsBalanced(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger, _ := zap.NewProduction()
-			defer logger.Sync()
+			zapLog, _ := uberzap.NewProduction(uberzap.AddCaller(), uberzap.AddCallerSkip(1))
+			defer zapLog.Sync()
 
 			c := &ClusterController{
 				client: tt.fields.client,
-				logger: logger.Sugar().With("tt.name", tt.name),
+				logger: zapr.NewLogger(zapLog).WithValues("tt.name", tt.name),
 			}
 			got, err := c.AreStoragePartitionsBalanced(tt.args.hc)
 			if (err != nil) != tt.wantErr {
@@ -553,12 +554,12 @@ func TestClusterController_RebalanceStoragePartitions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger, _ := zap.NewProduction()
-			defer logger.Sync() // flushes buffer, if any
+			zapLog, _ := uberzap.NewProduction(uberzap.AddCaller(), uberzap.AddCallerSkip(1))
+			defer zapLog.Sync()
 
 			c := &ClusterController{
 				client: tt.fields.client,
-				logger: logger.Sugar().With("tt.name", tt.name),
+				logger: zapr.NewLogger(zapLog).WithValues("tt.name", tt.name),
 			}
 			if err := c.RebalanceStoragePartitions(tt.args.hc); (err != nil) != tt.wantErr {
 				t.Errorf("ClusterController.RebalanceStoragePartitions() error = %v, wantErr %v", err, tt.wantErr)
@@ -754,12 +755,12 @@ func TestClusterController_AreIngestPartitionsBalanced(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger, _ := zap.NewProduction()
-			defer logger.Sync()
+			zapLog, _ := uberzap.NewProduction(uberzap.AddCaller(), uberzap.AddCallerSkip(1))
+			defer zapLog.Sync()
 
 			c := &ClusterController{
 				client: tt.fields.client,
-				logger: logger.Sugar().With("tt.name", tt.name),
+				logger: zapr.NewLogger(zapLog).WithValues("tt.name", tt.name),
 			}
 			got, err := c.AreIngestPartitionsBalanced(tt.args.hc)
 			if (err != nil) != tt.wantErr {
@@ -845,12 +846,12 @@ func TestClusterController_RebalanceIngestPartitions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger, _ := zap.NewProduction()
-			defer logger.Sync() // flushes buffer, if any
+			zapLog, _ := uberzap.NewProduction(uberzap.AddCaller(), uberzap.AddCallerSkip(1))
+			defer zapLog.Sync()
 
 			c := &ClusterController{
 				client: tt.fields.client,
-				logger: logger.Sugar().With("tt.name", tt.name),
+				logger: zapr.NewLogger(zapLog).WithValues("tt.name", tt.name),
 			}
 			if err := c.RebalanceIngestPartitions(tt.args.hc); (err != nil) != tt.wantErr {
 				t.Errorf("ClusterController.RebalanceIngestPartitions() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
Fixes #168 

@jswoods Logs are still identical the old logs, or at least very close to, but at least this way we only define one logger on the reconciler structs.

It is possible we could replace the `logr.Logger` with the `zap.SugaredLogger` on the reconciler's, but the default scaffolding assumes we use `logr.Logger`. Let me know what you think we should do. I'm thinking we should just go with this for now and perhaps refactor this to the other logger later if needed. Personally, I really like the way we log errors with the approach shown in this PR, and I think we log out errors many more places than we do info logs, so perhaps we can live without the old `Infof()` method and such.