### PR TITLE
Run E2E tests inside Docker

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,4 +21,5 @@ jobs:
         E2E_LOGS_HUMIO_INGEST_TOKEN: ${{ secrets.E2E_LOGS_HUMIO_INGEST_TOKEN }}
         E2E_RUN_ID: ${{ github.run_id }}
       run: |
-        make run-e2e-tests-ci-kind
+        docker build -t operatortestcontainerimage -f test.Dockerfile .
+        docker run --network=host --privileged --device /dev/net/tun:/dev/net/tun --cap-add=NET_ADMIN --env E2E_LOGS_HUMIO_HOSTNAME=ops.us.humio.com --env E2E_LOGS_HUMIO_INGEST_TOKEN=$E2E_LOGS_HUMIO_INGEST_TOKEN --env HUMIO_E2E_LICENSE=$HUMIO_E2E_LICENSE --rm --volume /var/run/docker.sock:/var/run/docker.sock --entrypoint /bin/bash operatortestcontainerimage -c "make run-e2e-tests-ci-kind"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -22,4 +22,5 @@ jobs:
         E2E_RUN_ID: ${{ github.run_id }}
       run: |
         docker build -t operatortestcontainerimage -f test.Dockerfile .
+        docker network inspect $(docker network ls -q)
         docker run --network=host --privileged --device /dev/net/tun:/dev/net/tun --cap-add=NET_ADMIN --env E2E_LOGS_HUMIO_HOSTNAME=ops.us.humio.com --env E2E_LOGS_HUMIO_INGEST_TOKEN=$E2E_LOGS_HUMIO_INGEST_TOKEN --env HUMIO_E2E_LICENSE=$HUMIO_E2E_LICENSE --rm --volume /var/run/docker.sock:/var/run/docker.sock --entrypoint /bin/bash operatortestcontainerimage -c "make run-e2e-tests-ci-kind"

--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ install-e2e-dependencies:
 
 run-e2e-tests-ci-kind: install-e2e-dependencies ginkgo
 	hack/install-helm-chart-dependencies-kind.sh
-	hack/run-e2e-tests-kind.sh
+	PROXY_METHOD=vpn-tcp hack/run-e2e-tests-kind.sh
 
 run-e2e-tests-local-kind:
 	hack/start-kind-cluster.sh

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ make test
 
 ### E2E Testing (Kubernetes)
 
