### PR TITLE
helper: Release 0.3.0

### DIFF
--- a/images/helper/version.go
+++ b/images/helper/version.go
@@ -17,5 +17,5 @@ limitations under the License.
 package main
 
 var (
-	Version = "0.2.0"
+	Version = "0.3.0"
 )


### PR DESCRIPTION
Noteworthy changes:
- Set more detailed version information when building the container image.
- Drop support for Humio version prior to 1.17.0 and clean up logic related to these older versions.