### PR TITLE
Bump to operator-sdk 1.3.0, kustomize 3.8.7 and helm 3.4.2.

### DIFF
--- a/.github/action/operator-sdk/Dockerfile
+++ b/.github/action/operator-sdk/Dockerfile
@@ -5,23 +5,13 @@ LABEL "com.github.actions.description"="operator-sdk image builder"
 LABEL "com.github.actions.icon"="layers"
 LABEL "com.github.actions.color"="red"
 
-ENV KUBECTL_VERSION=1.16.4
-ENV KIND_VERSION=0.9.0
-ENV RELEASE_VERSION=v1.0.1
-ENV HELM_VERSION=3.3.4
+ENV RELEASE_VERSION=v1.3.0
 ENV OPERATOR_COURIER_VERSION=2.1.10
 
 RUN apk update \
     && apk upgrade \
     && apk add --no-cache bash curl git openssh make mercurial openrc docker python3 git py-pip gcc \
     && pip3 install --upgrade pip setuptools
-
-RUN curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v${KIND_VERSION}/kind-$(uname)-amd64" && chmod +x ./kind && mv ./kind /usr/bin/kind
-
-RUN curl --max-time 300 -o /usr/local/bin/kubectl -L https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
-  && chmod 755 /usr/local/bin/kubectl
-
-RUN curl -L https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz -o /tmp/helm.tar.gz && tar -zxvf /tmp/helm.tar.gz -C /tmp && mv /tmp/linux-amd64/helm /bin/helm && rm -rf /tmp/*
 
 RUN pip3 install operator-courier==${OPERATOR_COURIER_VERSION}
 

--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -7,4 +7,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: helm v3 lint
-        run: docker run --rm --volume $GITHUB_WORKSPACE:/workspace --workdir /workspace alpine/helm:3.3.4 lint charts/humio-operator
+        run: docker run --rm --volume $GITHUB_WORKSPACE:/workspace --workdir /workspace alpine/helm:3.4.2 lint charts/humio-operator

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ ifeq (, $(shell which kustomize))
 	KUSTOMIZE_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$KUSTOMIZE_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/kustomize/kustomize/v3@v3.5.4 ;\
+	go get sigs.k8s.io/kustomize/kustomize/v3@v3.8.7 ;\
 	rm -rf $$KUSTOMIZE_GEN_TMP_DIR ;\
 	}
 KUSTOMIZE=$(GOBIN)/kustomize

--- a/hack/install-e2e-dependencies.sh
+++ b/hack/install-e2e-dependencies.sh
@@ -2,8 +2,8 @@
 
 set -ex
 
-declare -r helm_version=3.3.4
-declare -r operator_sdk_version=1.0.1
+declare -r helm_version=3.4.2
+declare -r operator_sdk_version=1.3.0
 declare -r telepresence_version=0.108
 declare -r bin_dir=${BIN_DIR:-/usr/local/bin}
 


### PR DESCRIPTION
Remove unused tools from operator-sdk action.

We've migrated our GitHub Action workflows to run helm/kubectl/etc.
directly from the shell in our workflows instead of running it inside
the operator-sdk action container due to connectivity complications.
Because of this, we already migrated away from using the tools in this
way and is safe to remove. Right now we don't use the operator-sdk
action at all, but we do have a few disabled workflow steps that uses
it, which is why I'm not deleting the action entirely.