### PR TITLE
Use RFC3339 format for operator log timestamps

### DIFF
--- a/controllers/humioaction_controller.go
+++ b/controllers/humioaction_controller.go
@@ -26,7 +26,6 @@ import (
 	"github.com/go-logr/zapr"
 	humioapi "github.com/humio/cli/api"
 	"github.com/humio/humio-operator/pkg/helpers"
-	uberzap "go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -48,7 +47,7 @@ type HumioActionReconciler struct {
 //+kubebuilder:rbac:groups=core.humio.com,resources=humioactions/finalizers,verbs=update
 
 func (r *HumioActionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	zapLog, _ := uberzap.NewProduction(uberzap.AddCaller(), uberzap.AddCallerSkip(1))
+	zapLog, _ := helpers.NewLogger()
 	defer zapLog.Sync()
 	r.Log = zapr.NewLogger(zapLog).WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name, "Request.Type", helpers.GetTypeName(r))
 	r.Log.Info("Reconciling HumioAction")

--- a/controllers/humioalert_controller.go
+++ b/controllers/humioalert_controller.go
@@ -24,7 +24,6 @@ import (
 	humioapi "github.com/humio/cli/api"
 
 	"github.com/humio/humio-operator/pkg/helpers"
-	uberzap "go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/go-logr/logr"
@@ -50,7 +49,7 @@ type HumioAlertReconciler struct {
 //+kubebuilder:rbac:groups=core.humio.com,resources=humioalerts/finalizers,verbs=update
 
 func (r *HumioAlertReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	zapLog, _ := uberzap.NewProduction(uberzap.AddCaller(), uberzap.AddCallerSkip(1))
+	zapLog, _ := helpers.NewLogger()
 	defer zapLog.Sync()
 	r.Log = zapr.NewLogger(zapLog).WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name, "Request.Type", helpers.GetTypeName(r))
 	r.Log.Info("Reconciling HumioAlert")

--- a/controllers/humiocluster_controller.go
+++ b/controllers/humiocluster_controller.go
@@ -31,7 +31,6 @@ import (
 	"github.com/humio/humio-operator/pkg/kubernetes"
 	"github.com/humio/humio-operator/pkg/openshift"
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1beta1"
-	uberzap "go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -69,7 +68,7 @@ type HumioClusterReconciler struct {
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=ingress,verbs=create;delete;get;list;patch;update;watch
 
 func (r *HumioClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	zapLog, _ := uberzap.NewProduction(uberzap.AddCaller(), uberzap.AddCallerSkip(1))
+	zapLog, _ := helpers.NewLogger()
 	defer zapLog.Sync()
 	r.Log = zapr.NewLogger(zapLog).WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name, "Request.Type", helpers.GetTypeName(r))
 	r.Log.Info("Reconciling HumioCluster")

--- a/controllers/humioexternalcluster_controller.go
+++ b/controllers/humioexternalcluster_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"github.com/go-logr/zapr"
 	"github.com/humio/humio-operator/pkg/helpers"
-	uberzap "go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"time"
@@ -45,7 +44,7 @@ type HumioExternalClusterReconciler struct {
 //+kubebuilder:rbac:groups=core.humio.com,resources=humioexternalclusters/finalizers,verbs=update
 
 func (r *HumioExternalClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	zapLog, _ := uberzap.NewProduction(uberzap.AddCaller(), uberzap.AddCallerSkip(1))
+	zapLog, _ := helpers.NewLogger()
 	defer zapLog.Sync()
 	r.Log = zapr.NewLogger(zapLog).WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name, "Request.Type", helpers.GetTypeName(r))
 	r.Log.Info("Reconciling HumioExternalCluster")

--- a/controllers/humioingesttoken_controller.go
+++ b/controllers/humioingesttoken_controller.go
@@ -24,7 +24,6 @@ import (
 	humioapi "github.com/humio/cli/api"
 	"github.com/humio/humio-operator/pkg/helpers"
 	"github.com/humio/humio-operator/pkg/kubernetes"
-	uberzap "go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -51,7 +50,7 @@ type HumioIngestTokenReconciler struct {
 //+kubebuilder:rbac:groups=core.humio.com,resources=humioingesttokens/finalizers,verbs=update
 
 func (r *HumioIngestTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	zapLog, _ := uberzap.NewProduction(uberzap.AddCaller(), uberzap.AddCallerSkip(1))
+	zapLog, _ := helpers.NewLogger()
 	defer zapLog.Sync()
 	r.Log = zapr.NewLogger(zapLog).WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name, "Request.Type", helpers.GetTypeName(r))
 	r.Log.Info("Reconciling HumioIngestToken")

--- a/controllers/humioparser_controller.go
+++ b/controllers/humioparser_controller.go
@@ -22,7 +22,6 @@ import (
 	"github.com/go-logr/zapr"
 	humioapi "github.com/humio/cli/api"
 	"github.com/humio/humio-operator/pkg/helpers"
-	uberzap "go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -48,7 +47,7 @@ type HumioParserReconciler struct {
 //+kubebuilder:rbac:groups=core.humio.com,resources=humioparsers/finalizers,verbs=update
 
 func (r *HumioParserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	zapLog, _ := uberzap.NewProduction(uberzap.AddCaller(), uberzap.AddCallerSkip(1))
+	zapLog, _ := helpers.NewLogger()
 	defer zapLog.Sync()
 	r.Log = zapr.NewLogger(zapLog).WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name, "Request.Type", helpers.GetTypeName(r))
 	r.Log.Info("Reconciling HumioParser")

--- a/controllers/humiorepository_controller.go
+++ b/controllers/humiorepository_controller.go
@@ -22,7 +22,6 @@ import (
 	"github.com/go-logr/zapr"
 	humioapi "github.com/humio/cli/api"
 	"github.com/humio/humio-operator/pkg/helpers"
-	uberzap "go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -48,7 +47,7 @@ type HumioRepositoryReconciler struct {
 //+kubebuilder:rbac:groups=core.humio.com,resources=humiorepositories/finalizers,verbs=update
 
 func (r *HumioRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	zapLog, _ := uberzap.NewProduction(uberzap.AddCaller(), uberzap.AddCallerSkip(1))
+	zapLog, _ := helpers.NewLogger()
 	defer zapLog.Sync()
 	r.Log = zapr.NewLogger(zapLog).WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name, "Request.Type", helpers.GetTypeName(r))
 	r.Log.Info("Reconciling HumioRepository")

--- a/controllers/humioview_controller.go
+++ b/controllers/humioview_controller.go
@@ -24,7 +24,6 @@ import (
 	humioapi "github.com/humio/cli/api"
 	"github.com/humio/humio-operator/pkg/helpers"
 	"github.com/humio/humio-operator/pkg/humio"
-	uberzap "go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"reflect"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -47,7 +46,7 @@ type HumioViewReconciler struct {
 //+kubebuilder:rbac:groups=core.humio.com,resources=humioviews/finalizers,verbs=update
 
 func (r *HumioViewReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	zapLog, _ := uberzap.NewProduction(uberzap.AddCaller(), uberzap.AddCallerSkip(1))
+	zapLog, _ := helpers.NewLogger()
 	defer zapLog.Sync()
 	r.Log = zapr.NewLogger(zapLog).WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name, "Request.Type", helpers.GetTypeName(r))
 	r.Log.Info("Reconciling HumioView")

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -32,7 +32,6 @@ import (
 	humioapi "github.com/humio/cli/api"
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1beta1"
 	openshiftsecurityv1 "github.com/openshift/api/security/v1"
-	uberzap "go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -79,7 +78,7 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	var log logr.Logger
-	zapLog, _ := uberzap.NewProduction(uberzap.AddCaller(), uberzap.AddCallerSkip(1))
+	zapLog, _ := helpers.NewLogger()
 	defer zapLog.Sync()
 	log = zapr.NewLogger(zapLog)
 	logf.SetLogger(log)

--- a/main.go
+++ b/main.go
@@ -27,8 +27,6 @@ import (
 	humioapi "github.com/humio/cli/api"
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1beta1"
 	openshiftsecurityv1 "github.com/openshift/api/security/v1"
-	uberzap "go.uber.org/zap"
-
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -71,7 +69,7 @@ func main() {
 	flag.Parse()
 
 	var log logr.Logger
-	zapLog, _ := uberzap.NewProduction(uberzap.AddCaller(), uberzap.AddCallerSkip(1))
+	zapLog, _ := helpers.NewLogger()
 	defer zapLog.Sync()
 	log = zapr.NewLogger(zapLog)
 	ctrl.SetLogger(log)

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -20,6 +20,8 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"github.com/shurcooL/graphql"
+	uberzap "go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"os"
 	"reflect"
 	"strings"
@@ -174,4 +176,12 @@ func MapToString(m map[string]string) string {
 		a = append(a, fmt.Sprintf("%s=%s", k, v))
 	}
 	return strings.Join(a, ",")
+}
+
+// NewLogger returns a JSON logger with references to the origin of the log entry.
+// All log entries also includes a field "ts" containing the timestamp in RFC3339 format.
+func NewLogger() (*uberzap.Logger, error) {
+	loggerCfg := uberzap.NewProductionConfig()
+	loggerCfg.EncoderConfig.EncodeTime = zapcore.RFC3339NanoTimeEncoder
+	return loggerCfg.Build(uberzap.AddCaller())
 }


### PR DESCRIPTION
Here's a snippet that shows the new format in top and the old ones in the bottom:
![Screenshot 2021-06-10 at 10 16 55](https://user-images.githubusercontent.com/6835411/121490137-0b50e500-c9d5-11eb-990e-8c6c9c467522.png)
