### PR TITLE
Set cleanup annotation on a per-test-process to prevent conflicts when running in parallel.

### DIFF
--- a/controllers/humiocluster_controller_test.go
+++ b/controllers/humiocluster_controller_test.go
@@ -61,8 +61,10 @@ var _ = Describe("HumioCluster Controller", func() {
 		var existingClusters humiov1alpha1.HumioClusterList
 		k8sClient.List(context.Background(), &existingClusters)
 		for _, cluster := range existingClusters.Items {
-			if _, ok := cluster.Annotations[autoCleanupAfterTestAnnotationName]; ok {
-				k8sClient.Delete(context.Background(), &cluster)
+			if val, ok := cluster.Annotations[autoCleanupAfterTestAnnotationName]; ok {
+				if val == testProcessID {
+					_ = k8sClient.Delete(context.Background(), &cluster)
+				}
 			}
 		}
 	})
@@ -2107,7 +2109,7 @@ func constructBasicSingleNodeHumioCluster(key types.NamespacedName) *humiov1alph
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        key.Name,
 			Namespace:   key.Namespace,
-			Annotations: map[string]string{autoCleanupAfterTestAnnotationName: "true"},
+			Annotations: map[string]string{autoCleanupAfterTestAnnotationName: testProcessID},
 		},
 		Spec: humiov1alpha1.HumioClusterSpec{
 			Image:                   image,

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"github.com/humio/humio-operator/pkg/kubernetes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -63,6 +64,7 @@ var testEnv *envtest.Environment
 var k8sManager ctrl.Manager
 var humioClient humio.Client
 var testTimeout time.Duration
+var testProcessID string
 
 const testInterval = time.Second * 1
 
@@ -83,6 +85,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	By("bootstrapping test environment")
 	useExistingCluster := true
+	testProcessID = kubernetes.RandomString()
 	if os.Getenv("TEST_USE_EXISTING_CLUSTER") == "true" {
 		testTimeout = time.Second * 300
 		testEnv = &envtest.Environment{


### PR DESCRIPTION
Without this, if you run the tests in parallel you often end up with
problems where one test finishes early and then the teardown of that
will remove other tests running in parallel.

This is not a problem for our e2e tests yet, as they right now still run
sequentially, but this is part of what is required to make it possible
to run the e2e tests in parallel.