### PR TITLE
Fix Ginkgo 2.0 deprecation warning

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -50,7 +50,6 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 
 	corev1alpha1 "github.com/humio/humio-operator/api/v1alpha1"
 	//+kubebuilder:scaffold:imports
@@ -72,9 +71,7 @@ const testInterval = time.Second * 1
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	RunSpecsWithDefaultAndCustomReporters(t,
-		"Controller Suite",
-		[]Reporter{printer.NewlineReporter{}})
+	RunSpecs(t, "Controller Suite")
 }
 
 var _ = BeforeSuite(func() {


### PR DESCRIPTION
`In Ginkgo 2.0 both RunSpecsWithDefaultAndCustomReporters and RunSpecsWithCustomReporters have been deprecated. Users must call RunSpecs instead.`

https://github.com/onsi/ginkgo/blob/v2/docs/MIGRATING_TO_V2.md#migration-strategy-2