### PR TITLE
sidecar: Drop cluster name and namespace from the hostname

### DIFF
--- a/controllers/humiocluster_annotations.go
+++ b/controllers/humiocluster_annotations.go
@@ -27,11 +27,13 @@ import (
 )
 
 const (
+	certHashAnnotation         = "humio.com/certificate-hash"
 	podHashAnnotation          = "humio.com/pod-hash"
 	podRevisionAnnotation      = "humio.com/pod-revision"
 	podRestartPolicyAnnotation = "humio.com/pod-restart-policy"
 	PodRestartPolicyRolling    = "rolling"
 	PodRestartPolicyRecreate   = "recreate"
+	pvcHashAnnotation          = "humio_pvc_hash"
 )
 
 func (r *HumioClusterReconciler) incrementHumioClusterPodRevision(ctx context.Context, hc *humiov1alpha1.HumioCluster, restartPolicy string) (int, error) {

--- a/controllers/humiocluster_pods.go
+++ b/controllers/humiocluster_pods.go
@@ -185,7 +185,7 @@ func constructPod(hc *humiov1alpha1.HumioCluster, humioNodeName string, attachme
 						},
 						{
 							Name:  "HUMIO_NODE_URL",
-							Value: fmt.Sprintf("%s://$(POD_NAME).$(CLUSTER_NAME).$(NAMESPACE):%d/", strings.ToLower(string(getProbeScheme(hc))), humioPort),
+							Value: fmt.Sprintf("%s://$(POD_NAME):%d/", strings.ToLower(string(getProbeScheme(hc))), humioPort),
 						},
 					},
 					VolumeMounts: []corev1.VolumeMount{

--- a/controllers/humiocluster_tls.go
+++ b/controllers/humiocluster_tls.go
@@ -170,13 +170,15 @@ func constructClusterCACertificateBundle(hc *humiov1alpha1.HumioCluster) cmapi.C
 func constructNodeCertificate(hc *humiov1alpha1.HumioCluster, nodeSuffix string) cmapi.Certificate {
 	return cmapi.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: hc.Namespace,
-			Name:      fmt.Sprintf("%s-core-%s", hc.Name, nodeSuffix),
-			Labels:    kubernetes.MatchingLabelsForHumio(hc.Name),
+			Annotations: map[string]string{},
+			Namespace:   hc.Namespace,
+			Name:        fmt.Sprintf("%s-core-%s", hc.Name, nodeSuffix),
+			Labels:      kubernetes.MatchingLabelsForHumio(hc.Name),
 		},
 		Spec: cmapi.CertificateSpec{
 			DNSNames: []string{
-				fmt.Sprintf("%s-core-%s.%s.%s", hc.Name, nodeSuffix, hc.Name, hc.Namespace), // Used for intra-cluster communication and auth sidecar
+				fmt.Sprintf("%s-core-%s.%s.%s", hc.Name, nodeSuffix, hc.Name, hc.Namespace), // Used for intra-cluster communication
+				fmt.Sprintf("%s-core-%s", hc.Name, nodeSuffix),                              // Used for auth sidecar
 				fmt.Sprintf("%s.%s", hc.Name, hc.Namespace),                                 // Used by humio-operator and ingress controllers to reach the Humio API
 			},
 			IssuerRef: cmmeta.ObjectReference{


### PR DESCRIPTION
This way we do not rely on cluster DNS. We can do this
because `/etc/hosts` for the sidecar already contains the
information needed to perform the lookup