### PR TITLE
Use shell trap to cleanup Telepresence components

### DIFF
--- a/hack/run-e2e-tests-crc.sh
+++ b/hack/run-e2e-tests-crc.sh
@@ -14,6 +14,12 @@ fi
 
 export PATH=$BIN_DIR:$PATH
 
+trap cleanup exit
+
+cleanup() {
+  telepresence uninstall --everything
+}
+
 eval $(crc oc-env)
 eval $(crc console --credentials | grep "To login as an admin, run" | cut -f2 -d"'")
 
@@ -29,4 +35,3 @@ oc adm policy add-scc-to-user anyuid -z default
 echo "NOTE: Running 'telepresence connect' needs root access so it will prompt for the password of the user account to set up rules with iptables (or similar)"
 telepresence connect
 OPENSHIFT_SCC_NAME=default-humio-operator USE_CERTMANAGER=true TEST_USE_EXISTING_CLUSTER=true $ginkgo -timeout 60m -skipPackage helpers -v ./... -covermode=count -coverprofile cover.out -progress
-telepresence uninstall --everything

--- a/hack/run-e2e-tests-kind.sh
+++ b/hack/run-e2e-tests-kind.sh
@@ -14,6 +14,12 @@ fi
 
 export PATH=$BIN_DIR:$PATH
 
+trap cleanup exit
+
+cleanup() {
+  telepresence uninstall --everything
+}
+
 # Extract humio images and tags from go source
 DEFAULT_IMAGE=$(grep '^\s*image' controllers/humiocluster_defaults.go | cut -d '"' -f 2)
 PRE_UPDATE_IMAGE=$(grep '^\s*toCreate\.Spec\.Image' controllers/humiocluster_controller_test.go | cut -d '"' -f 2)
@@ -35,4 +41,3 @@ $kubectl label node --overwrite --all topology.kubernetes.io/zone=az1
 echo "NOTE: Running 'telepresence connect' needs root access so it will prompt for the password of the user account to set up rules with iptables (or similar)"
 telepresence connect
 USE_CERTMANAGER=true TEST_USE_EXISTING_CLUSTER=true $ginkgo -timeout 60m -skipPackage helpers -v ./... -covermode=count -coverprofile cover.out -progress
-telepresence uninstall --everything


### PR DESCRIPTION
This means `ginkgo` command will be the last command and will thus
dictate what the exit code of the script will be. The exit code of the
script is what indicates whether the e2e test suite passed or not.