### PR TITLE
Add org.opencontainers.image LABELS to docker build steps

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -22,7 +22,18 @@ jobs:
         echo "RELEASE_COMMIT=$(git rev-parse --verify HEAD)" >> $GITHUB_ENV
         echo "RELEASE_DATE=$(date --iso-8601=seconds)" >> $GITHUB_ENV
     - name: docker build
-      run: make docker-build-operator IMG=humio/humio-operator:${{ env.RELEASE_VERSION }} IMG_BUILD_ARGS="--label version=${{ env.RELEASE_VERSION }} --label release=${{ github.run_id }} --build-arg RELEASE_VERSION=${{ env.RELEASE_VERSION }} --build-arg RELEASE_COMMIT=${{ env.RELEASE_COMMIT }} --build-arg RELEASE_DATE=${{ env.RELEASE_DATE }}"
+      run: make docker-build-operator
+      env:
+        IMG: humio/humio-operator:${{ env.RELEASE_VERSION }}
+        IMG_BUILD_ARGS: >-
+          --label version=${{ env.RELEASE_VERSION }}
+          --label release=${{ github.run_id }}
+          --label org.opencontainers.image.revision=${{ github.sha }}
+          --label org.opencontainers.image.source=https://github.com/humio/humio-operator
+          --label com.atomist.containers.image.dockerfile=Dockerfile
+          --build-arg RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+          --build-arg RELEASE_COMMIT=${{ env.RELEASE_COMMIT }}
+          --build-arg RELEASE_DATE=${{ env.RELEASE_DATE }}
     - name: Set up Python
       uses: actions/setup-python@v2
     - name: Install dependencies
@@ -55,7 +66,18 @@ jobs:
           echo "RELEASE_COMMIT=$(git rev-parse --verify HEAD)" >> $GITHUB_ENV
           echo "RELEASE_DATE=$(date --iso-8601=seconds)" >> $GITHUB_ENV
       - name: docker build
-        run: make docker-build-helper IMG=humio/humio-operator-helper:${{ env.RELEASE_VERSION }} IMG_BUILD_ARGS="--label version=${{ env.RELEASE_VERSION }} --label release=${{ github.run_id }} --build-arg RELEASE_VERSION=${{ env.RELEASE_VERSION }} --build-arg RELEASE_COMMIT=${{ env.RELEASE_COMMIT }} --build-arg RELEASE_DATE=${{ env.RELEASE_DATE }}"
+        run: make docker-build-helper 
+        env:
+          IMG: humio/humio-operator-helper:${{ env.RELEASE_VERSION }} 
+          IMG_BUILD_ARGS: >-
+            --label version=${{ env.RELEASE_VERSION }}
+            --label release=${{ github.run_id }}
+            --label org.opencontainers.image.revision=${{ github.sha }}
+            --label org.opencontainers.image.source=https://github.com/humio/humio-operator
+            --label com.atomist.containers.image.dockerfile=images/helper/Dockerfile
+            --build-arg RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+            --build-arg RELEASE_COMMIT=${{ env.RELEASE_COMMIT }}
+            --build-arg RELEASE_DATE=${{ env.RELEASE_DATE }}
       - name: Set up Python
         uses: actions/setup-python@v2
       - name: Install dependencies


### PR DESCRIPTION
cc @schofield 
Grant, based on our conversation last week, I just wanted to summarize the additional metadata that we are scanning for.  Two of the labels are part of the spec `org.opencontainers.image.revision` and `org.opencontainers.image.source`.  The third one (`com.atomist.containers.image.dockerfile`) distinguishes different Dockerfiles within one repository, and gives us the ability to do better forensics on how vulnerabilities map to different layers.

I tested this out and made sure that we're scanning and can set vulnerability baselines for our CheckRuns.

I also tested this pinning feature and unfortunately, we don't yet support pinning for public images in `registry.access.redhat.com`.  The vulnerability scanning is fine because we pull the image.  But the pinning feature is constantly scanning for moving tags (like when the `latest` tag moves on the ubi8/ubi8-minimal image.  It looks to me like they don't support the docker v2 api for pulling manifests, and even their v1 api support was missing the digest information.  We'll support it but unfortunately, you wouldn't see any automatic pinning pull requests on this repo if you turned us on here.

