### PR TITLE
Add HelperImage option to allow user-defined helper images.

### DIFF
--- a/api/v1alpha1/humiocluster_types.go
+++ b/api/v1alpha1/humiocluster_types.go
@@ -38,6 +38,8 @@ const (
 type HumioClusterSpec struct {
 	// Image is the desired humio container image, including the image tag
 	Image string `json:"image,omitempty"`
+	// HelperImage is the desired helper container image, including image tag
+	HelperImage string `json:"helperImage,omitempty"`
 	// AutoRebalancePartitions will enable auto-rebalancing of both digest and storage partitions assigned to humio cluster nodes
 	AutoRebalancePartitions bool `json:"autoRebalancePartitions,omitempty"`
 	// TargetReplicationFactor is the desired number of replicas of both storage and ingest partitions

--- a/charts/humio-operator/templates/crds.yaml
+++ b/charts/humio-operator/templates/crds.yaml
@@ -3539,6 +3539,10 @@ spec:
                   - name
                   type: object
                 type: array
+              helperImage:
+                description: HelperImage is the desired helper container image, including
+                  image tag
+                type: string
               hostname:
                 description: Hostname is the public hostname used by clients to access
                   Humio

--- a/config/crd/bases/core.humio.com_humioclusters.yaml
+++ b/config/crd/bases/core.humio.com_humioclusters.yaml
@@ -3447,6 +3447,10 @@ spec:
                   - name
                   type: object
                 type: array
+              helperImage:
+                description: HelperImage is the desired helper container image, including
+                  image tag
+                type: string
               hostname:
                 description: Hostname is the public hostname used by clients to access
                   Humio

--- a/controllers/humiocluster_controller.go
+++ b/controllers/humiocluster_controller.go
@@ -109,6 +109,7 @@ func (r *HumioClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 
 	_, err = constructPod(hc, "", &podAttachments{})
 	if err != nil {
+		r.Log.Error(err, "got error while trying to construct pod")
 		err = r.setState(context.TODO(), humiov1alpha1.HumioClusterStateConfigError, hc)
 		if err != nil {
 			r.Log.Error(err, "unable to set cluster state")

--- a/controllers/humiocluster_defaults.go
+++ b/controllers/humiocluster_defaults.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	image                        = "humio/humio-core:1.16.1"
+	helperImage                  = "humio/humio-operator-helper:0.1.0"
 	targetReplicationFactor      = 2
 	storagePartitionsCount       = 24
 	digestPartitionsCount        = 24
@@ -75,6 +76,13 @@ func setDefaults(hc *humiov1alpha1.HumioCluster) {
 		hc.Spec.DigestPartitionsCount = digestPartitionsCount
 	}
 
+}
+
+func helperImageOrDefault(hc *humiov1alpha1.HumioCluster) string {
+	if hc.Spec.HelperImage == "" {
+		return helperImage
+	}
+	return hc.Spec.HelperImage
 }
 
 func nodeCountOrDefault(hc *humiov1alpha1.HumioCluster) int {

--- a/controllers/humiocluster_pods.go
+++ b/controllers/humiocluster_pods.go
@@ -137,7 +137,6 @@ func constructPod(hc *humiov1alpha1.HumioCluster, humioNodeName string, attachme
 		productVersion = imageSplit[1]
 	}
 	userID := int64(65534)
-	helperImageTag := "humio/humio-operator-helper:0.1.0"
 
 	pod = corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -155,7 +154,7 @@ func constructPod(hc *humiov1alpha1.HumioCluster, humioNodeName string, attachme
 			InitContainers: []corev1.Container{
 				{
 					Name:  initContainerName,
-					Image: helperImageTag,
+					Image: helperImageOrDefault(hc),
 					Env: []corev1.EnvVar{
 						{
 							Name:  "MODE",
@@ -211,7 +210,7 @@ func constructPod(hc *humiov1alpha1.HumioCluster, humioNodeName string, attachme
 			Containers: []corev1.Container{
 				{
 					Name:  authContainerName,
-					Image: helperImageTag,
+					Image: helperImageOrDefault(hc),
 					Env: []corev1.EnvVar{
 						{
 							Name: "NAMESPACE",


### PR DESCRIPTION
This is useful when you are hosting a local container image registry.

Fixes https://github.com/humio/humio-operator/issues/258