### PR TITLE
Create a single base logger and attach version information to log entries

### DIFF
--- a/controllers/humioaction_controller.go
+++ b/controllers/humioaction_controller.go
@@ -19,11 +19,11 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"github.com/humio/humio-operator/pkg/kubernetes"
 	"reflect"
 
 	humiov1alpha1 "github.com/humio/humio-operator/api/v1alpha1"
 
-	"github.com/go-logr/zapr"
 	humioapi "github.com/humio/cli/api"
 	"github.com/humio/humio-operator/pkg/helpers"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -38,6 +38,7 @@ import (
 // HumioActionReconciler reconciles a HumioAction object
 type HumioActionReconciler struct {
 	client.Client
+	BaseLogger  logr.Logger
 	Log         logr.Logger
 	HumioClient humio.Client
 }
@@ -47,9 +48,7 @@ type HumioActionReconciler struct {
 //+kubebuilder:rbac:groups=core.humio.com,resources=humioactions/finalizers,verbs=update
 
 func (r *HumioActionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	zapLog, _ := helpers.NewLogger()
-	defer zapLog.Sync()
-	r.Log = zapr.NewLogger(zapLog).WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name, "Request.Type", helpers.GetTypeName(r))
+	r.Log = r.BaseLogger.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name, "Request.Type", helpers.GetTypeName(r), "Reconcile.ID", kubernetes.RandomString())
 	r.Log.Info("Reconciling HumioAction")
 
 	ha := &humiov1alpha1.HumioAction{}

--- a/controllers/humioalert_controller.go
+++ b/controllers/humioalert_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"github.com/humio/humio-operator/pkg/kubernetes"
 	"reflect"
 
 	humioapi "github.com/humio/cli/api"
@@ -27,7 +28,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/go-logr/logr"
-	"github.com/go-logr/zapr"
 	"k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,6 +40,7 @@ import (
 // HumioAlertReconciler reconciles a HumioAlert object
 type HumioAlertReconciler struct {
 	client.Client
+	BaseLogger  logr.Logger
 	Log         logr.Logger
 	HumioClient humio.Client
 }
@@ -49,9 +50,7 @@ type HumioAlertReconciler struct {
 //+kubebuilder:rbac:groups=core.humio.com,resources=humioalerts/finalizers,verbs=update
 
 func (r *HumioAlertReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	zapLog, _ := helpers.NewLogger()
-	defer zapLog.Sync()
-	r.Log = zapr.NewLogger(zapLog).WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name, "Request.Type", helpers.GetTypeName(r))
+	r.Log = r.BaseLogger.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name, "Request.Type", helpers.GetTypeName(r), "Reconcile.ID", kubernetes.RandomString())
 	r.Log.Info("Reconciling HumioAlert")
 
 	ha := &humiov1alpha1.HumioAlert{}

--- a/controllers/humiocluster_controller.go
+++ b/controllers/humiocluster_controller.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-logr/zapr"
 	humioapi "github.com/humio/cli/api"
 	"github.com/humio/humio-operator/pkg/helpers"
 	"github.com/humio/humio-operator/pkg/kubernetes"
@@ -49,6 +48,7 @@ import (
 // HumioClusterReconciler reconciles a HumioCluster object
 type HumioClusterReconciler struct {
 	client.Client
+	BaseLogger  logr.Logger
 	Log         logr.Logger
 	HumioClient humio.Client
 }
@@ -68,9 +68,7 @@ type HumioClusterReconciler struct {
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=ingress,verbs=create;delete;get;list;patch;update;watch
 
 func (r *HumioClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	zapLog, _ := helpers.NewLogger()
-	defer zapLog.Sync()
-	r.Log = zapr.NewLogger(zapLog).WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name, "Request.Type", helpers.GetTypeName(r))
+	r.Log = r.BaseLogger.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name, "Request.Type", helpers.GetTypeName(r), "Reconcile.ID", kubernetes.RandomString())
 	r.Log.Info("Reconciling HumioCluster")
 
 	// Fetch the HumioCluster

--- a/controllers/humioexternalcluster_controller.go
+++ b/controllers/humioexternalcluster_controller.go
@@ -18,8 +18,8 @@ package controllers
 
 import (
 	"context"
-	"github.com/go-logr/zapr"
 	"github.com/humio/humio-operator/pkg/helpers"
+	"github.com/humio/humio-operator/pkg/kubernetes"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"time"
@@ -35,6 +35,7 @@ import (
 // HumioExternalClusterReconciler reconciles a HumioExternalCluster object
 type HumioExternalClusterReconciler struct {
 	client.Client
+	BaseLogger  logr.Logger
 	Log         logr.Logger
 	HumioClient humio.Client
 }
@@ -44,9 +45,7 @@ type HumioExternalClusterReconciler struct {
 //+kubebuilder:rbac:groups=core.humio.com,resources=humioexternalclusters/finalizers,verbs=update
 
 func (r *HumioExternalClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	zapLog, _ := helpers.NewLogger()
-	defer zapLog.Sync()
-	r.Log = zapr.NewLogger(zapLog).WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name, "Request.Type", helpers.GetTypeName(r))
+	r.Log = r.BaseLogger.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name, "Request.Type", helpers.GetTypeName(r), "Reconcile.ID", kubernetes.RandomString())
 	r.Log.Info("Reconciling HumioExternalCluster")
 
 	// Fetch the HumioExternalCluster instance

--- a/controllers/humioingesttoken_controller.go
+++ b/controllers/humioingesttoken_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/go-logr/logr"
-	"github.com/go-logr/zapr"
 	humioapi "github.com/humio/cli/api"
 	"github.com/humio/humio-operator/pkg/helpers"
 	"github.com/humio/humio-operator/pkg/kubernetes"
@@ -41,6 +40,7 @@ const humioFinalizer = "core.humio.com/finalizer" // TODO: Not only used for ing
 // HumioIngestTokenReconciler reconciles a HumioIngestToken object
 type HumioIngestTokenReconciler struct {
 	client.Client
+	BaseLogger  logr.Logger
 	Log         logr.Logger
 	HumioClient humio.Client
 }
@@ -50,9 +50,7 @@ type HumioIngestTokenReconciler struct {
 //+kubebuilder:rbac:groups=core.humio.com,resources=humioingesttokens/finalizers,verbs=update
 
 func (r *HumioIngestTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	zapLog, _ := helpers.NewLogger()
-	defer zapLog.Sync()
-	r.Log = zapr.NewLogger(zapLog).WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name, "Request.Type", helpers.GetTypeName(r))
+	r.Log = r.BaseLogger.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name, "Request.Type", helpers.GetTypeName(r), "Reconcile.ID", kubernetes.RandomString())
 	r.Log.Info("Reconciling HumioIngestToken")
 
 	// Fetch the HumioIngestToken instance

--- a/controllers/humioparser_controller.go
+++ b/controllers/humioparser_controller.go
@@ -19,9 +19,9 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"github.com/go-logr/zapr"
 	humioapi "github.com/humio/cli/api"
 	"github.com/humio/humio-operator/pkg/helpers"
+	"github.com/humio/humio-operator/pkg/kubernetes"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -38,6 +38,7 @@ import (
 // HumioParserReconciler reconciles a HumioParser object
 type HumioParserReconciler struct {
 	client.Client
+	BaseLogger  logr.Logger
 	Log         logr.Logger
 	HumioClient humio.Client
 }
@@ -47,9 +48,7 @@ type HumioParserReconciler struct {
 //+kubebuilder:rbac:groups=core.humio.com,resources=humioparsers/finalizers,verbs=update
 
 func (r *HumioParserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	zapLog, _ := helpers.NewLogger()
-	defer zapLog.Sync()
-	r.Log = zapr.NewLogger(zapLog).WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name, "Request.Type", helpers.GetTypeName(r))
+	r.Log = r.BaseLogger.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name, "Request.Type", helpers.GetTypeName(r), "Reconcile.ID", kubernetes.RandomString())
 	r.Log.Info("Reconciling HumioParser")
 
 	// Fetch the HumioParser instance

--- a/controllers/humiorepository_controller.go
+++ b/controllers/humiorepository_controller.go
@@ -19,9 +19,9 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"github.com/go-logr/zapr"
 	humioapi "github.com/humio/cli/api"
 	"github.com/humio/humio-operator/pkg/helpers"
+	"github.com/humio/humio-operator/pkg/kubernetes"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -38,6 +38,7 @@ import (
 // HumioRepositoryReconciler reconciles a HumioRepository object
 type HumioRepositoryReconciler struct {
 	client.Client
+	BaseLogger  logr.Logger
 	Log         logr.Logger
 	HumioClient humio.Client
 }
@@ -47,9 +48,7 @@ type HumioRepositoryReconciler struct {
 //+kubebuilder:rbac:groups=core.humio.com,resources=humiorepositories/finalizers,verbs=update
 
 func (r *HumioRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	zapLog, _ := helpers.NewLogger()
-	defer zapLog.Sync()
-	r.Log = zapr.NewLogger(zapLog).WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name, "Request.Type", helpers.GetTypeName(r))
+	r.Log = r.BaseLogger.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name, "Request.Type", helpers.GetTypeName(r), "Reconcile.ID", kubernetes.RandomString())
 	r.Log.Info("Reconciling HumioRepository")
 
 	// Fetch the HumioRepository instance

--- a/controllers/humioview_controller.go
+++ b/controllers/humioview_controller.go
@@ -20,10 +20,10 @@ import (
 	"context"
 	"fmt"
 	"github.com/go-logr/logr"
-	"github.com/go-logr/zapr"
 	humioapi "github.com/humio/cli/api"
 	"github.com/humio/humio-operator/pkg/helpers"
 	"github.com/humio/humio-operator/pkg/humio"
+	"github.com/humio/humio-operator/pkg/kubernetes"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"reflect"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -37,6 +37,7 @@ import (
 // HumioViewReconciler reconciles a HumioView object
 type HumioViewReconciler struct {
 	client.Client
+	BaseLogger  logr.Logger
 	Log         logr.Logger
 	HumioClient humio.Client
 }
@@ -46,9 +47,7 @@ type HumioViewReconciler struct {
 //+kubebuilder:rbac:groups=core.humio.com,resources=humioviews/finalizers,verbs=update
 
 func (r *HumioViewReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	zapLog, _ := helpers.NewLogger()
-	defer zapLog.Sync()
-	r.Log = zapr.NewLogger(zapLog).WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name, "Request.Type", helpers.GetTypeName(r))
+	r.Log = r.BaseLogger.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name, "Request.Type", helpers.GetTypeName(r), "Reconcile.ID", kubernetes.RandomString())
 	r.Log.Info("Reconciling HumioView")
 
 	// Fetch the HumioView instance

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -149,48 +149,56 @@ var _ = BeforeSuite(func() {
 	err = (&HumioExternalClusterReconciler{
 		Client:      k8sManager.GetClient(),
 		HumioClient: humioClient,
+		BaseLogger:  log,
 	}).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&HumioClusterReconciler{
 		Client:      k8sManager.GetClient(),
 		HumioClient: humioClient,
+		BaseLogger:  log,
 	}).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&HumioIngestTokenReconciler{
 		Client:      k8sManager.GetClient(),
 		HumioClient: humioClient,
+		BaseLogger:  log,
 	}).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&HumioParserReconciler{
 		Client:      k8sManager.GetClient(),
 		HumioClient: humioClient,
+		BaseLogger:  log,
 	}).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&HumioRepositoryReconciler{
 		Client:      k8sManager.GetClient(),
 		HumioClient: humioClient,
+		BaseLogger:  log,
 	}).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&HumioViewReconciler{
 		Client:      k8sManager.GetClient(),
 		HumioClient: humioClient,
+		BaseLogger:  log,
 	}).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&HumioActionReconciler{
 		Client:      k8sManager.GetClient(),
 		HumioClient: humioClient,
+		BaseLogger:  log,
 	}).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&HumioAlertReconciler{
 		Client:      k8sManager.GetClient(),
 		HumioClient: humioClient,
+		BaseLogger:  log,
 	}).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/main.go
+++ b/main.go
@@ -76,10 +76,10 @@ func main() {
 	var log logr.Logger
 	zapLog, _ := helpers.NewLogger()
 	defer zapLog.Sync()
-	log = zapr.NewLogger(zapLog)
+	log = zapr.NewLogger(zapLog).WithValues("Operator.Commit", commit, "Operator.Date", date, "Operator.Version", version)
 	ctrl.SetLogger(log)
 
-	ctrl.Log.Info(fmt.Sprintf("starting humio-operator %s (%s on %s)", version, commit, date))
+	ctrl.Log.Info("starting humio-operator")
 
 	watchNamespace, err := getWatchNamespace()
 	if err != nil {
@@ -130,6 +130,7 @@ func main() {
 	if err = (&controllers.HumioExternalClusterReconciler{
 		Client:      mgr.GetClient(),
 		HumioClient: humio.NewClient(log, &humioapi.Config{}, userAgent),
+		BaseLogger:  log,
 	}).SetupWithManager(mgr); err != nil {
 		ctrl.Log.Error(err, "unable to create controller", "controller", "HumioExternalCluster")
 		os.Exit(1)
@@ -137,6 +138,7 @@ func main() {
 	if err = (&controllers.HumioClusterReconciler{
 		Client:      mgr.GetClient(),
 		HumioClient: humio.NewClient(log, &humioapi.Config{}, userAgent),
+		BaseLogger:  log,
 	}).SetupWithManager(mgr); err != nil {
 		ctrl.Log.Error(err, "unable to create controller", "controller", "HumioCluster")
 		os.Exit(1)
@@ -144,6 +146,7 @@ func main() {
 	if err = (&controllers.HumioIngestTokenReconciler{
 		Client:      mgr.GetClient(),
 		HumioClient: humio.NewClient(log, &humioapi.Config{}, userAgent),
+		BaseLogger:  log,
 	}).SetupWithManager(mgr); err != nil {
 		ctrl.Log.Error(err, "unable to create controller", "controller", "HumioIngestToken")
 		os.Exit(1)
@@ -151,6 +154,7 @@ func main() {
 	if err = (&controllers.HumioParserReconciler{
 		Client:      mgr.GetClient(),
 		HumioClient: humio.NewClient(log, &humioapi.Config{}, userAgent),
+		BaseLogger:  log,
 	}).SetupWithManager(mgr); err != nil {
 		ctrl.Log.Error(err, "unable to create controller", "controller", "HumioParser")
 		os.Exit(1)
@@ -158,6 +162,7 @@ func main() {
 	if err = (&controllers.HumioRepositoryReconciler{
 		Client:      mgr.GetClient(),
 		HumioClient: humio.NewClient(log, &humioapi.Config{}, userAgent),
+		BaseLogger:  log,
 	}).SetupWithManager(mgr); err != nil {
 		ctrl.Log.Error(err, "unable to create controller", "controller", "HumioRepository")
 		os.Exit(1)
@@ -165,6 +170,7 @@ func main() {
 	if err = (&controllers.HumioViewReconciler{
 		Client:      mgr.GetClient(),
 		HumioClient: humio.NewClient(log, &humioapi.Config{}, userAgent),
+		BaseLogger:  log,
 	}).SetupWithManager(mgr); err != nil {
 		ctrl.Log.Error(err, "unable to create controller", "controller", "HumioView")
 		os.Exit(1)
@@ -172,6 +178,7 @@ func main() {
 	if err = (&controllers.HumioActionReconciler{
 		Client:      mgr.GetClient(),
 		HumioClient: humio.NewClient(log, &humioapi.Config{}, userAgent),
+		BaseLogger:  log,
 	}).SetupWithManager(mgr); err != nil {
 		ctrl.Log.Error(err, "unable to create controller", "controller", "HumioAction")
 		os.Exit(1)
@@ -179,6 +186,7 @@ func main() {
 	if err = (&controllers.HumioAlertReconciler{
 		Client:      mgr.GetClient(),
 		HumioClient: humio.NewClient(log, &humioapi.Config{}, userAgent),
+		BaseLogger:  log,
 	}).SetupWithManager(mgr); err != nil {
 		ctrl.Log.Error(err, "unable to create controller", "controller", "HumioAlert")
 		os.Exit(1)


### PR DESCRIPTION
This together with function names and caller line numbers makes it easy
to know exactly where things are originating from.