### PR TITLE
Disable olm bundle lint/push as we do not have a bundle at this point

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -9,12 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: operator-sdk lint
-      env:
-        GO111MODULE: "on"
-      uses: ./.github/action/operator-sdk
-      with:
-        args: operator-courier --verbose verify --ui_validate_io deploy/olm-catalog/humio-operator
+# Disable olm checks until we have a new bundle we want to validate against
+#    - name: operator-sdk lint
+#      env:
+#        GO111MODULE: "on"
+#      uses: ./.github/action/operator-sdk
+#      with:
+#        args: operator-courier --verbose verify --ui_validate_io deploy/olm-catalog/humio-operator
     - name: operator-sdk build
       env:
         GO111MODULE: "on"

--- a/.github/workflows/release-container-image.yaml
+++ b/.github/workflows/release-container-image.yaml
@@ -41,14 +41,15 @@ jobs:
       env:
         RH_SCAN_OSPID: ${{ secrets.RH_SCAN_HUMIO_OPERATOR_OSPID }}
       run: make docker-push IMG=scan.connect.redhat.com/$RH_SCAN_OSPID/humio-operator:${{ env.RELEASE_VERSION }}
-    - name: operator-courier push
-      env:
-        GO111MODULE: "on"
-        QUAY_ACCESS_TOKEN: ${{ secrets.QUAY_ACCESS_TOKEN }}
-        QUAY_NAMESPACE: ${{ secrets.QUAY_NAMESPACE }}
-      uses: ./.github/action/operator-sdk
-      with:
-        args: operator-courier push deploy/olm-catalog/humio-operator ${{ env.QUAY_NAMESPACE }} humio-operator ${{ env.RELEASE_VERSION }} "basic ${{ env.QUAY_ACCESS_TOKEN }}"
+# Disable olm push until we have a new bundle
+#    - name: operator-courier push
+#      env:
+#        GO111MODULE: "on"
+#        QUAY_ACCESS_TOKEN: ${{ secrets.QUAY_ACCESS_TOKEN }}
+#        QUAY_NAMESPACE: ${{ secrets.QUAY_NAMESPACE }}
+#      uses: ./.github/action/operator-sdk
+#      with:
+#        args: operator-courier push deploy/olm-catalog/humio-operator ${{ env.QUAY_NAMESPACE }} humio-operator ${{ env.RELEASE_VERSION }} "basic ${{ env.QUAY_ACCESS_TOKEN }}"
   gh-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest


### PR DESCRIPTION
Looks like "Publish Master" workflow is failing because we reference the olm-catalog which right now doesn't exist.
https://github.com/humio/humio-operator/actions?query=workflow%3A%22Publish+Master%22