### PR TITLE
fix: helm2 compatibility

### DIFF
--- a/charts/humio-operator/templates/operator-rbac.yaml
+++ b/charts/humio-operator/templates/operator-rbac.yaml
@@ -1,6 +1,5 @@
----
 {{- if .Values.operator.rbac.create -}}
-
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
Helm2 produces an invalid manifest:

```yaml
# Source: humio-operator/templates/operator-rbac.yaml
---apiVersion: v1
kind: ServiceAccount
metadata:
  name: 'release-name'
```