### PR TITLE
Support user-defined service annotations.

### DIFF
--- a/api/v1alpha1/humiocluster_types.go
+++ b/api/v1alpha1/humiocluster_types.go
@@ -108,6 +108,9 @@ type HumioClusterSpec struct {
 	// HumioESServicePort is the port number of the Humio Service that is used to direct traffic to the ES interface of
 	// the Humio pods.
 	HumioESServicePort int32 `json:"humioESServicePort,omitempty"`
+	// HumioServiceAnnotations is the set of annotations added to the Kubernetes Service that is used to direct traffic
+	// to the Humio pods
+	HumioServiceAnnotations map[string]string `json:"humioServiceAnnotations,omitempty"`
 }
 
 // HumioClusterIngressSpec is used to set up ingress-related objects in order to reach Humio externally from the kubernetes cluster

--- a/charts/humio-operator/templates/crds.yaml
+++ b/charts/humio-operator/templates/crds.yaml
@@ -3501,6 +3501,13 @@ spec:
               description: HumioServiceAccountName is the name of the Kubernetes Service
                 Account that will be attached to the Humio pods
               type: string
+            humioServiceAnnotations:
+              additionalProperties:
+                type: string
+              description: HumioServiceAnnotations is the set of annotations added
+                to the Kubernetes Service that is used to direct traffic to the Humio
+                pods
+              type: object
             humioServicePort:
               description: HumioServicePort is the port number of the Humio Service
                 that is used to direct traffic to the http interface of the Humio

--- a/config/crd/bases/core.humio.com_humioclusters.yaml
+++ b/config/crd/bases/core.humio.com_humioclusters.yaml
@@ -3410,6 +3410,13 @@ spec:
               description: HumioServiceAccountName is the name of the Kubernetes Service
                 Account that will be attached to the Humio pods
               type: string
+            humioServiceAnnotations:
+              additionalProperties:
+                type: string
+              description: HumioServiceAnnotations is the set of annotations added
+                to the Kubernetes Service that is used to direct traffic to the Humio
+                pods
+              type: object
             humioServicePort:
               description: HumioServicePort is the port number of the Humio Service
                 that is used to direct traffic to the http interface of the Humio

--- a/controllers/humiocluster_defaults.go
+++ b/controllers/humiocluster_defaults.go
@@ -419,6 +419,13 @@ func humioESServicePortOrDefault(hc *humiov1alpha1.HumioCluster) int32 {
 	return elasticPort
 }
 
+func humioServiceAnnotationsOrDefault(hc *humiov1alpha1.HumioCluster) map[string]string {
+	if hc.Spec.HumioServiceAnnotations != nil {
+		return hc.Spec.HumioServiceAnnotations
+	}
+	return map[string]string(nil)
+}
+
 func humioPathOrDefault(hc *humiov1alpha1.HumioCluster) string {
 	if hc.Spec.Path != "" {
 		if strings.HasPrefix(hc.Spec.Path, "/") {

--- a/controllers/humiocluster_services.go
+++ b/controllers/humiocluster_services.go
@@ -26,9 +26,10 @@ import (
 func constructService(hc *humiov1alpha1.HumioCluster) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      hc.Name,
-			Namespace: hc.Namespace,
-			Labels:    kubernetes.LabelsForHumio(hc.Name),
+			Name:        hc.Name,
+			Namespace:   hc.Namespace,
+			Labels:      kubernetes.LabelsForHumio(hc.Name),
+			Annotations: humioServiceAnnotationsOrDefault(hc),
 		},
 		Spec: corev1.ServiceSpec{
 			Type:     humioServiceTypeOrDefault(hc),


### PR DESCRIPTION
Allow the user to define a custom set of annotations that should be
added to the service object pointing to the Humio pods.

The main benefit here is that you could run setups where you offload TLS
termination entirely to e.g. AWS NLB's without requiring the use of an
ingress controller.

Fixes https://github.com/humio/humio-operator/issues/215