### PR TITLE
Bump memory limit for auth sidecar

### DIFF
--- a/controllers/humiocluster_pods.go
+++ b/controllers/humiocluster_pods.go
@@ -219,7 +219,7 @@ func constructPod(hc *humiov1alpha1.HumioCluster, humioNodeName string, attachme
 					Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
 							corev1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
-							corev1.ResourceMemory: *resource.NewQuantity(150*1024*1024, resource.BinarySI),
+							corev1.ResourceMemory: *resource.NewQuantity(750*1024*1024, resource.BinarySI),
 						},
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),


### PR DESCRIPTION
Some setups can have larger files that will be parsed in the current
implementation of the sidecar. For now, bump memory limit to buy us a
bit of time before migrating completely away from parsing the files.