### PR TITLE
Upgrade dependency on Humio Go client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1
 	github.com/google/martian v2.1.0+incompatible
-	github.com/humio/cli v0.26.2-0.20201006145633-07c972c1cfdf
+	github.com/humio/cli v0.28.0
 	github.com/jetstack/cert-manager v0.16.1
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -247,6 +247,8 @@ github.com/humio/cli v0.26.2-0.20201006145633-07c972c1cfdf h1:uKZJginULuvGxYjGp6
 github.com/humio/cli v0.26.2-0.20201006145633-07c972c1cfdf/go.mod h1:NfCIf3bPf0Y/fNvw8qJJzddBDPgSirRUgnttapIpRAE=
 github.com/humio/cli v0.27.0 h1:SjT/zxVO5egiy3NUuQ2fVVC5iXqrJoJZQeSEo/iX42o=
 github.com/humio/cli v0.27.0/go.mod h1:NfCIf3bPf0Y/fNvw8qJJzddBDPgSirRUgnttapIpRAE=
+github.com/humio/cli v0.28.0 h1:JyoyKf4RN0qV7VGIzJZ9P2lTYMAyBTKTxMD/1ktlaaU=
+github.com/humio/cli v0.28.0/go.mod h1:24GlXZtyAUK5ZSFH2AIaTQnf11XopEViTilrRU1Mb/4=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=

--- a/images/helper/go.mod
+++ b/images/helper/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/gophercloud/gophercloud v0.13.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
-	github.com/humio/cli v0.27.0
+	github.com/humio/cli v0.28.0
 	github.com/imdario/mergo v0.3.5 // indirect
 	github.com/json-iterator/go v1.1.10 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect

--- a/images/helper/go.sum
+++ b/images/helper/go.sum
@@ -208,6 +208,8 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/humio/cli v0.27.0 h1:SjT/zxVO5egiy3NUuQ2fVVC5iXqrJoJZQeSEo/iX42o=
 github.com/humio/cli v0.27.0/go.mod h1:NfCIf3bPf0Y/fNvw8qJJzddBDPgSirRUgnttapIpRAE=
+github.com/humio/cli v0.28.0 h1:JyoyKf4RN0qV7VGIzJZ9P2lTYMAyBTKTxMD/1ktlaaU=
+github.com/humio/cli v0.28.0/go.mod h1:24GlXZtyAUK5ZSFH2AIaTQnf11XopEViTilrRU1Mb/4=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/images/helper/main.go
+++ b/images/helper/main.go
@@ -364,11 +364,6 @@ func authMode() {
 			Address: humioNodeURL,
 			Token:   localAdminToken,
 		})
-		if err != nil {
-			fmt.Printf("got err trying to create humio client: %s\n", err)
-			time.Sleep(5 * time.Second)
-			continue
-		}
 
 		// Get user ID of admin account
 		userID, err := createAndGetAdminAccountUserID(humioClient, organizationMode)

--- a/images/helper/main.go
+++ b/images/helper/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -194,7 +195,7 @@ func createAndGetAdminAccountUserID(client *humio.Client, organizationMode strin
 }
 
 // validateAdminSecretContent grabs the current token stored in kubernetes and returns nil if it is valid
-func validateAdminSecretContent(clientset *k8s.Clientset, namespace, clusterName, adminSecretNameSuffix, humioNodeURL string) error {
+func validateAdminSecretContent(clientset *k8s.Clientset, namespace, clusterName, adminSecretNameSuffix string, humioNodeURL *url.URL) error {
 	// Get existing Kubernetes secret
 	adminSecretName := fmt.Sprintf("%s-%s", clusterName, adminSecretNameSuffix)
 	secret, err := clientset.CoreV1().Secrets(namespace).Get(context.TODO(), adminSecretName, metav1.GetOptions{})
@@ -204,7 +205,7 @@ func validateAdminSecretContent(clientset *k8s.Clientset, namespace, clusterName
 
 	// Check if secret currently holds a valid humio api token
 	if adminToken, ok := secret.Data["token"]; ok {
-		humioClient, err := humio.NewClient(humio.Config{
+		humioClient := humio.NewClient(humio.Config{
 			Address: humioNodeURL,
 			Token:   string(adminToken),
 		})
@@ -342,7 +343,14 @@ func authMode() {
 			continue
 		}
 
-		err := validateAdminSecretContent(clientset, namespace, clusterName, adminSecretNameSuffix, humioNodeURL)
+		humioNodeURL, err := url.Parse(humioNodeURL)
+		if err != nil {
+			fmt.Printf("unable to parse url: %s\n", err)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+
+		err = validateAdminSecretContent(clientset, namespace, clusterName, adminSecretNameSuffix, humioNodeURL)
 		if err == nil {
 			fmt.Printf("validated existing token, no changes required. waiting 30 seconds\n")
 			time.Sleep(30 * time.Second)
@@ -352,7 +360,7 @@ func authMode() {
 		fmt.Printf("could not validate existing admin secret: %s\n", err)
 		fmt.Printf("continuing to create/update token\n")
 
-		humioClient, err := humio.NewClient(humio.Config{
+		humioClient := humio.NewClient(humio.Config{
 			Address: humioNodeURL,
 			Token:   localAdminToken,
 		})

--- a/pkg/humio/client_mock.go
+++ b/pkg/humio/client_mock.go
@@ -18,6 +18,7 @@ package humio
 
 import (
 	"fmt"
+	"net/url"
 
 	humioapi "github.com/humio/cli/api"
 	humiov1alpha1 "github.com/humio/humio-operator/api/v1alpha1"
@@ -141,8 +142,9 @@ func (h *MockClientConfig) GetIngestPartitions() (*[]humioapi.IngestPartition, e
 	return &h.apiClient.Cluster.IngestPartitions, nil
 }
 
-func (h *MockClientConfig) GetBaseURL(hc *humiov1alpha1.HumioCluster) string {
-	return fmt.Sprintf("http://%s.%s:%d/", hc.Name, hc.Namespace, 8080)
+func (h *MockClientConfig) GetBaseURL(hc *humiov1alpha1.HumioCluster) *url.URL {
+	baseURL, _ := url.Parse(fmt.Sprintf("http://%s.%s:%d/", hc.Name, hc.Namespace, 8080))
+	return baseURL
 }
 
 func (h *MockClientConfig) TestAPIToken() error {


### PR DESCRIPTION
This is mostly in preparation for a new feature. The new feature allows us to rotate the API token for a given user ID and is being introduced in https://github.com/humio/cli/pull/49

Main two changes are:
- The `Address` in the `humioapi.Config{}` was changed from `string` to `*url.URL`
- `NewClient()` no longer returns an error