### PR TITLE
Allow disabling TLS for ingress.

### DIFF
--- a/api/v1alpha1/humiocluster_types.go
+++ b/api/v1alpha1/humiocluster_types.go
@@ -116,6 +116,8 @@ type HumioClusterIngressSpec struct {
 	Enabled bool `json:"enabled,omitempty"`
 	// Controller is used to specify the controller used for ingress in the Kubernetes cluster. For now, only nginx is supported.
 	Controller string `json:"controller,omitempty"`
+	// TLS is used to specify whether the ingress controller will be using TLS for requests from external clients
+	TLS *bool `json:"tls,omitempty"`
 	// SecretName is used to specify the Kubernetes secret that contains the TLS certificate that should be used
 	SecretName string `json:"secretName,omitempty"`
 	// ESSecretName is used to specify the Kubernetes secret that contains the TLS certificate that should be used, specifically for the ESHostname

--- a/charts/humio-operator/templates/crds.yaml
+++ b/charts/humio-operator/templates/crds.yaml
@@ -3564,6 +3564,10 @@ spec:
                   description: SecretName is used to specify the Kubernetes secret
                     that contains the TLS certificate that should be used
                   type: string
+                tls:
+                  description: TLS is used to specify whether the ingress controller
+                    will be using TLS for requests from external clients
+                  type: boolean
               type: object
             initServiceAccountName:
               description: InitServiceAccountName is the name of the Kubernetes Service

--- a/config/crd/bases/core.humio.com_humioclusters.yaml
+++ b/config/crd/bases/core.humio.com_humioclusters.yaml
@@ -3473,6 +3473,10 @@ spec:
                   description: SecretName is used to specify the Kubernetes secret
                     that contains the TLS certificate that should be used
                   type: string
+                tls:
+                  description: TLS is used to specify whether the ingress controller
+                    will be using TLS for requests from external clients
+                  type: boolean
               type: object
             initServiceAccountName:
               description: InitServiceAccountName is the name of the Kubernetes Service

--- a/controllers/humiocluster_defaults.go
+++ b/controllers/humiocluster_defaults.go
@@ -367,6 +367,13 @@ func esCertificateSecretNameOrDefault(hc *humiov1alpha1.HumioCluster) string {
 	return fmt.Sprintf("%s-es-certificate", hc.Name)
 }
 
+func ingressTLSOrDefault(hc *humiov1alpha1.HumioCluster) bool {
+	if hc.Spec.Ingress.TLS == nil {
+		return true
+	}
+	return *hc.Spec.Ingress.TLS
+}
+
 func extraHumioVolumeMountsOrDefault(hc *humiov1alpha1.HumioCluster) []corev1.VolumeMount {
 	emptyVolumeMounts := []corev1.VolumeMount{}
 	if reflect.DeepEqual(hc.Spec.ExtraHumioVolumeMounts, emptyVolumeMounts) {


### PR DESCRIPTION
This is useful if you rely on e.g. AWS NLB's for doing TLS termination,
while the NLB is communicating to ingress-nginx over unencrypted communications.

By default, we will stick to the assumption that TLS should be enabled
on ingress objects. This means TLS will only be disabled for ingress if
explicitly defined as such.

Fixes https://github.com/humio/humio-operator/issues/216