### PR TITLE
Release Helm chart 0.9.0

### DIFF
--- a/charts/humio-operator/Chart.yaml
+++ b/charts/humio-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: humio-operator
-version: 0.8.1
-appVersion: 0.8.1
+version: 0.9.0
+appVersion: 0.9.0
 home: https://github.com/humio/humio-operator
 description: Kubernetes Operator for running Humio on top of Kubernetes
 icon: https://www.humio.com/static/3ae40396981ac553b27d76dabefe0caa/9911c/logo--og-humio.png

--- a/charts/humio-operator/values.yaml
+++ b/charts/humio-operator/values.yaml
@@ -1,7 +1,7 @@
 operator:
   image:
     repository: humio/humio-operator
-    tag: 0.8.1
+    tag: 0.9.0
     pullPolicy: IfNotPresent
     pullSecrets: []
   prometheus:

--- a/config/crd/bases/core.humio.com_humioactions.yaml
+++ b/config/crd/bases/core.humio.com_humioactions.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/name: 'humio-operator'
     app.kubernetes.io/instance: 'humio-operator'
     app.kubernetes.io/managed-by: 'Helm'
-    helm.sh/chart: 'humio-operator-0.8.1'
+    helm.sh/chart: 'humio-operator-0.9.0'
 spec:
   group: core.humio.com
   names:

--- a/config/crd/bases/core.humio.com_humioalerts.yaml
+++ b/config/crd/bases/core.humio.com_humioalerts.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/name: 'humio-operator'
     app.kubernetes.io/instance: 'humio-operator'
     app.kubernetes.io/managed-by: 'Helm'
-    helm.sh/chart: 'humio-operator-0.8.1'
+    helm.sh/chart: 'humio-operator-0.9.0'
 spec:
   group: core.humio.com
   names:

--- a/config/crd/bases/core.humio.com_humioclusters.yaml
+++ b/config/crd/bases/core.humio.com_humioclusters.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/name: 'humio-operator'
     app.kubernetes.io/instance: 'humio-operator'
     app.kubernetes.io/managed-by: 'Helm'
-    helm.sh/chart: 'humio-operator-0.8.1'
+    helm.sh/chart: 'humio-operator-0.9.0'
 spec:
   group: core.humio.com
   names:

--- a/config/crd/bases/core.humio.com_humioexternalclusters.yaml
+++ b/config/crd/bases/core.humio.com_humioexternalclusters.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/name: 'humio-operator'
     app.kubernetes.io/instance: 'humio-operator'
     app.kubernetes.io/managed-by: 'Helm'
-    helm.sh/chart: 'humio-operator-0.8.1'
+    helm.sh/chart: 'humio-operator-0.9.0'
 spec:
   group: core.humio.com
   names:

--- a/config/crd/bases/core.humio.com_humioingesttokens.yaml
+++ b/config/crd/bases/core.humio.com_humioingesttokens.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/name: 'humio-operator'
     app.kubernetes.io/instance: 'humio-operator'
     app.kubernetes.io/managed-by: 'Helm'
-    helm.sh/chart: 'humio-operator-0.8.1'
+    helm.sh/chart: 'humio-operator-0.9.0'
 spec:
   group: core.humio.com
   names:

--- a/config/crd/bases/core.humio.com_humioparsers.yaml
+++ b/config/crd/bases/core.humio.com_humioparsers.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/name: 'humio-operator'
     app.kubernetes.io/instance: 'humio-operator'
     app.kubernetes.io/managed-by: 'Helm'
-    helm.sh/chart: 'humio-operator-0.8.1'
+    helm.sh/chart: 'humio-operator-0.9.0'
 spec:
   group: core.humio.com
   names:

--- a/config/crd/bases/core.humio.com_humiorepositories.yaml
+++ b/config/crd/bases/core.humio.com_humiorepositories.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/name: 'humio-operator'
     app.kubernetes.io/instance: 'humio-operator'
     app.kubernetes.io/managed-by: 'Helm'
-    helm.sh/chart: 'humio-operator-0.8.1'
+    helm.sh/chart: 'humio-operator-0.9.0'
 spec:
   group: core.humio.com
   names:

--- a/config/crd/bases/core.humio.com_humioviews.yaml
+++ b/config/crd/bases/core.humio.com_humioviews.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/name: 'humio-operator'
     app.kubernetes.io/instance: 'humio-operator'
     app.kubernetes.io/managed-by: 'Helm'
-    helm.sh/chart: 'humio-operator-0.8.1'
+    helm.sh/chart: 'humio-operator-0.9.0'
 spec:
   group: core.humio.com
   names:


### PR DESCRIPTION
Depends on: https://github.com/humio/humio-operator/pull/397

Note: Tests needs to be rerun after we have cut the new release of the helper image.