-We use [kind](https://kind.sigs.k8s.io/) and [telepresence 2](https://www.getambassador.io/docs/telepresence/latest/quick-start/) for local testing.
+We use [kind](https://kind.sigs.k8s.io/) and [telepresence v1](https://www.telepresence.io/docs/v1/reference/install/) for local testing.
 
 Note that for running zookeeper and kafka locally, we currently rely on the [cp-helm-charts](https://github.com/humio/cp-helm-charts) and that that repository is cloned into a directory `~/git/humio-cp-helm-charts`.
 
@@ -60,7 +60,7 @@ hack/stop-kind-cluster.sh
 
 ### E2E Testing (OpenShift)
 
-We use [crc](https://developers.redhat.com/products/codeready-containers/overview) and [telepresence 2](https://www.getambassador.io/docs/telepresence/latest/quick-start/) for local testing.
+We use [crc](https://developers.redhat.com/products/codeready-containers/overview) and [telepresence v1](https://www.telepresence.io/docs/v1/reference/install/) for local testing.
 
 Note that for running zookeeper and kafka locally, we currently rely on the [cp-helm-charts](https://github.com/humio/cp-helm-charts) and that that repository is cloned into a directory `~/git/humio-cp-helm-charts`.
 

--- a/hack/install-e2e-dependencies.sh
+++ b/hack/install-e2e-dependencies.sh
@@ -5,7 +5,6 @@ set -ex
 declare -r helm_version=3.5.4
 declare -r kubectl_version=1.19.11
 declare -r operator_sdk_version=1.7.1
-declare -r telepresence_version=2.2.1
 declare -r bin_dir=${BIN_DIR:-/usr/local/bin}
 
 install_helm() {
@@ -26,11 +25,6 @@ install_operator_sdk() {
     && rm operator-sdk-v${operator_sdk_version}-x86_64-linux-gnu
 }
 
-install_telepresence() {
-  curl -fL https://app.getambassador.io/download/tel2/linux/amd64/${telepresence_version}/telepresence -o ${bin_dir}/telepresence \
-    && chmod a+x ${bin_dir}/telepresence
-}
-
 install_ginkgo() {
   go get github.com/onsi/ginkgo/ginkgo
   go get github.com/onsi/gomega/...
@@ -39,5 +33,4 @@ install_ginkgo() {
 install_helm
 install_kubectl
 install_operator_sdk
-install_telepresence
 install_ginkgo

--- a/hack/run-e2e-tests-kind.sh
+++ b/hack/run-e2e-tests-kind.sh
@@ -34,4 +34,5 @@ $kubectl label node --overwrite --all topology.kubernetes.io/zone=az1
 # We skip the helpers package as those tests assumes the environment variable USE_CERT_MANAGER is not set.
 # Documentation for Go support states that inject-tcp method will not work. https://www.telepresence.io/howto/golang
 echo "NOTE: Running 'telepresence connect' needs root access so it will prompt for the password of the user account to set up rules with iptables (or similar)"
+$kubectl get pods,svc -A -o wide
 KUBECONFIG=$tmp_kubeconfig USE_CERTMANAGER=true TEST_USE_EXISTING_CLUSTER=true telepresence --method $proxy_method --run $ginkgo -timeout 90m -skipPackage helpers -v ./... -covermode=count -coverprofile cover.out -progress

--- a/hack/run-e2e-tests-kind.sh
+++ b/hack/run-e2e-tests-kind.sh
@@ -6,6 +6,7 @@ declare -r tmp_kubeconfig=/tmp/kubeconfig
 declare -r kubectl="kubectl --kubeconfig $tmp_kubeconfig"
 declare -r envtest_assets_dir=${ENVTEST_ASSETS_DIR:-/tmp/envtest}
 declare -r ginkgo=$(go env GOPATH)/bin/ginkgo
+declare -r proxy_method=${PROXY_METHOD:-inject-tcp}
 
 if [[ -z "${HUMIO_E2E_LICENSE}" ]]; then
   echo "Environment variable HUMIO_E2E_LICENSE not set. Aborting."
@@ -13,12 +14,6 @@ if [[ -z "${HUMIO_E2E_LICENSE}" ]]; then
 fi
 
 export PATH=$BIN_DIR:$PATH
-
-trap cleanup exit
-
-cleanup() {
-  telepresence uninstall --kubeconfig $tmp_kubeconfig --everything
-}
 
 # Extract humio images and tags from go source
 DEFAULT_IMAGE=$(grep '^\s*image' controllers/humiocluster_defaults.go | cut -d '"' -f 2)
@@ -39,17 +34,4 @@ $kubectl label node --overwrite --all topology.kubernetes.io/zone=az1
 # We skip the helpers package as those tests assumes the environment variable USE_CERT_MANAGER is not set.
 # Documentation for Go support states that inject-tcp method will not work. https://www.telepresence.io/howto/golang
 echo "NOTE: Running 'telepresence connect' needs root access so it will prompt for the password of the user account to set up rules with iptables (or similar)"
-telepresence connect --kubeconfig $tmp_kubeconfig
-
-iterations=0
-while ! curl -k https://kubernetes.default
-do
-  let "iterations+=1"
-  echo curl failed $iterations times
-  if [ $iterations -ge 30 ]; then
-    exit 1
-  fi
-  sleep 2
-done
-
-KUBECONFIG=$tmp_kubeconfig USE_CERTMANAGER=true TEST_USE_EXISTING_CLUSTER=true $ginkgo -timeout 90m -skipPackage helpers -v ./... -covermode=count -coverprofile cover.out -progress
+KUBECONFIG=$tmp_kubeconfig USE_CERTMANAGER=true TEST_USE_EXISTING_CLUSTER=true telepresence --method $proxy_method --run $ginkgo -timeout 90m -skipPackage helpers -v ./... -covermode=count -coverprofile cover.out -progress

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:20.04
+
+# Install make and curl
+RUN apt update \
+ && apt install -y build-essential curl
+
+# Install go
+RUN curl -s https://dl.google.com/go/go1.15.12.linux-amd64.tar.gz | tar -xz -C /usr/local
+RUN ln -s /usr/local/go/bin/go /usr/bin/go
+
+# Install kind
+RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64 \
+ && chmod +x ./kind \
+ && mv ./kind /usr/bin/kind
+
+# Install docker-ce-cli
+RUN apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+RUN echo \
+  "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+RUN apt-get update \
+ && apt-get install -y docker-ce-cli
+
+# Install telepresence
+ENV DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true
+RUN apt update \
+ && apt install -y iproute2 sshfs iptables sudo
+RUN curl -s https://packagecloud.io/install/repositories/datawireio/telepresence/script.deb.sh | bash \
+ && apt install -y --no-install-recommends telepresence=0.109
+
+# Create and populate /var/src with the source code for the humio-operator repository
+RUN mkdir /var/src
+COPY ./ /var/src
+WORKDIR /var/src


### PR DESCRIPTION
Running Telepresence v2 inside Docker doesn't seem to work out just yet, so for now we can use the older Telepresence version until we've resolved the issues and can upgrade to Telepresence v2 again.