### PR TITLE
Randomize specs when running CI tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,13 +35,18 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test: generate fmt vet manifests ginkgo
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); USE_CERTMANAGER=false TEST_USE_EXISTING_CLUSTER=false $(GINKGO) -p -timeout 10m ./... -covermode=count -coverprofile cover.out
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); USE_CERTMANAGER=false TEST_USE_EXISTING_CLUSTER=false $(GINKGO) -p -randomizeSuites -randomizeAllSpecs -timeout 10m ./... -covermode=count -coverprofile cover.out
+
+test-until-it-fails: generate fmt vet manifests ginkgo
+	mkdir -p ${ENVTEST_ASSETS_DIR}
+	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/hack/setup-envtest.sh
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); USE_CERTMANAGER=false TEST_USE_EXISTING_CLUSTER=false $(GINKGO) -untilItFails -p -randomizeSuites -randomizeAllSpecs -timeout 10m ./... -covermode=count -coverprofile cover.out
 
 # Run tests in watch-mode where ginkgo automatically reruns packages with changes
 test-watch: generate fmt vet manifests ginkgo
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); USE_CERTMANAGER=false TEST_USE_EXISTING_CLUSTER=false $(GINKGO) watch -p -notify -timeout 10m ./... -covermode=count -coverprofile cover.out
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); USE_CERTMANAGER=false TEST_USE_EXISTING_CLUSTER=false $(GINKGO) watch -notify -p -randomizeSuites -randomizeAllSpecs -timeout 10m ./... -covermode=count -coverprofile cover.out
 
 # Build manager binary
 manager: generate fmt vet


### PR DESCRIPTION
Also, add a new test target to run tests until they fail.
I've used this new target locally with 40+ iterations without issues.