### PR TITLE
Remove dependency on test target for building operator container.

### DIFF
--- a/.github/workflows/release-container-image.yaml
+++ b/.github/workflows/release-container-image.yaml
@@ -7,10 +7,12 @@ on:
 name: Publish Container Image Release
 jobs:
   build-and-publish:
-    name: Build and Publish
+    name: Test, Build and Publish
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - shell: bash
+      run: make test
     - name: Get release version
       id: get_version
       run: echo ::set-env name=RELEASE_VERSION::$(cat VERSION)

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 # Build the operator docker image
-docker-build-operator: test
+docker-build-operator:
 	docker build . -t ${IMG} ${IMG_BUILD_ARGS}
 
 # Build the helper docker image


### PR DESCRIPTION
We already run the tests as a separate job in the CI workflow.
Without this change we run tests twice in our CI workflow,
making the CI workflow run for an additional ~3-4 minutes.

I've decided to add a run of our tests as part of releasing a new
operator container image. We could also leave it out, but without
this we could end in situations where not all the relevant changes
have been tested together, mainly in scenarios where we have branches
for a PR that are not up to date with master but passes tests.