### PR TITLE
No need to specify Requeue if RequeueAfter is already specified

### DIFF
--- a/controllers/humiocluster_controller.go
+++ b/controllers/humiocluster_controller.go
@@ -352,7 +352,7 @@ func (r *HumioClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			hc.Status.State, podsStatus.waitingOnPods(), podsStatus.podRevisionsInSync(),
 			podsStatus.podRevisions, podsStatus.podDeletionTimestampSet, podsStatus.podNames,
 			podsStatus.expectedRunningPods, podsStatus.readyCount, podsStatus.notReadyCount))
-		return reconcile.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
+		return reconcile.Result{RequeueAfter: time.Second * 5}, nil
 	}
 
 	err = r.ensurePartitionsAreBalanced(hc, cluster.Config(), req)
@@ -378,7 +378,7 @@ func (r *HumioClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	r.Log.Info("done reconciling, will requeue after 15 seconds")
-	return reconcile.Result{Requeue: true, RequeueAfter: time.Second * 15}, nil
+	return reconcile.Result{RequeueAfter: time.Second * 15}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -2001,12 +2001,12 @@ func (r *HumioClusterReconciler) ensurePodsExist(ctx context.Context, hc *humiov
 		attachments, err := r.newPodAttachments(ctx, hc, foundPodList)
 		if err != nil {
 			r.Log.Error(err, "failed to get pod attachments")
-			return reconcile.Result{Requeue: true, RequeueAfter: time.Second * 5}, err
+			return reconcile.Result{RequeueAfter: time.Second * 5}, err
 		}
 		pod, err := r.createPod(ctx, hc, attachments)
 		if err != nil {
 			r.Log.Error(err, "unable to create pod")
-			return reconcile.Result{Requeue: true, RequeueAfter: time.Second * 5}, err
+			return reconcile.Result{RequeueAfter: time.Second * 5}, err
 		}
 		humioClusterPrometheusMetrics.Counters.PodsCreated.Inc()
 
@@ -2051,17 +2051,17 @@ func (r *HumioClusterReconciler) ensurePersistentVolumeClaimsExist(ctx context.C
 		err = r.Create(ctx, pvc)
 		if err != nil {
 			r.Log.Error(err, "unable to create pvc")
-			return reconcile.Result{Requeue: true, RequeueAfter: time.Second * 5}, err
+			return reconcile.Result{RequeueAfter: time.Second * 5}, err
 		}
 		r.Log.Info(fmt.Sprintf("successfully created pvc %s for HumioCluster %s", pvc.Name, hc.Name))
 		humioClusterPrometheusMetrics.Counters.PvcsCreated.Inc()
 
 		if err = r.waitForNewPvc(ctx, hc, pvc); err != nil {
 			r.Log.Error(err, "unable to create pvc: %s", err)
-			return reconcile.Result{Requeue: true, RequeueAfter: time.Second * 5}, err
+			return reconcile.Result{RequeueAfter: time.Second * 5}, err
 		}
 
-		return reconcile.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
+		return reconcile.Result{RequeueAfter: time.Second * 5}, nil
 	}
 
 	// TODO: what should happen if we have more pvcs than are expected?

--- a/controllers/humioexternalcluster_controller.go
+++ b/controllers/humioexternalcluster_controller.go
@@ -96,7 +96,7 @@ func (r *HumioExternalClusterReconciler) Reconcile(ctx context.Context, req ctrl
 			r.Log.Error(err, "unable to set cluster state")
 			return reconcile.Result{}, err
 		}
-		return reconcile.Result{Requeue: true, RequeueAfter: time.Second * 15}, nil
+		return reconcile.Result{RequeueAfter: time.Second * 15}, nil
 	}
 
 	err = r.Client.Get(ctx, req.NamespacedName, hec)
@@ -113,7 +113,7 @@ func (r *HumioExternalClusterReconciler) Reconcile(ctx context.Context, req ctrl
 	}
 
 	r.Log.Info("done reconciling, will requeue after 15 seconds")
-	return reconcile.Result{Requeue: true, RequeueAfter: time.Second * 15}, nil
+	return reconcile.Result{RequeueAfter: time.Second * 15}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/humioingesttoken_controller.go
+++ b/controllers/humioingesttoken_controller.go
@@ -179,7 +179,7 @@ func (r *HumioIngestTokenReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// A workaround for now is to delete the ingest token CR and create it again.
 
 	r.Log.Info("done reconciling, will requeue after 15 seconds")
-	return reconcile.Result{Requeue: true, RequeueAfter: time.Second * 15}, nil
+	return reconcile.Result{RequeueAfter: time.Second * 15}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/humioparser_controller.go
+++ b/controllers/humioparser_controller.go
@@ -170,7 +170,7 @@ func (r *HumioParserReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// A workaround for now is to delete the parser CR and create it again.
 
 	r.Log.Info("done reconciling, will requeue after 15 seconds")
-	return reconcile.Result{Requeue: true, RequeueAfter: time.Second * 15}, nil
+	return reconcile.Result{RequeueAfter: time.Second * 15}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/humiorepository_controller.go
+++ b/controllers/humiorepository_controller.go
@@ -181,7 +181,7 @@ func (r *HumioRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// A workaround for now is to delete the repository CR and create it again.
 
 	r.Log.Info("done reconciling, will requeue after 15 seconds")
-	return reconcile.Result{Requeue: true, RequeueAfter: time.Second * 15}, nil
+	return reconcile.Result{RequeueAfter: time.Second * 15}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/humioview_controller.go
+++ b/controllers/humioview_controller.go
@@ -172,7 +172,7 @@ func (r *HumioViewReconciler) reconcileHumioView(ctx context.Context, config *hu
 	}
 
 	r.Log.Info("done reconciling, will requeue after 15 seconds")
-	return reconcile.Result{Requeue: true, RequeueAfter: time.Second * 15}, nil
+	return reconcile.Result{RequeueAfter: time.Second * 15}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/reconcile/reconcile.go#L28-L33