### PR TITLE
Set custom user agent headers

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -16,26 +16,36 @@ jobs:
 #      uses: ./.github/action/operator-sdk
 #      with:
 #        args: operator-courier --verbose verify --ui_validate_io deploy/olm-catalog/humio-operator
+    - name: Set version information
+      run: |
+        echo "RELEASE_VERSION=master" >> $GITHUB_ENV
+        echo "RELEASE_COMMIT=$(git rev-parse --verify HEAD)" >> $GITHUB_ENV
+        echo "RELEASE_DATE=$(date --rfc-3339=seconds)" >> $GITHUB_ENV
     - name: docker build
-      run: make docker-build-operator IMG=humio/humio-operator:master IMG_BUILD_ARGS="--label version=master --label release=${{ github.run_id }}"
+      run: make docker-build-operator IMG=humio/humio-operator:${{ env.RELEASE_VERSION }} IMG_BUILD_ARGS="--label version=${{ env.RELEASE_VERSION }} --label release=${{ github.run_id }} --build-arg RELEASE_VERSION=${{ env.RELEASE_VERSION }} --build-arg RELEASE_COMMIT=${{ env.RELEASE_COMMIT }} --build-arg RELEASE_DATE=${{ env.RELEASE_DATE }}"
     - name: Login to DockerHub
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
     - name: docker push
-      run: make docker-push IMG=humio/humio-operator:master
+      run: make docker-push IMG=humio/humio-operator:{{ env.RELEASE_VERSION }}
   build-and-publish-helper:
     name: Build and Publish Helperimage
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Set version information
+        run: |
+          echo "RELEASE_VERSION=master" >> $GITHUB_ENV
+          echo "RELEASE_COMMIT=$(git rev-parse --verify HEAD)" >> $GITHUB_ENV
+          echo "RELEASE_DATE=$(date --rfc-3339=seconds)" >> $GITHUB_ENV
       - name: docker build
-        run: make docker-build-helper IMG=humio/humio-operator-helper:master IMG_BUILD_ARGS="--label version=master --label release=${{ github.run_id }}"
+        run: make docker-build-helper IMG=humio/humio-operator-helper:${{ env.RELEASE_VERSION }} IMG_BUILD_ARGS="--label version=${{ env.RELEASE_VERSION }} --label release=${{ github.run_id }} --build-arg RELEASE_VERSION=${{ env.RELEASE_VERSION }} --build-arg RELEASE_COMMIT=${{ env.RELEASE_COMMIT }} --build-arg RELEASE_DATE=${{ env.RELEASE_DATE }}"
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: docker push
-        run: make docker-push IMG=humio/humio-operator-helper:master
+        run: make docker-push IMG=humio/humio-operator-helper:{{ env.RELEASE_VERSION }}

--- a/.github/workflows/release-container-helperimage.yaml
+++ b/.github/workflows/release-container-helperimage.yaml
@@ -11,16 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Get release version
-      id: get_version
-      run: echo "RELEASE_VERSION=$(grep "Version =" images/helper/version.go | awk -F'"' '{print $2}')" >> $GITHUB_ENV
+    - name: Set version information
+      run: |
+        echo "RELEASE_VERSION=$(grep "Version =" images/helper/version.go | awk -F'"' '{print $2}')" >> $GITHUB_ENV
+        echo "RELEASE_COMMIT=$(git rev-parse --verify HEAD)" >> $GITHUB_ENV
+        echo "RELEASE_DATE=$(date --rfc-3339=seconds)" >> $GITHUB_ENV
     - name: Login to DockerHub
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
     - name: docker build
-      run: make docker-build-helper IMG=humio/humio-operator-helper:${{ env.RELEASE_VERSION }} IMG_BUILD_ARGS="--label version=${{ env.RELEASE_VERSION }} --label release=${{ github.run_id }}"
+      run: make docker-build-helper IMG=humio/humio-operator-helper:${{ env.RELEASE_VERSION }} IMG_BUILD_ARGS="--label version=${{ env.RELEASE_VERSION }} --label release=${{ github.run_id }} --build-arg RELEASE_VERSION=${{ env.RELEASE_VERSION }} --build-arg RELEASE_COMMIT=${{ env.RELEASE_COMMIT }} --build-arg RELEASE_DATE=${{ env.RELEASE_DATE }}"
     - name: docker push
       run: make docker-push IMG=humio/humio-operator-helper:${{ env.RELEASE_VERSION }}
     - name: redhat scan login

