### PR TITLE
Add test script with shared ServiceAccount and linkerd proxy injection

### DIFF
--- a/config/samples/core_v1alpha1_humiocluster_shared_serviceaccount.yaml
+++ b/config/samples/core_v1alpha1_humiocluster_shared_serviceaccount.yaml
@@ -1,0 +1,31 @@
+apiVersion: core.humio.com/v1alpha1
+kind: HumioCluster
+metadata:
+  name: example-humiocluster
+  labels:
+    app: 'humiocluster'
+    app.kubernetes.io/name: 'humiocluster'
+    app.kubernetes.io/instance: 'example-humiocluster'
+    app.kubernetes.io/managed-by: 'manual'
+spec:
+  extraKafkaConfigs: "security.protocol=PLAINTEXT"
+  tls:
+    enabled: false
+  image: "humio/humio-core:1.16.0"
+  humioServiceAccountName: humio
+  initServiceAccountName: humio
+  authServiceAccountName: humio
+  podAnnotations:
+    linkerd.io/inject: enabled
+    config.linkerd.io/skip-outbound-ports: "2181"
+    config.linkerd.io/skip-inbound-ports: "2181"
+  nodeCount: 1
+  environmentVariables:
+    - name: "HUMIO_JVM_ARGS"
+      value:  "-Xss2m -Xms256m -Xmx1536m -server -XX:+UseParallelOldGC -XX:+ScavengeBeforeFullGC -XX:+DisableExplicitGC -Dzookeeper.client.secure=false"
+    - name: "ZOOKEEPER_URL"
+      value: "humio-cp-zookeeper-0.humio-cp-zookeeper-headless:2181"
+    - name: "KAFKA_SERVERS"
+      value: "humio-cp-kafka-0.humio-cp-kafka-headless:9092"
+    - name: "SINGLE_USER_PASSWORD"
+      value: "develop3r"

--- a/hack/test-helm-chart-kind-shared-serviceaccount-linkerd.sh
+++ b/hack/test-helm-chart-kind-shared-serviceaccount-linkerd.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+
+################################################################
+# The purpose of this script is to test the following process: #
+# 0. Delete existing Kubernetes cluster with kind              #
+# 1. Spin up a kubernetes cluster with kind                    #
+# 2. Start up cert-manager, Kafka and Zookeeper                #
+# 3. Install humio-operator using Helm                         #
+# 4. Create CR to test the operator behaviour                  #
+################################################################
+
+# This script assumes you have installed the following tools:
+# - Git: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
+# - Helm v3: https://helm.sh/docs/intro/install/
+# - Operator SDK: https://docs.openshift.com/container-platform/4.4/operators/operator_sdk/osdk-getting-started.html#osdk-installing-cli_osdk-getting-started
+# - kubectl: https://kubernetes.io/docs/tasks/tools/install-kubectl/
+# - kind: https://kind.sigs.k8s.io/docs/user/quick-start#installation
+
+
+set -x
+
+declare -r operator_namespace=${NAMESPACE:-default}
+declare -r kubectl="kubectl --context kind-kind"
+declare -r git_rev=$(git rev-parse --short HEAD)
+declare -r operator_image=humio/humio-operator:local-$git_rev
+declare -r helm_chart_dir=./charts/humio-operator
+declare -r helm_chart_values_file=values.yaml
+declare -r hack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! command -v linkerd &> /dev/null
+then
+    echo "linkerd could not be found. It's a requirement for this script"
+    exit
+fi
+
+# Ensure we start from scratch
+source ${hack_dir}/delete-kind-cluster.sh
+
+# Wait a bit before we start everything up again
+sleep 5
+
+# Create new kind cluster
+source ${hack_dir}/start-kind-cluster.sh
+
+# Use helm to install cert-manager, Kafka and Zookeeper
+source ${hack_dir}/install-helm-chart-dependencies-kind.sh
+
+# Create a CR instance of HumioCluster
+sleep 10
+
+# Ensure we use the most recent CRD's
+make manifests
+
+# Build and pre-load the image into the cluster
+make docker-build-operator IMG=$operator_image
+
+kind load docker-image $operator_image
+
+$kubectl create namespace $operator_namespace
+
+helm upgrade --install humio-operator $helm_chart_dir \
+  --namespace $operator_namespace \
+  --set operator.image.tag=local-$git_rev \
+  --set installCRDs=true \
+  --values $helm_chart_dir/$helm_chart_values_file
+
+# Install linkerd and verify the control plane is up and running
+linkerd install | kubectl apply -f -
+linkerd check
+
+sleep 10
+
+# As we opt out of the indiviual service account, we need to provide a service account, and correct roles for all containers
+
+## Service Account to be used
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: humio
+  namespace: default
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: humio
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: humio
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: humio
+subjects:
+- kind: ServiceAccount
+  name: humio
+  namespace: default
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: humio
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: humio
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: humio
+subjects:
+- kind: ServiceAccount
+  name: humio
+  namespace: default
+EOF
+
+
+$kubectl apply -f config/samples/core_v1alpha1_humiocluster_shared_serviceaccount.yaml
+
+while [[ $($kubectl get humiocluster example-humiocluster -o 'jsonpath={..status.state}') != "Running" ]]
+do
+  echo "Waiting for example-humiocluster humiocluster to become Running"
+  sleep 10
+done


### PR DESCRIPTION
This PR adds a test script and sample `HumioCluster` with `linkerd` proxy injection using `podAnnotations` and a shared `ServiceAccount`. 

The script simulates the manual creation of resources when opting out of the service account per container setup and setup of linkerd in a kind cluster.