### PR TITLE
Add ZONE configuration option to Humio containers.

### DIFF
--- a/controllers/humiocluster_controller.go
+++ b/controllers/humiocluster_controller.go
@@ -972,7 +972,7 @@ func (r *HumioClusterReconciler) ensureLabels(ctx context.Context, hc *humiov1al
 			r.Log.Info(fmt.Sprintf("not setting labels for pod %s because it is in state %s", pod.Name, pod.Status.Phase))
 			continue
 		}
-		r.Log.Info(fmt.Sprintf("setting labels for nodes: %v", cluster.Nodes))
+		r.Log.Info(fmt.Sprintf("setting labels for nodes: %#+v", cluster.Nodes))
 		for _, node := range cluster.Nodes {
 			if node.Uri == fmt.Sprintf("http://%s:%d", pod.Status.PodIP, humioPort) {
 				labels := kubernetes.LabelsForPod(hc.Name, node.Id)

--- a/controllers/humiocluster_pods.go
+++ b/controllers/humiocluster_pods.go
@@ -96,7 +96,7 @@ func constructPod(hc *humiov1alpha1.HumioCluster, humioNodeName string, attachme
 			Hostname:           humioNodeName,
 			InitContainers: []corev1.Container{
 				{
-					Name:  "zookeeper-prefix",
+					Name:  "init",
 					Image: "humio/humio-operator-helper:0.0.7",
 					Env: []corev1.EnvVar{
 						{
@@ -105,7 +105,7 @@ func constructPod(hc *humiov1alpha1.HumioCluster, humioNodeName string, attachme
 						},
 						{
 							Name:  "TARGET_FILE",
-							Value: fmt.Sprintf("%s/zookeeper-prefix", sharedPath),
+							Value: fmt.Sprintf("%s/availability-zone", sharedPath),
 						},
 						{
 							Name: "NODE_NAME",
@@ -233,8 +233,8 @@ func constructPod(hc *humiov1alpha1.HumioCluster, humioNodeName string, attachme
 					Image:   hc.Spec.Image,
 					Command: []string{"/bin/sh"},
 					Args: []string{"-c",
-						fmt.Sprintf("export ZOOKEEPER_PREFIX_FOR_NODE_UUID=/%s$(cat %s/zookeeper-prefix)_ && exec bash %s/run.sh",
-							nodeUUIDPrefixOrDefault(hc), sharedPath, humioAppPath)},
+						fmt.Sprintf("export ZONE=$(cat %s/availability-zone) && export ZOOKEEPER_PREFIX_FOR_NODE_UUID=/%s$(cat %s/availability-zone)_ && exec bash %s/run.sh",
+							sharedPath, nodeUUIDPrefixOrDefault(hc), sharedPath, humioAppPath)},
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "http",

--- a/controllers/humioresources_controller_test.go
+++ b/controllers/humioresources_controller_test.go
@@ -66,6 +66,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 					Namespace: clusterKey.Namespace,
 				},
 				Spec: humiov1alpha1.HumioClusterSpec{
+					Image:             image,
 					NodeCount:         helpers.IntPtr(1),
 					ExtraKafkaConfigs: "security.protocol=PLAINTEXT",
 					TLS:               &humiov1alpha1.HumioClusterTLSSpec{Enabled: helpers.BoolPtr(false)},

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,11 @@ module github.com/humio/humio-operator
 go 1.15
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1
 	github.com/google/martian v2.1.0+incompatible
-	github.com/humio/cli v0.27.0
+	github.com/humio/cli v0.26.2-0.20201006145633-07c972c1cfdf
 	github.com/jetstack/cert-manager v0.16.1
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6L
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -241,6 +243,8 @@ github.com/humio/cli v0.26.1 h1:WpqcqJJwkIqN11POhIlSP1M1J8tHv/LPOyXp+dDcgos=
 github.com/humio/cli v0.26.1/go.mod h1:9v5/6etu0lFf/PNRwvojGyIUO2V7EMBpzQcMjTFyY7g=
 github.com/humio/cli v0.26.2-0.20200923221341-5120306a558c h1:exAzLk3legOD0rUfS7JOxCVFr/qLrOcspjGqAu5rdPo=
 github.com/humio/cli v0.26.2-0.20200923221341-5120306a558c/go.mod h1:NfCIf3bPf0Y/fNvw8qJJzddBDPgSirRUgnttapIpRAE=
+github.com/humio/cli v0.26.2-0.20201006145633-07c972c1cfdf h1:uKZJginULuvGxYjGp6+Ac1KEo5mtMtriildERMG60qM=
+github.com/humio/cli v0.26.2-0.20201006145633-07c972c1cfdf/go.mod h1:NfCIf3bPf0Y/fNvw8qJJzddBDPgSirRUgnttapIpRAE=
 github.com/humio/cli v0.27.0 h1:SjT/zxVO5egiy3NUuQ2fVVC5iXqrJoJZQeSEo/iX42o=
 github.com/humio/cli v0.27.0/go.mod h1:NfCIf3bPf0Y/fNvw8qJJzddBDPgSirRUgnttapIpRAE=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/hack/start-crc-cluster.sh
+++ b/hack/start-crc-cluster.sh
@@ -2,7 +2,12 @@
 
 set -x
 
+declare -r tmp_kubeconfig=$HOME/.crc/machines/crc/kubeconfig
+declare -r kubectl="oc --kubeconfig $tmp_kubeconfig"
+
 crc setup
 crc start --pull-secret-file=.crc-pull-secret.txt --memory 20480 --cpus 6
 eval $(crc oc-env)
 eval $(crc console --credentials | grep "To login as an admin, run" | cut -f2 -d"'")
+
+$kubectl label node --all failure-domain.beta.kubernetes.io/zone=az1

--- a/hack/start-kind-cluster.sh
+++ b/hack/start-kind-cluster.sh
@@ -3,8 +3,11 @@
 set -x
 
 declare -r tmp_kubeconfig=/tmp/kubeconfig
+declare -r kubectl="kubectl --kubeconfig $tmp_kubeconfig"
 
 kind create cluster --name kind --image kindest/node:v1.17.11
 kind get kubeconfig > $tmp_kubeconfig
 docker exec kind-control-plane sh -c 'echo nameserver 8.8.8.8 > /etc/resolv.conf'
 docker exec kind-control-plane sh -c 'echo options ndots:0 >> /etc/resolv.conf'
+
+$kubectl label node --all failure-domain.beta.kubernetes.io/zone=az1


### PR DESCRIPTION
Initially I was adding all the 3 configuration options (in https://github.com/humio/humio-operator/pull/171) to be able to leverage suggested partition layouts, but this causes a few problems at this point. We can however start by just adding the ZONE configuration as a start, then add replication factors later.

The few TODO's I removed are already captured in an issue, so I don't see why we would keep the TODO's around in the code as well: https://github.com/humio/humio-operator/issues/167