### PR TITLE
Stop using Telepresence to run E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,16 +212,23 @@ docker-build-helper:
 install-e2e-dependencies:
 	hack/install-e2e-dependencies.sh
 
-run-e2e-tests-ci-kind: install-e2e-dependencies ginkgo
+preload-images-kind:
+	hack/preload-images-kind.sh
+
+run-e2e-tests-ci-kind: install-e2e-dependencies
 	hack/install-helm-chart-dependencies-kind.sh
-	hack/run-e2e-tests-kind.sh
+	make preload-images-kind
+	hack/run-e2e-tests-using-kubectl-kind.sh
 
 run-e2e-tests-local-kind:
 	hack/start-kind-cluster.sh
 	hack/install-helm-chart-dependencies-kind.sh
-	hack/run-e2e-tests-kind.sh
+	make preload-images-kind
+	hack/run-e2e-tests-using-kubectl-kind.sh
 
 run-e2e-tests-local-crc:
+	echo "Needs rework since removing Telepresence. Aborting..."
+	exit 1
 	hack/start-crc-cluster.sh
 	hack/install-helm-chart-dependencies-crc.sh
 	hack/run-e2e-tests-crc.sh

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ make test
 
 ### E2E Testing (Kubernetes)
 
-We use [kind](https://kind.sigs.k8s.io/) and [telepresence 2](https://www.getambassador.io/docs/telepresence/latest/quick-start/) for local testing.
+We use [kind](https://kind.sigs.k8s.io/) for local testing.
 
 Note that for running zookeeper and kafka locally, we currently rely on the [cp-helm-charts](https://github.com/humio/cp-helm-charts) and that that repository is cloned into a directory `~/git/humio-cp-helm-charts`.
 
@@ -60,7 +60,9 @@ hack/stop-kind-cluster.sh
 
 ### E2E Testing (OpenShift)
 
-We use [crc](https://developers.redhat.com/products/codeready-containers/overview) and [telepresence 2](https://www.getambassador.io/docs/telepresence/latest/quick-start/) for local testing.
+We use [crc](https://developers.redhat.com/products/codeready-containers/overview) for local testing.
+
+Note: At present, all scripts using crc needs some rework before they are usable again.
 
 Note that for running zookeeper and kafka locally, we currently rely on the [cp-helm-charts](https://github.com/humio/cp-helm-charts) and that that repository is cloned into a directory `~/git/humio-cp-helm-charts`.
 

--- a/hack/install-e2e-dependencies.sh
+++ b/hack/install-e2e-dependencies.sh
@@ -5,7 +5,6 @@ set -ex
 declare -r helm_version=3.5.4
 declare -r kubectl_version=1.19.11
 declare -r operator_sdk_version=1.7.1
-declare -r telepresence_version=2.2.1
 declare -r bin_dir=${BIN_DIR:-/usr/local/bin}
 
 install_helm() {
@@ -26,18 +25,6 @@ install_operator_sdk() {
     && rm operator-sdk-v${operator_sdk_version}-x86_64-linux-gnu
 }
 
-install_telepresence() {
-  curl -fL https://app.getambassador.io/download/tel2/linux/amd64/${telepresence_version}/telepresence -o ${bin_dir}/telepresence \
-    && chmod a+x ${bin_dir}/telepresence
-}
-
-install_ginkgo() {
-  go get github.com/onsi/ginkgo/ginkgo
-  go get github.com/onsi/gomega/...
-}
-
 install_helm
 install_kubectl
 install_operator_sdk
-install_telepresence
-install_ginkgo

--- a/hack/install-helm-chart-dependencies-kind.sh
+++ b/hack/install-helm-chart-dependencies-kind.sh
@@ -6,11 +6,13 @@ declare -r e2e_run_ref=${GITHUB_REF:-outside-github-$(hostname)}
 declare -r e2e_run_id=${GITHUB_RUN_ID:-none}
 declare -r humio_hostname=${E2E_LOGS_HUMIO_HOSTNAME:-none}
 declare -r humio_ingest_token=${E2E_LOGS_HUMIO_INGEST_TOKEN:-none}
-declare -r tmp_kubeconfig=/tmp/kubeconfig
 
 export PATH=$BIN_DIR:$PATH
 
-kind get kubeconfig > $tmp_kubeconfig
+if ! kubectl get daemonset -n kube-system kindnet ; then
+  echo "Cluster unavailable or not using a kind cluster. Only kind clusters are supported!"
+  exit 1
+fi
 
 if [[ $humio_hostname != "none" ]] && [[ $humio_ingest_token != "none" ]]; then
 
@@ -24,7 +26,7 @@ EOF
 )
 
   helm repo add shipper https://humio.github.io/humio-helm-charts
-  helm install --kubeconfig=$tmp_kubeconfig log-shipper shipper/humio-helm-charts --namespace=default \
+  helm install log-shipper shipper/humio-helm-charts --namespace=default \
   --set humio-fluentbit.enabled=true \
   --set humio-fluentbit.es.port=443 \
   --set humio-fluentbit.es.tls=true \
@@ -34,31 +36,31 @@ EOF
   --set humio-fluentbit.token=$humio_ingest_token
 fi
 
-kubectl --kubeconfig=$tmp_kubeconfig create namespace cert-manager
+kubectl create namespace cert-manager
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
-helm install --kubeconfig=$tmp_kubeconfig cert-manager jetstack/cert-manager --namespace cert-manager \
+helm install cert-manager jetstack/cert-manager --namespace cert-manager \
 --version v1.0.2 \
 --set installCRDs=true
 
 helm repo add humio https://humio.github.io/cp-helm-charts
-helm install --kubeconfig=$tmp_kubeconfig humio humio/cp-helm-charts --namespace=default \
+helm install humio humio/cp-helm-charts --namespace=default \
 --set cp-zookeeper.servers=1 --set cp-kafka.brokers=1 --set cp-schema-registry.enabled=false \
 --set cp-kafka-rest.enabled=false --set cp-kafka-connect.enabled=false \
 --set cp-ksql-server.enabled=false --set cp-control-center.enabled=false
 
-while [[ $(kubectl --kubeconfig=$tmp_kubeconfig get pods humio-cp-zookeeper-0 -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]
+while [[ $(kubectl get pods humio-cp-zookeeper-0 -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]
 do
   echo "Waiting for humio-cp-zookeeper-0 pod to become Ready"
-  kubectl --kubeconfig=$tmp_kubeconfig get pods -A
-  kubectl --kubeconfig=$tmp_kubeconfig describe pod humio-cp-zookeeper-0
+  kubectl get pods -A
+  kubectl describe pod humio-cp-zookeeper-0
   sleep 10
 done
 
-while [[ $(kubectl --kubeconfig=$tmp_kubeconfig get pods humio-cp-kafka-0 -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]
+while [[ $(kubectl get pods humio-cp-kafka-0 -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]
 do
   echo "Waiting for humio-cp-kafka-0 pod to become Ready"
-  kubectl --kubeconfig=$tmp_kubeconfig get pods -A
-  kubectl --kubeconfig=$tmp_kubeconfig describe pod humio-cp-kafka-0
+  kubectl get pods -A
+  kubectl describe pod humio-cp-kafka-0
   sleep 10
 done

--- a/hack/preload-images-kind.sh
+++ b/hack/preload-images-kind.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -x
+
+# Extract humio images and tags from go source
+DEFAULT_IMAGE=$(grep '^\s*image' controllers/humiocluster_defaults.go | cut -d '"' -f 2)
+PRE_UPDATE_IMAGE=$(grep '^\s*toCreate\.Spec\.Image' controllers/humiocluster_controller_test.go | cut -d '"' -f 2)
+
+# Preload default image used by tests
+docker pull $DEFAULT_IMAGE
+kind load docker-image --name kind $DEFAULT_IMAGE
+
+# Preload image used by e2e update tests
+docker pull $PRE_UPDATE_IMAGE
+kind load docker-image --name kind $PRE_UPDATE_IMAGE
+
+# Preload image we will run e2e tests from within
+docker build -t testcontainer -f test.Dockerfile .
+kind load docker-image testcontainer

--- a/hack/run-e2e-tests-crc.sh
+++ b/hack/run-e2e-tests-crc.sh
@@ -7,18 +7,20 @@ declare -r kubectl="oc --kubeconfig $tmp_kubeconfig"
 declare -r git_rev=$(git rev-parse --short HEAD)
 declare -r ginkgo=$(go env GOPATH)/bin/ginkgo
 
+echo "Script needs rework after we're no longer using Telepresence. Aborting..."
+exit 1
+
+if ! kubectl get namespace -n openshift ; then
+  echo "Cluster unavailable or not using a crc/openshift cluster. Only crc clusters are supported!"
+  exit 1
+fi
+
 if [[ -z "${HUMIO_E2E_LICENSE}" ]]; then
   echo "Environment variable HUMIO_E2E_LICENSE not set. Aborting."
   exit 1
 fi
 
 export PATH=$BIN_DIR:$PATH
-
-trap cleanup exit
-
-cleanup() {
-  telepresence uninstall --kubeconfig $tmp_kubeconfig --everything
-}
 
 eval $(crc oc-env)
 eval $(crc console --credentials | grep "To login as an admin, run" | cut -f2 -d"'")
@@ -27,13 +29,7 @@ $kubectl apply -k config/crd/
 $kubectl label node --overwrite --all topology.kubernetes.io/zone=az1
 
 # https://github.com/telepresenceio/telepresence/issues/1309
-oc adm policy add-scc-to-user anyuid -z default
-
-# TODO: add -p to automatically detect optimal number of test nodes, OR, -nodes=n to set parallelism, and add -stream to output logs from tests running in parallel.
-# We skip the helpers package as those tests assumes the environment variable USE_CERT_MANAGER is not set.
-# Documentation for Go support states that inject-tcp method will not work. https://www.telepresence.io/howto/golang
-echo "NOTE: Running 'telepresence connect' needs root access so it will prompt for the password of the user account to set up rules with iptables (or similar)"
-telepresence connect --kubeconfig $tmp_kubeconfig
+oc adm policy add-scc-to-user anyuid -z default # default in this command refers to the service account name that is used
 
 iterations=0
 while ! curl -k https://kubernetes.default
@@ -46,4 +42,6 @@ do
   sleep 2
 done
 
+# TODO: add -p to automatically detect optimal number of test nodes, OR, -nodes=n to set parallelism, and add -stream to output logs from tests running in parallel.
+# We skip the helpers package as those tests assumes the environment variable USE_CERT_MANAGER is not set.
 OPENSHIFT_SCC_NAME=default-humio-operator KUBECONFIG=$tmp_kubeconfig USE_CERTMANAGER=true TEST_USE_EXISTING_CLUSTER=true $ginkgo -timeout 90m -skipPackage helpers -v ./... -covermode=count -coverprofile cover.out -progress

--- a/hack/run-e2e-tests-kind.sh
+++ b/hack/run-e2e-tests-kind.sh
@@ -2,10 +2,13 @@
 
 set -x
 
-declare -r tmp_kubeconfig=/tmp/kubeconfig
-declare -r kubectl="kubectl --kubeconfig $tmp_kubeconfig"
 declare -r envtest_assets_dir=${ENVTEST_ASSETS_DIR:-/tmp/envtest}
 declare -r ginkgo=$(go env GOPATH)/bin/ginkgo
+
+if ! kubectl get daemonset -n kube-system kindnet ; then
+  echo "Cluster unavailable or not using a kind cluster. Only kind clusters are supported!"
+  exit 1
+fi
 
 if [[ -z "${HUMIO_E2E_LICENSE}" ]]; then
   echo "Environment variable HUMIO_E2E_LICENSE not set. Aborting."
@@ -14,32 +17,8 @@ fi
 
 export PATH=$BIN_DIR:$PATH
 
-trap cleanup exit
-
-cleanup() {
-  telepresence uninstall --kubeconfig $tmp_kubeconfig --everything
-}
-
-# Extract humio images and tags from go source
-DEFAULT_IMAGE=$(grep '^\s*image' controllers/humiocluster_defaults.go | cut -d '"' -f 2)
-PRE_UPDATE_IMAGE=$(grep '^\s*toCreate\.Spec\.Image' controllers/humiocluster_controller_test.go | cut -d '"' -f 2)
-
-# Preload default image used by tests
-docker pull $DEFAULT_IMAGE
-kind load docker-image --name kind $DEFAULT_IMAGE
-
-# Preload image used by e2e update tests
-docker pull $PRE_UPDATE_IMAGE
-kind load docker-image --name kind $PRE_UPDATE_IMAGE
-
-$kubectl apply -k config/crd/
-$kubectl label node --overwrite --all topology.kubernetes.io/zone=az1
-
-# TODO: add -p to automatically detect optimal number of test nodes, OR, -nodes=n to set parallelism, and add -stream to output logs from tests running in parallel.
-# We skip the helpers package as those tests assumes the environment variable USE_CERT_MANAGER is not set.
-# Documentation for Go support states that inject-tcp method will not work. https://www.telepresence.io/howto/golang
-echo "NOTE: Running 'telepresence connect' needs root access so it will prompt for the password of the user account to set up rules with iptables (or similar)"
-telepresence connect --kubeconfig $tmp_kubeconfig
+kubectl apply -k config/crd/
+kubectl label node --overwrite --all topology.kubernetes.io/zone=az1
 
 iterations=0
 while ! curl -k https://kubernetes.default
@@ -52,4 +31,8 @@ do
   sleep 2
 done
 
-KUBECONFIG=$tmp_kubeconfig USE_CERTMANAGER=true TEST_USE_EXISTING_CLUSTER=true $ginkgo -timeout 90m -skipPackage helpers -v ./... -covermode=count -coverprofile cover.out -progress
+make ginkgo
+
+# TODO: add -p to automatically detect optimal number of test nodes, OR, -nodes=n to set parallelism, and add -stream to output logs from tests running in parallel.
+# We skip the helpers package as those tests assumes the environment variable USE_CERT_MANAGER is not set.
+USE_CERTMANAGER=true TEST_USE_EXISTING_CLUSTER=true $ginkgo -timeout 90m -skipPackage helpers -v ./... -covermode=count -coverprofile cover.out -progress

--- a/hack/run-e2e-tests-using-kubectl-kind.sh
+++ b/hack/run-e2e-tests-using-kubectl-kind.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -x
+
+export PATH=$BIN_DIR:$PATH
+
+if ! kubectl get daemonset -n kube-system kindnet ; then
+  echo "Cluster unavailable or not using a kind cluster. Only kind clusters are supported!"
+  exit 1
+fi
+
+kubectl patch clusterrolebinding cluster-admin --type='json' -p='[{"op": "add", "path": "/subjects/1", "value": {"kind": "ServiceAccount", "name": "default", "namespace": "default" } }]'
+kubectl run test-pod --env="HUMIO_E2E_LICENSE=$HUMIO_E2E_LICENSE" --env="E2E_LOGS_HUMIO_HOSTNAME=$E2E_LOGS_HUMIO_HOSTNAME" --env="E2E_LOGS_HUMIO_INGEST_TOKEN=$E2E_LOGS_HUMIO_INGEST_TOKEN" --env="E2E_RUN_ID=$E2E_RUN_ID" --restart=Never --image=testcontainer --image-pull-policy=Never -- sleep 86400
+while [[ $(kubectl get pods test-pod -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do echo "waiting for pod" ; kubectl describe pod test-pod ; sleep 1 ; done
+kubectl exec test-pod -- hack/run-e2e-tests-kind.sh

--- a/hack/start-kind-cluster.sh
+++ b/hack/start-kind-cluster.sh
@@ -2,12 +2,16 @@
 
 set -x
 
-declare -r tmp_kubeconfig=/tmp/kubeconfig
-declare -r kubectl="kubectl --kubeconfig $tmp_kubeconfig"
-
 kind create cluster --name kind --image kindest/node:v1.17.17@sha256:c581fbf67f720f70aaabc74b44c2332cc753df262b6c0bca5d26338492470c17
-kind get kubeconfig > $tmp_kubeconfig
+
+sleep 5
+
+if ! kubectl get daemonset -n kube-system kindnet ; then
+  echo "Cluster unavailable or not using a kind cluster. Only kind clusters are supported!"
+  exit 1
+fi
+
 docker exec kind-control-plane sh -c 'echo nameserver 8.8.8.8 > /etc/resolv.conf'
 docker exec kind-control-plane sh -c 'echo options ndots:0 >> /etc/resolv.conf'
 
-$kubectl label node --overwrite --all topology.kubernetes.io/zone=az1
+kubectl label node --overwrite --all topology.kubernetes.io/zone=az1

--- a/hack/test-helm-chart-crc.sh
+++ b/hack/test-helm-chart-crc.sh
@@ -28,6 +28,9 @@ declare -r helm_chart_dir=./charts/humio-operator
 declare -r helm_chart_values_file=values.yaml
 declare -r hack_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+echo "Script needs rework after we're no longer using Telepresence. Aborting..."
+exit 1
+
 # Ensure we start from scratch
 source ${hack_dir}/delete-crc-cluster.sh
 

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:20.04
+
+# Install make and curl
+RUN apt update \
+ && apt install -y build-essential curl
+
+# Install go
+RUN curl -s https://dl.google.com/go/go1.15.12.linux-amd64.tar.gz | tar -xz -C /usr/local
+RUN ln -s /usr/local/go/bin/go /usr/bin/go
+
+# Install kind
+RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64 \
+ && chmod +x ./kind \
+ && mv ./kind /usr/bin/kind
+
+# Install docker-ce-cli
+RUN apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+RUN echo \
+  "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+RUN apt-get update \
+ && apt-get install -y docker-ce-cli
+
+# Create and populate /var/src with the source code for the humio-operator repository
+RUN mkdir /var/src
+COPY ./ /var/src
+WORKDIR /var/src
+
+# Install e2e dependencies
+RUN /var/src/hack/install-e2e-dependencies.sh


### PR DESCRIPTION
Instead we run a pod inside the `kind` cluster with the source code and
tools to compile and run the tests inside the cluster itself.

This unfortunately means the tests using `crc` for testing will not
work. We use `kind load docker-image` to load the container where the
tests will be performed within and `crc` doesn't have a similar command.
This means that the `crc` scripts will likely need to either push the
containers to a remote registry, or potentially "docker push" the image
directly to a registry running inside the `crc` cluster.