### PR TITLE
Only set license status if it has changed

### DIFF
--- a/controllers/humiocluster_controller.go
+++ b/controllers/humiocluster_controller.go
@@ -1343,7 +1343,7 @@ func (r *HumioClusterReconciler) ensureInitialLicense(ctx context.Context, hc *h
 				Type:       existingLicense.LicenseType(),
 				Expiration: existingLicense.ExpiresAt(),
 			}
-			r.setLicense(ctx, licenseStatus, hc)
+			_ = r.setLicense(ctx, licenseStatus, hc)
 		}(ctx, hc)
 		return reconcile.Result{}, nil
 	}
@@ -1453,7 +1453,7 @@ func (r *HumioClusterReconciler) ensureLicense(ctx context.Context, hc *humiov1a
 				Type:       existingLicense.LicenseType(),
 				Expiration: existingLicense.ExpiresAt(),
 			}
-			r.setLicense(ctx, licenseStatus, hc)
+			_ = r.setLicense(ctx, licenseStatus, hc)
 		}
 	}(ctx, hc)
 

--- a/controllers/humiocluster_status.go
+++ b/controllers/humiocluster_status.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strconv"
 
 	humiov1alpha1 "github.com/humio/humio-operator/api/v1alpha1"
@@ -55,13 +56,13 @@ func (r *HumioClusterReconciler) setVersion(ctx context.Context, version string,
 	return r.Status().Update(ctx, hc)
 }
 
-func (r *HumioClusterReconciler) setLicense(ctx context.Context, licenseStatus humiov1alpha1.HumioLicenseStatus, hc *humiov1alpha1.HumioCluster) {
+func (r *HumioClusterReconciler) setLicense(ctx context.Context, licenseStatus humiov1alpha1.HumioLicenseStatus, hc *humiov1alpha1.HumioCluster) error {
+	if reflect.DeepEqual(hc.Status.LicenseStatus,licenseStatus) {
+		return nil
+	}
 	r.Log.Info(fmt.Sprintf("setting cluster license status to %v", licenseStatus))
 	hc.Status.LicenseStatus = licenseStatus
-	err := r.Status().Update(ctx, hc)
-	if err != nil {
-		r.Log.Error(err, "unable to set license status")
-	}
+	return r.Status().Update(ctx, hc)
 }
 
 func (r *HumioClusterReconciler) setNodeCount(ctx context.Context, nodeCount int, hc *humiov1alpha1.HumioCluster) error {


### PR DESCRIPTION
Status updates trigger reconciliation, so we should only update the status if it has changed.

The reason I changed `setLicense()` to return an `error` is to keep things consistent with the other methods setting status.