### PR TITLE
Require explicitly defined storage configuration.

### DIFF
--- a/config/samples/core_v1alpha1_humiocluster.yaml
+++ b/config/samples/core_v1alpha1_humiocluster.yaml
@@ -23,3 +23,9 @@ spec:
       value: "humio-cp-kafka-0.humio-cp-kafka-headless:9092"
     - name: "SINGLE_USER_PASSWORD"
       value: "develop3r"
+  dataVolumePersistentVolumeClaimSpecTemplate:
+    storageClassName: standard
+    accessModes: [ReadWriteOnce]
+    resources:
+      requests:
+        storage: 10Gi

--- a/config/samples/core_v1alpha1_humiocluster_shared_serviceaccount.yaml
+++ b/config/samples/core_v1alpha1_humiocluster_shared_serviceaccount.yaml
@@ -30,3 +30,9 @@ spec:
       value: "humio-cp-kafka-0.humio-cp-kafka-headless:9092"
     - name: "SINGLE_USER_PASSWORD"
       value: "develop3r"
+  dataVolumePersistentVolumeClaimSpecTemplate:
+    storageClassName: standard
+    accessModes: [ReadWriteOnce]
+    resources:
+      requests:
+        storage: 10Gi

--- a/controllers/humiocluster_defaults.go
+++ b/controllers/humiocluster_defaults.go
@@ -114,9 +114,7 @@ func dataVolumePersistentVolumeClaimSpecTemplateOrDefault(hc *humiov1alpha1.Humi
 func dataVolumeSourceOrDefault(hc *humiov1alpha1.HumioCluster) corev1.VolumeSource {
 	emptyDataVolume := corev1.VolumeSource{}
 	if reflect.DeepEqual(hc.Spec.DataVolumeSource, emptyDataVolume) {
-		return corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{},
-		}
+		return corev1.VolumeSource{}
 	}
 	return hc.Spec.DataVolumeSource
 }

--- a/examples/humiocluster-affinity-and-tolerations.yaml
+++ b/examples/humiocluster-affinity-and-tolerations.yaml
@@ -37,6 +37,12 @@ spec:
             values:
             - humio
         topologyKey: kubernetes.io/hostname
+  dataVolumePersistentVolumeClaimSpecTemplate:
+    storageClassName: standard
+    accessModes: [ReadWriteOnce]
+    resources:
+      requests:
+        storage: 10Gi
   tolerations:
     - key: "node.kubernetes.io/unreachable"
       operator: "Exists"

--- a/examples/humiocluster-nginx-ingress-with-cert-manager.yaml
+++ b/examples/humiocluster-nginx-ingress-with-cert-manager.yaml
@@ -18,3 +18,9 @@ spec:
       use-http01-solver: "true"
       cert-manager.io/cluster-issuer: letsencrypt-prod
       kubernetes.io/ingress.class: nginx
+  dataVolumePersistentVolumeClaimSpecTemplate:
+    storageClassName: standard
+    accessModes: [ReadWriteOnce]
+    resources:
+      requests:
+        storage: 10Gi

--- a/examples/humiocluster-nginx-ingress-with-custom-path.yaml
+++ b/examples/humiocluster-nginx-ingress-with-custom-path.yaml
@@ -15,3 +15,9 @@ spec:
   ingress:
     enabled: true
     controller: nginx
+  dataVolumePersistentVolumeClaimSpecTemplate:
+    storageClassName: standard
+    accessModes: [ReadWriteOnce]
+    resources:
+      requests:
+        storage: 10Gi


### PR DESCRIPTION
Up until the default has been to EmptyDir. It is safer to require the
user to specify which type of storage they want to use. This should
help in scenarios where the user forgot to configure what type of
storage they want to use and thus unknowingly ended up using the
previous default.