### PR TITLE
Print pod spec diff when pods don't match

### DIFF
--- a/controllers/humiocluster_defaults.go
+++ b/controllers/humiocluster_defaults.go
@@ -94,6 +94,10 @@ func nodeCountOrDefault(hc *humiov1alpha1.HumioCluster) int {
 	return *hc.Spec.NodeCount
 }
 
+func imagePullPolicyOrDefault(hc *humiov1alpha1.HumioCluster) corev1.PullPolicy {
+	return hc.Spec.ImagePullPolicy
+}
+
 func imagePullSecretsOrDefault(hc *humiov1alpha1.HumioCluster) []corev1.LocalObjectReference {
 	emptyImagePullSecrets := []corev1.LocalObjectReference{}
 	if reflect.DeepEqual(hc.Spec.ImagePullSecrets, emptyImagePullSecrets) {
@@ -378,7 +382,8 @@ func setEnvironmentVariableDefaults(hc *humiov1alpha1.HumioCluster) {
 			Name: "THIS_POD_IP",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: "status.podIP",
+					APIVersion: "v1",
+					FieldPath:  "status.podIP",
 				},
 			},
 		},
@@ -386,7 +391,8 @@ func setEnvironmentVariableDefaults(hc *humiov1alpha1.HumioCluster) {
 			Name: "POD_NAME",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: "metadata.name",
+					APIVersion: "v1",
+					FieldPath:  "metadata.name",
 				},
 			},
 		},
@@ -394,7 +400,8 @@ func setEnvironmentVariableDefaults(hc *humiov1alpha1.HumioCluster) {
 			Name: "POD_NAMESPACE",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: "metadata.namespace",
+					APIVersion: "v1",
+					FieldPath:  "metadata.namespace",
 				},
 			},
 		},

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/go-logr/logr v0.4.0
 	github.com/go-logr/zapr v0.4.0
+	github.com/google/go-cmp v0.5.5
 	github.com/google/martian v2.1.0+incompatible
 	github.com/humio/cli v0.28.6
 	github.com/jetstack/cert-manager v1.4.4


### PR DESCRIPTION
This also moves the image pull policy default logic to separate function.
Moving this makes it more consistent with the other default functions we
already have in place.