### PR TITLE
Changes USER declaration due to RH scanner error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,6 @@ COPY LICENSE /licenses/LICENSE
 
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER nonroot:nonroot
+USER 1001
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Changes USER from nonroot:nonroot to 1001, otherwise breaks RH registry scanning.  Based on other operators using UBI8 base images this seems to be the norm. I don't think there are any negative implications, but maybe the e2e tests will tell us.