--- a/.github/workflows/release-container-image.yaml
+++ b/.github/workflows/release-container-image.yaml
@@ -11,16 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Get release version
-      id: get_version
-      run: echo "RELEASE_VERSION=$(cat VERSION)" >> $GITHUB_ENV
+    - name: Set version information
+      run: |
+        echo "RELEASE_VERSION=$(cat VERSION)" >> $GITHUB_ENV
+        echo "RELEASE_COMMIT=$(git rev-parse --verify HEAD)" >> $GITHUB_ENV
+        echo "RELEASE_DATE=$(date --rfc-3339=seconds)" >> $GITHUB_ENV
     - name: Login to DockerHub
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
     - name: docker build
-      run: make docker-build-operator IMG=humio/humio-operator:${{ env.RELEASE_VERSION }} IMG_BUILD_ARGS="--label version=${{ env.RELEASE_VERSION }} --label release=${{ github.run_id }}"
+      run: make docker-build-operator IMG=humio/humio-operator:${{ env.RELEASE_VERSION }} IMG_BUILD_ARGS="--label version=${{ env.RELEASE_VERSION }} --label release=${{ github.run_id }} --build-arg RELEASE_VERSION=${{ env.RELEASE_VERSION }} --build-arg RELEASE_COMMIT=${{ env.RELEASE_COMMIT }} --build-arg RELEASE_DATE=${{ env.RELEASE_DATE }}"
     - name: docker push
       run:  make docker-push IMG=humio/humio-operator:${{ env.RELEASE_VERSION }}
     - name: redhat scan login
@@ -52,10 +54,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Get release version
-        id: get_version
         run: echo "RELEASE_VERSION=$(cat VERSION)" >> $GITHUB_ENV
       - uses: actions/create-release@latest
-        id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 # Build the manager binary
 FROM golang:1.15 as builder
 
+ARG RELEASE_VERSION=master
+ARG RELEASE_COMMIT=none
+ARG RELEASE_DATE=unknown
+
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -16,7 +20,7 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -ldflags="-X 'main.version=$RELEASE_VERSION' -X 'main.commit=$RELEASE_COMMIT' -X 'main.date=$RELEASE_DATE'" -a -o manager main.go
 
 # Use ubi8 as base image to package the manager binary to comply with Red Hat image certification requirements
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest

--- a/Makefile
+++ b/Makefile
@@ -64,9 +64,6 @@ build: generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
-docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
-
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
 

--- a/controllers/humiocluster_status.go
+++ b/controllers/humiocluster_status.go
@@ -36,7 +36,6 @@ func (r *HumioClusterReconciler) getLatestHumioCluster(ctx context.Context, hc *
 }
 
 // setState is used to change the cluster state
