### PR TITLE
Only try to cleanup CA Issuer if cert-manager is present.

### DIFF
--- a/controllers/humiocluster_controller.go
+++ b/controllers/humiocluster_controller.go
@@ -1528,6 +1528,10 @@ func (r *HumioClusterReconciler) cleanupUnusedCAIssuer(ctx context.Context, hc *
 		return reconcile.Result{}, nil
 	}
 
+	if !helpers.UseCertManager() {
+		return reconcile.Result{}, nil
+	}
+
 	var existingCAIssuer cmapi.Issuer
 	err := r.Get(ctx, types.NamespacedName{
 		Namespace: hc.Namespace,


### PR DESCRIPTION
Previously it would try to fetch the `Issuer` object to check if it should be cleaned up no matter if cert-manager is present or not. If cert-manager is not present, we will not be able to fetch the `Issuer` objects as the CRD will not be present.

Related to https://github.com/humio/humio-operator/issues/358