### PR TITLE
Test for HumioView should also clean up repository

### DIFF
--- a/controllers/humioresources_controller_test.go
+++ b/controllers/humioresources_controller_test.go
@@ -463,12 +463,20 @@ var _ = Describe("Humio Resources Controllers", func() {
 				return *updatedView
 			}, testTimeout, testInterval).Should(Equal(expectedUpdatedView))
 
-			By("Successfully deleting it")
+			By("Successfully deleting the view")
 			Expect(k8sClient.Delete(context.Background(), fetchedView)).To(Succeed())
 			Eventually(func() bool {
 				err := k8sClient.Get(context.Background(), viewKey, fetchedView)
 				return errors.IsNotFound(err)
 			}, testTimeout, testInterval).Should(BeTrue())
+
+			By("Successfully deleting the repo")
+			Expect(k8sClient.Delete(context.Background(), fetchedRepo)).To(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), viewKey, fetchedRepo)
+				return errors.IsNotFound(err)
+			}, testTimeout, testInterval).Should(BeTrue())
+
 		})
 	})
 


### PR DESCRIPTION
This doesn't fail when using a "new/empty" Kubernetes cluster when running the e2e tests because we typically start from scratch for every e2e test run.

I noticed this issue while trying to run the e2e tests a second time on the same `kind` cluster.