### PR TITLE
Validate API token is obtained using the expected methods

### DIFF
--- a/controllers/humiocluster_defaults.go
+++ b/controllers/humiocluster_defaults.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	image                        = "humio/humio-core:1.16.3"
-	helperImage                  = "humio/humio-operator-helper:0.1.0"
+	helperImage                  = "humio/humio-operator-helper:0.2.0"
 	targetReplicationFactor      = 2
 	storagePartitionsCount       = 24
 	digestPartitionsCount        = 24

--- a/controllers/humiocluster_version.go
+++ b/controllers/humiocluster_version.go
@@ -9,8 +9,9 @@ import (
 )
 
 const (
-	HumioVersionWhichContainsZone             = "1.16.0"
-	HumioVersionWhichContainsHumioLog4JEnvVar = "1.19.0"
+	HumioVersionWhichContainsZone                     = "1.16.0"
+	HumioVersionWhichContainsHumioLog4JEnvVar         = "1.19.0"
+	HumioVersionWhichContainsAPITokenRotationMutation = "1.17.0"
 )
 
 type HumioVersion struct {


### PR DESCRIPTION
I did run the tests locally where I bumped the default Humio container image tag to 1.17.0, which worked just fine, but I'm guessing we want to stick with our stable releases as the default version.

Also, not sure what to do about the constants at this point. Right now the helper image only contains one package, which I can't import, so we'd need to split that up if we want to keep the constants in a separate package. If we split such things out, we may also want to refactor the other couple of things we have layout around which also has a copy in the main project as well as the helper image project.