### PR TITLE
Use available context introduced after upgrading operator-sdk

### DIFF
--- a/controllers/humioaction_annotations.go
+++ b/controllers/humioaction_annotations.go
@@ -12,10 +12,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func (r *HumioActionReconciler) reconcileHumioActionAnnotations(addedNotifier *humioapi.Notifier, ha *humiov1alpha1.HumioAction, req ctrl.Request) (reconcile.Result, error) {
+func (r *HumioActionReconciler) reconcileHumioActionAnnotations(ctx context.Context, addedNotifier *humioapi.Notifier, ha *humiov1alpha1.HumioAction, req ctrl.Request) (reconcile.Result, error) {
 	r.Log.Info(fmt.Sprintf("Adding ID %s to action %s", addedNotifier.ID, addedNotifier.Name))
 	currentAction := &humiov1alpha1.HumioAction{}
-	err := r.Get(context.TODO(), req.NamespacedName, currentAction)
+	err := r.Get(ctx, req.NamespacedName, currentAction)
 	if err != nil {
 		r.Log.Error(err, "failed to add ID annotation to action")
 		return reconcile.Result{}, err
@@ -34,7 +34,7 @@ func (r *HumioActionReconciler) reconcileHumioActionAnnotations(addedNotifier *h
 		currentAction.ObjectMeta.Annotations[k] = v
 	}
 
-	err = r.Update(context.TODO(), currentAction)
+	err = r.Update(ctx, currentAction)
 	if err != nil {
 		r.Log.Error(err, "failed to add ID annotation to action")
 		return reconcile.Result{}, err

--- a/controllers/humioalert_annotations.go
+++ b/controllers/humioalert_annotations.go
@@ -11,10 +11,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func (r *HumioAlertReconciler) reconcileHumioAlertAnnotations(addedAlert *humioapi.Alert, ha *humiov1alpha1.HumioAlert, req ctrl.Request) (reconcile.Result, error) {
+func (r *HumioAlertReconciler) reconcileHumioAlertAnnotations(ctx context.Context, addedAlert *humioapi.Alert, ha *humiov1alpha1.HumioAlert, req ctrl.Request) (reconcile.Result, error) {
 	r.Log.Info(fmt.Sprintf("Adding ID \"%s\" to alert \"%s\"", addedAlert.ID, addedAlert.Name))
 	currentAlert := &humiov1alpha1.HumioAlert{}
-	err := r.Get(context.TODO(), req.NamespacedName, currentAlert)
+	err := r.Get(ctx, req.NamespacedName, currentAlert)
 	if err != nil {
 		r.Log.Error(err, "failed to add ID annotation to alert")
 		return reconcile.Result{}, err
@@ -30,7 +30,7 @@ func (r *HumioAlertReconciler) reconcileHumioAlertAnnotations(addedAlert *humioa
 		currentAlert.ObjectMeta.Annotations[k] = v
 	}
 
-	err = r.Update(context.TODO(), currentAlert)
+	err = r.Update(ctx, currentAlert)
 	if err != nil {
 		r.Log.Error(err, "failed to add ID annotation to alert")
 		return reconcile.Result{}, err

--- a/controllers/humiocluster_persistent_volumes.go
+++ b/controllers/humiocluster_persistent_volumes.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"time"
@@ -88,10 +89,10 @@ func pvcsEnabled(hc *humiov1alpha1.HumioCluster) bool {
 	return !reflect.DeepEqual(hc.Spec.DataVolumePersistentVolumeClaimSpecTemplate, emptyPersistentVolumeClaimSpec)
 }
 
-func (r *HumioClusterReconciler) waitForNewPvc(hc *humiov1alpha1.HumioCluster, expectedPvc *corev1.PersistentVolumeClaim) error {
+func (r *HumioClusterReconciler) waitForNewPvc(ctx context.Context, hc *humiov1alpha1.HumioCluster, expectedPvc *corev1.PersistentVolumeClaim) error {
 	for i := 0; i < waitForPvcTimeoutSeconds; i++ {
 		r.Log.Info(fmt.Sprintf("validating new pvc was created. waiting for pvc with name %s", expectedPvc.Name))
-		latestPvcList, err := kubernetes.ListPersistentVolumeClaims(r, hc.Namespace, kubernetes.MatchingLabelsForHumio(hc.Name))
+		latestPvcList, err := kubernetes.ListPersistentVolumeClaims(ctx, r, hc.Namespace, kubernetes.MatchingLabelsForHumio(hc.Name))
 		if err != nil {
 			return fmt.Errorf("failed to list pvcs: %s", err)
 		}

--- a/controllers/humiocluster_pods.go
+++ b/controllers/humiocluster_pods.go
@@ -793,7 +793,7 @@ func (r *HumioClusterReconciler) createPod(ctx context.Context, hc *humiov1alpha
 
 // waitForNewPod can be used to wait for a new pod to be created after the create call is issued. It is important that
 // the previousPodList contains the list of pods prior to when the new pod was created
-func (r *HumioClusterReconciler) waitForNewPod(hc *humiov1alpha1.HumioCluster, previousPodList []corev1.Pod, expectedPod *corev1.Pod) error {
+func (r *HumioClusterReconciler) waitForNewPod(ctx context.Context, hc *humiov1alpha1.HumioCluster, previousPodList []corev1.Pod, expectedPod *corev1.Pod) error {
 	// We must check only pods that were running prior to the new pod being created, and we must only include pods that
 	// were running the same revision as the newly created pod. This is because there may be pods under the previous
 	// revision that were still terminating when the new pod was created
@@ -808,7 +808,7 @@ func (r *HumioClusterReconciler) waitForNewPod(hc *humiov1alpha1.HumioCluster, p
 
 	for i := 0; i < waitForPodTimeoutSeconds; i++ {
 		var podsMatchingRevisionCount int
-		latestPodList, err := kubernetes.ListPods(r, hc.Namespace, kubernetes.MatchingLabelsForHumio(hc.Name))
+		latestPodList, err := kubernetes.ListPods(ctx, r, hc.Namespace, kubernetes.MatchingLabelsForHumio(hc.Name))
 		if err != nil {
 			return err
 		}
@@ -935,7 +935,7 @@ func findHumioNodeName(ctx context.Context, c client.Client, hc *humiov1alpha1.H
 	}
 
 	// if TLS is enabled, use the first available TLS certificate
-	certificates, err := kubernetes.ListCertificates(c, hc.Namespace, kubernetes.MatchingLabelsForHumio(hc.Name))
+	certificates, err := kubernetes.ListCertificates(ctx, c, hc.Namespace, kubernetes.MatchingLabelsForHumio(hc.Name))
 	if err != nil {
 		return "", err
 	}
@@ -967,7 +967,7 @@ func findHumioNodeName(ctx context.Context, c client.Client, hc *humiov1alpha1.H
 }
 
 func (r *HumioClusterReconciler) newPodAttachments(ctx context.Context, hc *humiov1alpha1.HumioCluster, foundPodList []corev1.Pod) (*podAttachments, error) {
-	pvcList, err := r.pvcList(hc)
+	pvcList, err := r.pvcList(ctx, hc)
 	if err != nil {
 		return &podAttachments{}, fmt.Errorf("problem getting pvc list: %s", err)
 	}

--- a/controllers/humiocluster_secrets.go
+++ b/controllers/humiocluster_secrets.go
@@ -16,12 +16,12 @@ const (
 
 // waitForNewSecret can be used to wait for a new secret to be created after the create call is issued. It is important
 // that the previousSecretList contains the list of secrets prior to when the new secret was created
-func (r *HumioClusterReconciler) waitForNewSecret(hc *humiov1alpha1.HumioCluster, previousSecretList []corev1.Secret, expectedSecretName string) error {
+func (r *HumioClusterReconciler) waitForNewSecret(ctx context.Context, hc *humiov1alpha1.HumioCluster, previousSecretList []corev1.Secret, expectedSecretName string) error {
 	// We must check only secrets that existed prior to the new secret being created
 	expectedSecretCount := len(previousSecretList) + 1
 
 	for i := 0; i < waitForSecretTimeoutSeconds; i++ {
-		foundSecretsList, err := kubernetes.ListSecrets(context.TODO(), r, hc.Namespace, kubernetes.MatchingLabelsForSecret(hc.Name, expectedSecretName))
+		foundSecretsList, err := kubernetes.ListSecrets(ctx, r, hc.Namespace, kubernetes.MatchingLabelsForSecret(hc.Name, expectedSecretName))
 		if err != nil {
 			r.Log.Error(err, "unable list secrets")
 			return err

--- a/controllers/humiocluster_status.go
+++ b/controllers/humiocluster_status.go
@@ -75,7 +75,7 @@ func (r *HumioClusterReconciler) setNodeCount(ctx context.Context, nodeCount int
 
 func (r *HumioClusterReconciler) setPod(ctx context.Context, hc *humiov1alpha1.HumioCluster) error {
 	r.Log.Info("setting cluster pod status")
-	pods, err := kubernetes.ListPods(r, hc.Namespace, kubernetes.MatchingLabelsForHumio(hc.Name))
+	pods, err := kubernetes.ListPods(ctx, r, hc.Namespace, kubernetes.MatchingLabelsForHumio(hc.Name))
 	if err != nil {
 		r.Log.Error(err, "unable to set pod status")
 		return err

--- a/controllers/humiocluster_tls.go
+++ b/controllers/humiocluster_tls.go
@@ -227,7 +227,7 @@ func (r *HumioClusterReconciler) waitForNewNodeCertificate(ctx context.Context, 
 // updateNodeCertificates updates existing node certificates that have been changed. Returns the count of existing node
 // certificates
 func (r *HumioClusterReconciler) updateNodeCertificates(ctx context.Context, hc *humiov1alpha1.HumioCluster) (int, error) {
-	certificates, err := kubernetes.ListCertificates(r, hc.Namespace, kubernetes.MatchingLabelsForHumio(hc.Name))
+	certificates, err := kubernetes.ListCertificates(ctx, r, hc.Namespace, kubernetes.MatchingLabelsForHumio(hc.Name))
 	if err != nil {
 		return -1, err
 	}

--- a/controllers/humioexternalcluster_controller.go
+++ b/controllers/humioexternalcluster_controller.go
@@ -52,7 +52,7 @@ func (r *HumioExternalClusterReconciler) Reconcile(ctx context.Context, req ctrl
 
 	// Fetch the HumioExternalCluster instance
 	hec := &humiov1alpha1.HumioExternalCluster{}
-	err := r.Get(context.TODO(), req.NamespacedName, hec)
+	err := r.Get(ctx, req.NamespacedName, hec)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -65,14 +65,14 @@ func (r *HumioExternalClusterReconciler) Reconcile(ctx context.Context, req ctrl
 	}
 
 	if hec.Status.State == "" {
-		err := r.setState(context.TODO(), humiov1alpha1.HumioExternalClusterStateUnknown, hec)
+		err := r.setState(ctx, humiov1alpha1.HumioExternalClusterStateUnknown, hec)
 		if err != nil {
 			r.Log.Error(err, "unable to set cluster state")
 			return reconcile.Result{}, err
 		}
 	}
 
-	cluster, err := helpers.NewCluster(context.TODO(), r, "", hec.Name, hec.Namespace, helpers.UseCertManager())
+	cluster, err := helpers.NewCluster(ctx, r, "", hec.Name, hec.Namespace, helpers.UseCertManager())
 	if err != nil || cluster.Config() == nil {
 		r.Log.Error(err, "unable to obtain humio client config")
 		return reconcile.Result{}, err
@@ -82,12 +82,12 @@ func (r *HumioExternalClusterReconciler) Reconcile(ctx context.Context, req ctrl
 
 	err = r.HumioClient.TestAPIToken()
 	if err != nil {
-		err = r.Client.Get(context.TODO(), req.NamespacedName, hec)
+		err = r.Client.Get(ctx, req.NamespacedName, hec)
 		if err != nil {
 			r.Log.Error(err, "unable to get cluster state")
 			return reconcile.Result{}, err
 		}
-		err = r.setState(context.TODO(), humiov1alpha1.HumioExternalClusterStateUnknown, hec)
+		err = r.setState(ctx, humiov1alpha1.HumioExternalClusterStateUnknown, hec)
 		if err != nil {
 			r.Log.Error(err, "unable to set cluster state")
 			return reconcile.Result{}, err
@@ -95,13 +95,13 @@ func (r *HumioExternalClusterReconciler) Reconcile(ctx context.Context, req ctrl
 		return reconcile.Result{Requeue: true, RequeueAfter: time.Second * 15}, nil
 	}
 
-	err = r.Client.Get(context.TODO(), req.NamespacedName, hec)
+	err = r.Client.Get(ctx, req.NamespacedName, hec)
 	if err != nil {
 		r.Log.Error(err, "unable to get cluster state")
 		return reconcile.Result{}, err
 	}
 	if hec.Status.State != humiov1alpha1.HumioExternalClusterStateReady {
-		err = r.setState(context.TODO(), humiov1alpha1.HumioExternalClusterStateReady, hec)
+		err = r.setState(ctx, humiov1alpha1.HumioExternalClusterStateReady, hec)
 		if err != nil {
 			r.Log.Error(err, "unable to set cluster state")
 			return reconcile.Result{}, err

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -208,8 +208,9 @@ var _ = BeforeSuite(func() {
 
 	if helpers.IsOpenShift() {
 		var err error
+		ctx := context.Background()
 		Eventually(func() bool {
-			_, err = openshift.GetSecurityContextConstraints(context.Background(), k8sClient)
+			_, err = openshift.GetSecurityContextConstraints(ctx, k8sClient)
 			if errors.IsNotFound(err) {
 				// Object has not been created yet
 				return true
@@ -277,7 +278,7 @@ var _ = BeforeSuite(func() {
 				Groups:                 nil,
 				SeccompProfiles:        nil,
 			}
-			Expect(k8sClient.Create(context.Background(), &scc)).To(Succeed())
+			Expect(k8sClient.Create(ctx, &scc)).To(Succeed())
 		}
 	}
 

--- a/pkg/helpers/clusterinterface.go
+++ b/pkg/helpers/clusterinterface.go
@@ -32,7 +32,7 @@ import (
 )
 
 type ClusterInterface interface {
-	Url(client.Client) (*url.URL, error)
+	Url(context.Context, client.Client) (*url.URL, error)
 	Name() string
 	Config() *humioapi.Config
 	constructHumioConfig(context.Context, client.Client) (*humioapi.Config, error)
@@ -73,11 +73,11 @@ func NewCluster(ctx context.Context, k8sClient client.Client, managedClusterName
 	return cluster, nil
 }
 
-func (c Cluster) Url(k8sClient client.Client) (*url.URL, error) {
+func (c Cluster) Url(ctx context.Context, k8sClient client.Client) (*url.URL, error) {
 	if c.managedClusterName != "" {
 		// Lookup ManagedHumioCluster resource to figure out if we expect to use TLS or not
 		var humioManagedCluster humiov1alpha1.HumioCluster
-		err := k8sClient.Get(context.TODO(), types.NamespacedName{
+		err := k8sClient.Get(ctx, types.NamespacedName{
 			Namespace: c.namespace,
 			Name:      c.managedClusterName,
 		}, &humioManagedCluster)
@@ -100,7 +100,7 @@ func (c Cluster) Url(k8sClient client.Client) (*url.URL, error) {
 
 	// Fetch the HumioExternalCluster instance
 	var humioExternalCluster humiov1alpha1.HumioExternalCluster
-	err := k8sClient.Get(context.TODO(), types.NamespacedName{
+	err := k8sClient.Get(ctx, types.NamespacedName{
 		Namespace: c.namespace,
 		Name:      c.externalClusterName,
 	}, &humioExternalCluster)
@@ -133,7 +133,7 @@ func (c Cluster) constructHumioConfig(ctx context.Context, k8sClient client.Clie
 	if c.managedClusterName != "" {
 		// Lookup ManagedHumioCluster resource to figure out if we expect to use TLS or not
 		var humioManagedCluster humiov1alpha1.HumioCluster
-		err := k8sClient.Get(context.TODO(), types.NamespacedName{
+		err := k8sClient.Get(ctx, types.NamespacedName{
 			Namespace: c.namespace,
 			Name:      c.managedClusterName,
 		}, &humioManagedCluster)
@@ -142,7 +142,7 @@ func (c Cluster) constructHumioConfig(ctx context.Context, k8sClient client.Clie
 		}
 
 		// Get the URL we want to use
-		clusterURL, err := c.Url(k8sClient)
+		clusterURL, err := c.Url(ctx, k8sClient)
 		if err != nil {
 			return nil, err
 		}
@@ -193,7 +193,7 @@ func (c Cluster) constructHumioConfig(ctx context.Context, k8sClient client.Clie
 
 	// Fetch the HumioExternalCluster instance
 	var humioExternalCluster humiov1alpha1.HumioExternalCluster
-	err := k8sClient.Get(context.TODO(), types.NamespacedName{
+	err := k8sClient.Get(ctx, types.NamespacedName{
 		Namespace: c.namespace,
 		Name:      c.externalClusterName,
 	}, &humioExternalCluster)

--- a/pkg/helpers/clusterinterface_test.go
+++ b/pkg/helpers/clusterinterface_test.go
@@ -175,7 +175,7 @@ func TestCluster_HumioConfig_managedHumioCluster(t *testing.T) {
 
 			cl := fake.NewFakeClient(objs...)
 
-			cluster, err := NewCluster(context.TODO(), cl, tt.managedHumioCluster.Name, "", tt.managedHumioCluster.Namespace, tt.certManagerEnabled)
+			cluster, err := NewCluster(context.Background(), cl, tt.managedHumioCluster.Name, "", tt.managedHumioCluster.Namespace, tt.certManagerEnabled)
 			if err != nil || cluster.Config() == nil {
 				t.Errorf("unable to obtain humio client config: %s", err)
 			}
@@ -372,7 +372,7 @@ func TestCluster_HumioConfig_externalHumioCluster(t *testing.T) {
 
 			cl := fake.NewFakeClient(objs...)
 
-			cluster, err := NewCluster(context.TODO(), cl, "", tt.externalHumioCluster.Name, tt.externalHumioCluster.Namespace, false)
+			cluster, err := NewCluster(context.Background(), cl, "", tt.externalHumioCluster.Name, tt.externalHumioCluster.Namespace, false)
 			if tt.expectedConfigFailure && (err == nil) {
 				t.Errorf("unable to get a valid config: %s", err)
 			}
@@ -499,7 +499,7 @@ func TestCluster_NewCluster(t *testing.T) {
 
 			cl := fake.NewFakeClient(objs...)
 
-			_, err := NewCluster(context.TODO(), cl, tt.managedClusterName, tt.externalClusterName, tt.namespace, false)
+			_, err := NewCluster(context.Background(), cl, tt.managedClusterName, tt.externalClusterName, tt.namespace, false)
 			if tt.expectError == (err == nil) {
 				t.Fatalf("expectError: %+v but got=%+v", tt.expectError, err)
 			}

--- a/pkg/kubernetes/certificates.go
+++ b/pkg/kubernetes/certificates.go
@@ -23,9 +23,9 @@ import (
 )
 
 // ListCertificates grabs the list of all certificates associated to a an instance of HumioCluster
-func ListCertificates(c client.Client, humioClusterNamespace string, matchingLabels client.MatchingLabels) ([]cmapi.Certificate, error) {
+func ListCertificates(ctx context.Context, c client.Client, humioClusterNamespace string, matchingLabels client.MatchingLabels) ([]cmapi.Certificate, error) {
 	var foundCertificateList cmapi.CertificateList
-	err := c.List(context.TODO(), &foundCertificateList, client.InNamespace(humioClusterNamespace), matchingLabels)
+	err := c.List(ctx, &foundCertificateList, client.InNamespace(humioClusterNamespace), matchingLabels)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubernetes/ingresses.go
+++ b/pkg/kubernetes/ingresses.go
@@ -36,9 +36,9 @@ func GetIngress(ctx context.Context, c client.Client, ingressName, humioClusterN
 }
 
 // ListIngresses grabs the list of all ingress objects associated to a an instance of HumioCluster
-func ListIngresses(c client.Client, humioClusterNamespace string, matchingLabels client.MatchingLabels) ([]v1beta1.Ingress, error) {
+func ListIngresses(ctx context.Context, c client.Client, humioClusterNamespace string, matchingLabels client.MatchingLabels) ([]v1beta1.Ingress, error) {
 	var foundIngressList v1beta1.IngressList
-	err := c.List(context.TODO(), &foundIngressList, client.InNamespace(humioClusterNamespace), matchingLabels)
+	err := c.List(ctx, &foundIngressList, client.InNamespace(humioClusterNamespace), matchingLabels)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubernetes/persistent_volume_claims.go
+++ b/pkg/kubernetes/persistent_volume_claims.go
@@ -24,9 +24,9 @@ import (
 )
 
 // ListPersistentVolumeClaims grabs the list of all persistent volume claims associated to a an instance of HumioCluster
-func ListPersistentVolumeClaims(c client.Client, humioClusterNamespace string, matchingLabels client.MatchingLabels) ([]corev1.PersistentVolumeClaim, error) {
+func ListPersistentVolumeClaims(ctx context.Context, c client.Client, humioClusterNamespace string, matchingLabels client.MatchingLabels) ([]corev1.PersistentVolumeClaim, error) {
 	var foundPersistentVolumeClaimList corev1.PersistentVolumeClaimList
-	err := c.List(context.TODO(), &foundPersistentVolumeClaimList, client.InNamespace(humioClusterNamespace), matchingLabels)
+	err := c.List(ctx, &foundPersistentVolumeClaimList, client.InNamespace(humioClusterNamespace), matchingLabels)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubernetes/pods.go
+++ b/pkg/kubernetes/pods.go
@@ -25,9 +25,9 @@ import (
 )
 
 // ListPods grabs the list of all pods associated to a an instance of HumioCluster
-func ListPods(c client.Client, humioClusterNamespace string, matchingLabels client.MatchingLabels) ([]corev1.Pod, error) {
+func ListPods(ctx context.Context, c client.Client, humioClusterNamespace string, matchingLabels client.MatchingLabels) ([]corev1.Pod, error) {
 	var foundPodList corev1.PodList
-	err := c.List(context.TODO(), &foundPodList, client.InNamespace(humioClusterNamespace), matchingLabels)
+	err := c.List(ctx, &foundPodList, client.InNamespace(humioClusterNamespace), matchingLabels)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
For test cases, we also create a single empty context in the beginning
and reuse that instead of creating an empty context over an over.