### PR TITLE
Fix bug where license updates are triggered continuously

### DIFF
--- a/controllers/humiocluster_controller.go
+++ b/controllers/humiocluster_controller.go
@@ -1508,6 +1508,7 @@ func (r *HumioClusterReconciler) ensureLicense(ctx context.Context, hc *humiov1a
 	if existingLicense.LicenseType() != desiredLicense.LicenseType() ||
 		existingLicense.IssuedAt() != desiredLicense.IssuedAt() ||
 		existingLicense.ExpiresAt() != desiredLicense.ExpiresAt() {
+		r.Log.Info(fmt.Sprintf("updating license because of: existingLicense.LicenseType(%s) != desiredLicense.LicenseType(%s) || existingLicense.IssuedAt(%s) != desiredLicense.IssuedAt(%s) || existingLicense.ExpiresAt(%s) != desiredLicense.ExpiresAt(%s)", existingLicense.LicenseType(), desiredLicense.LicenseType(), existingLicense.IssuedAt(), desiredLicense.IssuedAt(), existingLicense.ExpiresAt(), desiredLicense.ExpiresAt()))
 		if err := r.HumioClient.InstallLicense(licenseStr); err != nil {
 			r.Log.Error(err, "could not install license")
 			return r.ensureInitialLicense(ctx, hc, r.HumioClient.GetBaseURL(hc))

--- a/pkg/humio/client_mock.go
+++ b/pkg/humio/client_mock.go
@@ -38,7 +38,6 @@ type ClientMock struct {
 	Parser                            humioapi.Parser
 	Repository                        humioapi.Repository
 	View                              humioapi.View
-	TrialLicense                      humioapi.TrialLicense
 	OnPremLicense                     humioapi.OnPremLicense
 	Notifier                          humioapi.Notifier
 	Alert                             humioapi.Alert
@@ -64,7 +63,6 @@ func NewMockClient(cluster humioapi.Cluster, clusterError error, updateStoragePa
 			Parser:                            humioapi.Parser{Tests: []humioapi.ParserTestCase{}},
 			Repository:                        humioapi.Repository{},
 			View:                              humioapi.View{},
-			TrialLicense:                      humioapi.TrialLicense{},
 			OnPremLicense:                     humioapi.OnPremLicense{},
 			Notifier:                          humioapi.Notifier{},
 			Alert:                             humioapi.Alert{},
@@ -282,21 +280,16 @@ func (h *MockClientConfig) GetLicense() (humioapi.License, error) {
 		return licenseInterface, nil
 	}
 
-	// by default, humio starts with a trial license
-	h.apiClient.TrialLicense = humioapi.TrialLicense{}
-	licenseInterface = h.apiClient.TrialLicense
-	return licenseInterface, nil
+	// by default, humio starts without a license
+	return nil, fmt.Errorf("No license installed. Please contact Humio support.")
 }
 
 func (h *MockClientConfig) InstallLicense(licenseString string) error {
-	trialLicense, onPremLicense, err := ParseLicenseType(licenseString)
+	onPremLicense, err := ParseLicenseType(licenseString)
 	if err != nil {
 		return fmt.Errorf("failed to parse license type: %s", err)
 	}
 
-	if trialLicense != nil {
-		h.apiClient.TrialLicense = *trialLicense
-	}
 	if onPremLicense != nil {
 		h.apiClient.OnPremLicense = *onPremLicense
 	}

--- a/pkg/humio/license.go
+++ b/pkg/humio/license.go
@@ -2,7 +2,7 @@ package humio
 
 import (
 	"fmt"
-	"strconv"
+	"time"
 
 	"gopkg.in/square/go-jose.v2/jwt"
 
@@ -10,21 +10,9 @@ import (
 )
 
 type license struct {
-	IDVal        string `json:"uid,omitempty"`
-	ExpiresAtVal int    `json:"exp,omitempty"`
-	IssuedAtVal  int    `json:"iat,omitempty"`
-}
-
-func (l *license) ID() string {
-	return l.IDVal
-}
-
-func (l *license) IssuedAt() string {
-	return strconv.Itoa(l.IssuedAtVal)
-}
-
-func (l license) ExpiresAt() string {
-	return strconv.Itoa(l.ExpiresAtVal)
+	IDVal         string `json:"uid,omitempty"`
+	ValidUntilVal int    `json:"validUntil,omitempty"`
+	IssuedAtVal   int    `json:"iat,omitempty"`
 }
 
 func (l license) LicenseType() string {
@@ -35,13 +23,7 @@ func (l license) LicenseType() string {
 }
 
 func ParseLicense(licenseString string) (humioapi.License, error) {
-	trialLicense, onPremLicense, err := ParseLicenseType(licenseString)
-	if trialLicense != nil {
-		return &humioapi.TrialLicense{
-			ExpiresAtVal: trialLicense.ExpiresAtVal,
-			IssuedAtVal:  trialLicense.IssuedAtVal,
-		}, nil
-	}
+	onPremLicense, err := ParseLicenseType(licenseString)
 	if onPremLicense != nil {
 		return &humioapi.OnPremLicense{
 			ID:           onPremLicense.ID,
@@ -52,31 +34,30 @@ func ParseLicense(licenseString string) (humioapi.License, error) {
 	return nil, fmt.Errorf("invalid license: %s", err)
 }
 
-func ParseLicenseType(licenseString string) (*humioapi.TrialLicense, *humioapi.OnPremLicense, error) {
+func ParseLicenseType(licenseString string) (*humioapi.OnPremLicense, error) {
 	licenseContent := &license{}
 
 	token, err := jwt.ParseSigned(licenseString)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error when parsing license: %s", err)
+		return nil, fmt.Errorf("error when parsing license: %s", err)
 	}
 	err = token.UnsafeClaimsWithoutVerification(&licenseContent)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error when parsing license: %s", err)
+		return nil, fmt.Errorf("error when parsing license: %s", err)
 	}
 
-	if licenseContent.LicenseType() == "trial" {
-		return &humioapi.TrialLicense{
-			ExpiresAtVal: strconv.Itoa(licenseContent.ExpiresAtVal),
-			IssuedAtVal:  strconv.Itoa(licenseContent.IssuedAtVal),
-		}, nil, nil
-	}
+	locUTC, _ := time.LoadLocation("UTC")
+
+	expiresAtVal := time.Unix(int64(licenseContent.ValidUntilVal), 0).In(locUTC)
+	issuedAtVal := time.Unix(int64(licenseContent.IssuedAtVal), 0).In(locUTC)
+
 	if licenseContent.LicenseType() == "onprem" {
-		return nil, &humioapi.OnPremLicense{
+		return &humioapi.OnPremLicense{
 			ID:           licenseContent.IDVal,
-			ExpiresAtVal: strconv.Itoa(licenseContent.ExpiresAtVal),
-			IssuedAtVal:  strconv.Itoa(licenseContent.IssuedAtVal),
+			ExpiresAtVal: expiresAtVal.Format(time.RFC3339),
+			IssuedAtVal:  issuedAtVal.Format(time.RFC3339),
 		}, nil
 	}
 
-	return nil, nil, fmt.Errorf("invalid license type: %s", licenseContent.LicenseType())
+	return nil, fmt.Errorf("invalid license type: %s", licenseContent.LicenseType())
 }


### PR DESCRIPTION
Humio's GraphQL API returns timestamps in RFC3339 format whereas
the actual license itself contains the timestamps in unix time.