### PR TITLE
Use new logging format for Humio 1.20.1+

### DIFF
--- a/controllers/humiocluster_defaults.go
+++ b/controllers/humiocluster_defaults.go
@@ -344,7 +344,12 @@ func setEnvironmentVariableDefaults(hc *humiov1alpha1.HumioCluster) {
 	}
 
 	humioVersion, _ := HumioVersionFromCluster(hc)
-	if ok, _ := humioVersion.AtLeast(HumioVersionWhichContainsHumioLog4JEnvVar); ok {
+	if ok, _ := humioVersion.AtLeast(HumioVersionWhichContainsNewJSONLogging); ok {
+		envDefaults = append(envDefaults, corev1.EnvVar{
+			Name:  "HUMIO_LOG4J_CONFIGURATION",
+			Value: "log4j2-json-stdout.xml",
+		})
+	} else if ok, _ := humioVersion.AtLeast(HumioVersionWhichContainsHumioLog4JEnvVar); ok {
 		envDefaults = append(envDefaults, corev1.EnvVar{
 			Name:  "HUMIO_LOG4J_CONFIGURATION",
 			Value: "log4j2-stdout-json.xml",

--- a/controllers/humiocluster_defaults_test.go
+++ b/controllers/humiocluster_defaults_test.go
@@ -141,7 +141,23 @@ var _ = Describe("HumioCluster Defaults", func() {
 		})
 
 		It("Should contain supported Log4J Environment Variable", func() {
-			versions := []string{"1.19.0", "master", "latest"}
+			toCreate := &humiov1alpha1.HumioCluster{
+				Spec: humiov1alpha1.HumioClusterSpec{
+					Image: "humio/humio-core:1.19.0",
+				},
+			}
+
+			setEnvironmentVariableDefaults(toCreate)
+			Expect(toCreate.Spec.EnvironmentVariables).Should(ContainElements([]corev1.EnvVar{
+				{
+					Name:  "HUMIO_LOG4J_CONFIGURATION",
+					Value: "log4j2-stdout-json.xml",
+				},
+			}))
+		})
+
+		It("Should contain supported Log4J Environment Variable", func() {
+			versions := []string{"1.20.1", "master", "latest"}
 			for _, version := range versions {
 				image := "humio/humio-core"
 				if version != "" {
@@ -157,7 +173,7 @@ var _ = Describe("HumioCluster Defaults", func() {
 				Expect(toCreate.Spec.EnvironmentVariables).Should(ContainElements([]corev1.EnvVar{
 					{
 						Name:  "HUMIO_LOG4J_CONFIGURATION",
-						Value: "log4j2-stdout-json.xml",
+						Value: "log4j2-json-stdout.xml",
 					},
 				}))
 			}

--- a/controllers/humiocluster_version.go
+++ b/controllers/humiocluster_version.go
@@ -13,6 +13,7 @@ const (
 	HumioVersionWhichContainsAPITokenRotationMutation  = "1.17.0"
 	HumioVersionWhichContainsSuggestedPartitionLayouts = "1.17.0"
 	HumioVersionWhichContainsHumioLog4JEnvVar          = "1.19.0"
+	HumioVersionWhichContainsNewJSONLogging            = "1.20.1"
 )
 
 type HumioVersion struct {


### PR DESCRIPTION
This will adjust how Humio logs and will help streamline the log formats used across our different logging methods, such as stdout, files and such.

Given the change to the logging format, any dashboards, alerts, etc. would need to be adjusted to work with the new format.