-// TODO: we use this to determine if we should have a delay between startup of humio pods during bootstrap vs starting up pods during an image update
 func (r *HumioClusterReconciler) setState(ctx context.Context, state string, hc *humiov1alpha1.HumioCluster) error {
 	if hc.Status.State == state {
 		return nil

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -90,7 +90,7 @@ var _ = BeforeSuite(func() {
 		testEnv = &envtest.Environment{
 			UseExistingCluster: &useExistingCluster,
 		}
-		humioClient = humio.NewClient(log, &humioapi.Config{})
+		humioClient = humio.NewClient(log, &humioapi.Config{}, "")
 	} else {
 		testTimeout = time.Second * 30
 		testEnv = &envtest.Environment{

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-logr/logr v0.3.0
 	github.com/go-logr/zapr v0.3.0
 	github.com/google/martian v2.1.0+incompatible
-	github.com/humio/cli v0.28.4-0.20210511072726-ce92f7bbdbae
+	github.com/humio/cli v0.28.4-0.20210615074159-36ca7bdbd37e
 	github.com/jetstack/cert-manager v1.3.1
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -362,6 +362,8 @@ github.com/humio/cli v0.28.4-0.20210510114626-345137458c0b h1:PB2r3X0OXCezeStBM4
 github.com/humio/cli v0.28.4-0.20210510114626-345137458c0b/go.mod h1:24GlXZtyAUK5ZSFH2AIaTQnf11XopEViTilrRU1Mb/4=
 github.com/humio/cli v0.28.4-0.20210511072726-ce92f7bbdbae h1:6f/veeePjlQuJy31XX52lg9piKJ6KDC3qKZplaKBHjI=
 github.com/humio/cli v0.28.4-0.20210511072726-ce92f7bbdbae/go.mod h1:24GlXZtyAUK5ZSFH2AIaTQnf11XopEViTilrRU1Mb/4=
+github.com/humio/cli v0.28.4-0.20210615074159-36ca7bdbd37e h1:CDqdG4SF/aYQjOUp87FTwYyqF4QKsEkFP5lbHwZj/gI=
+github.com/humio/cli v0.28.4-0.20210615074159-36ca7bdbd37e/go.mod h1:24GlXZtyAUK5ZSFH2AIaTQnf11XopEViTilrRU1Mb/4=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=

--- a/images/helper/Dockerfile
+++ b/images/helper/Dockerfile
@@ -1,7 +1,12 @@
 FROM golang:1.15 as builder
+
+ARG RELEASE_VERSION=master
+ARG RELEASE_COMMIT=none
+ARG RELEASE_DATE=unknown
+
 WORKDIR /src
 COPY . /src
-RUN CGO_ENABLED=0 go build -o /app /src/*.go
+RUN CGO_ENABLED=0 go build -ldflags="-X 'main.version=$RELEASE_VERSION' -X 'main.commit=$RELEASE_COMMIT' -X 'main.date=$RELEASE_DATE'" -o /app /src/*.go
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 

--- a/images/helper/go.mod
+++ b/images/helper/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/gophercloud/gophercloud v0.13.0 // indirect
-	github.com/humio/cli v0.28.1
+	github.com/humio/cli v0.28.4-0.20210615074159-36ca7bdbd37e
 	github.com/json-iterator/go v1.1.10 // indirect
 	github.com/savaki/jq v0.0.0-20161209013833-0e6baecebbf8
 	github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a

--- a/images/helper/go.sum
+++ b/images/helper/go.sum
@@ -190,6 +190,8 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/humio/cli v0.28.1 h1:PYxquAQVnCVhoYIFApXzPgIYtYPSgwKsSt43VI/Zfa4=
 github.com/humio/cli v0.28.1/go.mod h1:24GlXZtyAUK5ZSFH2AIaTQnf11XopEViTilrRU1Mb/4=
+github.com/humio/cli v0.28.4-0.20210615074159-36ca7bdbd37e h1:CDqdG4SF/aYQjOUp87FTwYyqF4QKsEkFP5lbHwZj/gI=
+github.com/humio/cli v0.28.4-0.20210615074159-36ca7bdbd37e/go.mod h1:24GlXZtyAUK5ZSFH2AIaTQnf11XopEViTilrRU1Mb/4=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/images/helper/main.go
+++ b/images/helper/main.go
@@ -49,6 +49,13 @@ const (
 	apiTokenMethodFromAPI = "api"
 )
 
+var (
+	// We override these using ldflags when running "go build"
+	commit  = "none"
+	date    = "unknown"
+	version = "master"
+)
+
 // getFileContent returns the content of a file as a string
 func getFileContent(filePath string) string {
 	data, err := ioutil.ReadFile(filePath)
@@ -209,7 +216,7 @@ func validateAdminSecretContent(ctx context.Context, clientset *k8s.Clientset, n
 	if adminToken, ok := secret.Data["token"]; ok {
 		humioClient := humio.NewClient(humio.Config{
 			Address:   humioNodeURL,
-			UserAgent: fmt.Sprintf("humio-operator-helper/%s", Version),
+			UserAgent: fmt.Sprintf("humio-operator-helper/%s (%s on %s)", version, commit, date),
 			Token:     string(adminToken),
 		})
 
@@ -369,7 +376,7 @@ func authMode() {
 
 		humioClient := humio.NewClient(humio.Config{
 			Address:   humioNodeURL,
-			UserAgent: fmt.Sprintf("humio-operator-helper/%s", Version),
+			UserAgent: fmt.Sprintf("humio-operator-helper/%s (%s on %s)", version, commit, date),
 			Token:     localAdminToken,
 		})
 
@@ -441,7 +448,7 @@ func httpHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	fmt.Printf("Starting humio-operator-helper version %s\n", Version)
+	fmt.Printf("Starting humio-operator-helper %s (%s on %s)\n", version, commit, date)
 	mode, found := os.LookupEnv("MODE")
 	if !found || mode == "" {
 		panic("environment variable MODE not set or empty")

--- a/images/helper/main.go
+++ b/images/helper/main.go
@@ -208,8 +208,9 @@ func validateAdminSecretContent(ctx context.Context, clientset *k8s.Clientset, n
 	// Check if secret currently holds a valid humio api token
 	if adminToken, ok := secret.Data["token"]; ok {
 		humioClient := humio.NewClient(humio.Config{
-			Address: humioNodeURL,
-			Token:   string(adminToken),
+			Address:   humioNodeURL,
+			UserAgent: fmt.Sprintf("humio-operator-helper/%s", Version),
+			Token:     string(adminToken),
 		})
 
 		_, err = humioClient.Clusters().Get()
@@ -367,8 +368,9 @@ func authMode() {
 		fmt.Printf("Continuing to create/update token.\n")
 
 		humioClient := humio.NewClient(humio.Config{
-			Address: humioNodeURL,
-			Token:   localAdminToken,
+			Address:   humioNodeURL,
+			UserAgent: fmt.Sprintf("humio-operator-helper/%s", Version),
+			Token:     localAdminToken,
 		})
 
 		// Get user ID of admin account

--- a/main.go
+++ b/main.go
@@ -48,6 +48,11 @@ import (
 
 var (
 	scheme = runtime.NewScheme()
+
+	// We override these using ldflags when running "go build"
+	commit  = "none"
+	date    = "unknown"
+	version = "master"
 )
 
 func init() {
@@ -73,6 +78,8 @@ func main() {
 	defer zapLog.Sync()
 	log = zapr.NewLogger(zapLog)
 	ctrl.SetLogger(log)
+
+	ctrl.Log.Info(fmt.Sprintf("starting humio-operator %s (%s on %s)", version, commit, date))
 
 	watchNamespace, err := getWatchNamespace()
 	if err != nil {
@@ -112,58 +119,60 @@ func main() {
 		cmapi.AddToScheme(mgr.GetScheme())
 	}
 
+	userAgent := fmt.Sprintf("humio-operator/%s (%s on %s)", version, commit, date)
+
 	if err = (&controllers.HumioExternalClusterReconciler{
 		Client:      mgr.GetClient(),
-		HumioClient: humio.NewClient(log, &humioapi.Config{}),
+		HumioClient: humio.NewClient(log, &humioapi.Config{}, userAgent),
 	}).SetupWithManager(mgr); err != nil {
 		ctrl.Log.Error(err, "unable to create controller", "controller", "HumioExternalCluster")
 		os.Exit(1)
 	}
 	if err = (&controllers.HumioClusterReconciler{
 		Client:      mgr.GetClient(),
-		HumioClient: humio.NewClient(log, &humioapi.Config{}),
+		HumioClient: humio.NewClient(log, &humioapi.Config{}, userAgent),
 	}).SetupWithManager(mgr); err != nil {
 		ctrl.Log.Error(err, "unable to create controller", "controller", "HumioCluster")
 		os.Exit(1)
 	}
 	if err = (&controllers.HumioIngestTokenReconciler{
 		Client:      mgr.GetClient(),
-		HumioClient: humio.NewClient(log, &humioapi.Config{}),
+		HumioClient: humio.NewClient(log, &humioapi.Config{}, userAgent),
 	}).SetupWithManager(mgr); err != nil {
 		ctrl.Log.Error(err, "unable to create controller", "controller", "HumioIngestToken")
 		os.Exit(1)
 	}
 	if err = (&controllers.HumioParserReconciler{
 		Client:      mgr.GetClient(),
-		HumioClient: humio.NewClient(log, &humioapi.Config{}),
+		HumioClient: humio.NewClient(log, &humioapi.Config{}, userAgent),
 	}).SetupWithManager(mgr); err != nil {
 		ctrl.Log.Error(err, "unable to create controller", "controller", "HumioParser")
 		os.Exit(1)
 	}
 	if err = (&controllers.HumioRepositoryReconciler{
 		Client:      mgr.GetClient(),
-		HumioClient: humio.NewClient(log, &humioapi.Config{}),
+		HumioClient: humio.NewClient(log, &humioapi.Config{}, userAgent),
 	}).SetupWithManager(mgr); err != nil {
 		ctrl.Log.Error(err, "unable to create controller", "controller", "HumioRepository")
 		os.Exit(1)
 	}
 	if err = (&controllers.HumioViewReconciler{
 		Client:      mgr.GetClient(),
-		HumioClient: humio.NewClient(log, &humioapi.Config{}),
+		HumioClient: humio.NewClient(log, &humioapi.Config{}, userAgent),
 	}).SetupWithManager(mgr); err != nil {
 		ctrl.Log.Error(err, "unable to create controller", "controller", "HumioView")
 		os.Exit(1)
 	}
 	if err = (&controllers.HumioActionReconciler{
 		Client:      mgr.GetClient(),
-		HumioClient: humio.NewClient(log, &humioapi.Config{}),
+		HumioClient: humio.NewClient(log, &humioapi.Config{}, userAgent),
 	}).SetupWithManager(mgr); err != nil {
 		ctrl.Log.Error(err, "unable to create controller", "controller", "HumioAction")
 		os.Exit(1)
 	}
 	if err = (&controllers.HumioAlertReconciler{
 		Client:      mgr.GetClient(),
-		HumioClient: humio.NewClient(log, &humioapi.Config{}),
+		HumioClient: humio.NewClient(log, &humioapi.Config{}, userAgent),
 	}).SetupWithManager(mgr); err != nil {
 		ctrl.Log.Error(err, "unable to create controller", "controller", "HumioAlert")
 		os.Exit(1)
@@ -179,7 +188,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	ctrl.Log.Info("starting manager")
+	ctrl.Log.Info(fmt.Sprintf("starting manager for humio-operator %s (%s on %s)", version, commit, date))
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		ctrl.Log.Error(err, "problem running manager")
 		os.Exit(1)

--- a/pkg/humio/client.go
+++ b/pkg/humio/client.go
@@ -108,14 +108,16 @@ type LicenseClient interface {
 type ClientConfig struct {
 	apiClient *humioapi.Client
 	logger    logr.Logger
+	userAgent string
 }
 
 // NewClient returns a ClientConfig
-func NewClient(logger logr.Logger, config *humioapi.Config) *ClientConfig {
+func NewClient(logger logr.Logger, config *humioapi.Config, userAgent string) *ClientConfig {
 	client := humioapi.NewClient(*config)
 	return &ClientConfig{
 		apiClient: client,
 		logger:    logger,
+		userAgent: userAgent,
 	}
 }
 
@@ -132,6 +134,7 @@ func (h *ClientConfig) SetHumioClientConfig(config *humioapi.Config, overrideExi
 			config.CACertificatePEM = h.apiClient.CACertificate()
 		}
 	}
+	config.UserAgent = h.userAgent
 	h.apiClient = humioapi.NewClient(*config)
 	return
 }

--- a/pkg/humio/client.go
+++ b/pkg/humio/client.go
@@ -512,7 +512,7 @@ func getConnectionMap(viewConnections []humioapi.ViewConnection) map[string]stri
 func (h *ClientConfig) GetLicense() (humioapi.License, error) {
 	licensesClient := h.apiClient.Licenses()
 	emptyConfig := humioapi.Config{}
-	if !reflect.DeepEqual(h.apiClient.Config(), emptyConfig) {
+	if !reflect.DeepEqual(h.apiClient.Config(), emptyConfig) && h.apiClient.Config().Address != nil {
 		return licensesClient.Get()
 	}
 	return nil, fmt.Errorf("no api client configured yet")


### PR DESCRIPTION
This sets the `User-Agent` header as follows:
- Helper image: `humio-operator-helper/$VERSION ($COMMIT on $DATE)`
- Operator image: `humio-operator/$VERSION ($COMMIT on $DATE)`

This makes it easier to track what specific implementations are in use.