### PR TITLE
Upgrade humio cli dep to 0.28.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-logr/logr v0.4.0
 	github.com/go-logr/zapr v0.4.0
 	github.com/google/martian v2.1.0+incompatible
-	github.com/humio/cli v0.28.6
+	github.com/humio/cli v0.28.7
 	github.com/jetstack/cert-manager v1.4.4
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -578,8 +578,8 @@ github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c/go.mod h1:lADxMC39cJ
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
-github.com/humio/cli v0.28.6 h1:EzKQSwQZwAZGqsy8U4PQlmM+aONtcX3Nm5mGigz3M2M=
-github.com/humio/cli v0.28.6/go.mod h1:j09wyZdZO0+uUsndNOmthom+Gnr4xX5/iflZQ2zLN1Y=
+github.com/humio/cli v0.28.7 h1:Bt9dFY3Q+Z/fC5+Kgv5a0MmSFT5ebU+YlJ6rJcO2Fj4=
+github.com/humio/cli v0.28.7/go.mod h1:j09wyZdZO0+uUsndNOmthom+Gnr4xX5/iflZQ2zLN1Y=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=


### PR DESCRIPTION
This cherry-picks the humio api update from https://github.com/humio/humio-operator/pull/440 since that one is inconsistently passing/failing tests and I need to troubleshoot it. This should at least get us the timeout which is a less risky change.