### PR TITLE
Various cleanup and removing some uses of reflect package

### DIFF
--- a/controllers/humiocluster_controller.go
+++ b/controllers/humiocluster_controller.go
@@ -1808,9 +1808,11 @@ func (r *HumioClusterReconciler) ensureHumioServiceAccountAnnotations(ctx contex
 	}
 
 	serviceAccount := kubernetes.ConstructServiceAccount(serviceAccountName, hc.Name, hc.Namespace, serviceAccountAnnotations)
-	if !reflect.DeepEqual(existingServiceAccount.Annotations, serviceAccount.Annotations) {
+	serviceAccountAnnotationsString := helpers.MapToSortedString(serviceAccountAnnotations)
+	existingServiceAccountAnnotationsString := helpers.MapToSortedString(existingServiceAccount.Annotations)
+	if serviceAccountAnnotationsString != existingServiceAccountAnnotationsString {
 		r.Log.Info(fmt.Sprintf("service account annotations do not match: annotations %s, got %s. updating service account %s",
-			helpers.MapToString(serviceAccount.Annotations), helpers.MapToString(existingServiceAccount.Annotations), existingServiceAccount.Name))
+			serviceAccountAnnotationsString, existingServiceAccountAnnotationsString, existingServiceAccount.Name))
 		existingServiceAccount.Annotations = serviceAccount.Annotations
 		err = r.Update(ctx, existingServiceAccount)
 		if err != nil {
@@ -1982,8 +1984,10 @@ func (r *HumioClusterReconciler) ingressesMatch(ingress *networkingv1.Ingress, d
 		return false
 	}
 
-	if !reflect.DeepEqual(ingress.Annotations, desiredIngress.Annotations) {
-		r.Log.Info(fmt.Sprintf("ingress annotations do not match: got %+v, wanted %+v", ingress.Annotations, desiredIngress.Annotations))
+	ingressAnnotations := helpers.MapToSortedString(ingress.Annotations)
+	desiredIngressAnnotations := helpers.MapToSortedString(desiredIngress.Annotations)
+	if ingressAnnotations != desiredIngressAnnotations {
+		r.Log.Info(fmt.Sprintf("ingress annotations do not match: got %s, wanted %s", ingressAnnotations, desiredIngressAnnotations))
 		return false
 	}
 	return true

--- a/controllers/humiocluster_defaults.go
+++ b/controllers/humiocluster_defaults.go
@@ -125,8 +125,7 @@ func dataVolumeSourceOrDefault(hc *humiov1alpha1.HumioCluster) corev1.VolumeSour
 }
 
 func affinityOrDefault(hc *humiov1alpha1.HumioCluster) *corev1.Affinity {
-	emptyAffinity := corev1.Affinity{}
-	if reflect.DeepEqual(hc.Spec.Affinity, emptyAffinity) {
+	if hc.Spec.Affinity == (corev1.Affinity{}) {
 		return &corev1.Affinity{
 			NodeAffinity: &corev1.NodeAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
@@ -172,10 +171,7 @@ func shareProcessNamespaceOrDefault(hc *humiov1alpha1.HumioCluster) *bool {
 }
 
 func humioServiceAccountAnnotationsOrDefault(hc *humiov1alpha1.HumioCluster) map[string]string {
-	if hc.Spec.HumioServiceAccountAnnotations != nil {
-		return hc.Spec.HumioServiceAccountAnnotations
-	}
-	return map[string]string(nil)
+	return hc.Spec.HumioServiceAccountAnnotations
 }
 
 func humioServiceAccountNameOrDefault(hc *humiov1alpha1.HumioCluster) string {
@@ -247,8 +243,7 @@ func authRoleBindingName(hc *humiov1alpha1.HumioCluster) string {
 }
 
 func containerReadinessProbeOrDefault(hc *humiov1alpha1.HumioCluster) *corev1.Probe {
-	emptyProbe := &corev1.Probe{}
-	if reflect.DeepEqual(hc.Spec.ContainerReadinessProbe, emptyProbe) {
+	if hc.Spec.ContainerReadinessProbe != nil && (*hc.Spec.ContainerReadinessProbe == (corev1.Probe{})) {
 		return nil
 	}
 
@@ -272,8 +267,7 @@ func containerReadinessProbeOrDefault(hc *humiov1alpha1.HumioCluster) *corev1.Pr
 }
 
 func containerLivenessProbeOrDefault(hc *humiov1alpha1.HumioCluster) *corev1.Probe {
-	emptyProbe := &corev1.Probe{}
-	if reflect.DeepEqual(hc.Spec.ContainerLivenessProbe, emptyProbe) {
+	if hc.Spec.ContainerLivenessProbe != nil && (*hc.Spec.ContainerLivenessProbe == (corev1.Probe{})) {
 		return nil
 	}
 
@@ -297,8 +291,7 @@ func containerLivenessProbeOrDefault(hc *humiov1alpha1.HumioCluster) *corev1.Pro
 }
 
 func containerStartupProbeOrDefault(hc *humiov1alpha1.HumioCluster) *corev1.Probe {
-	emptyProbe := &corev1.Probe{}
-	if reflect.DeepEqual(hc.Spec.ContainerStartupProbe, emptyProbe) {
+	if hc.Spec.ContainerStartupProbe != nil && (*hc.Spec.ContainerStartupProbe == (corev1.Probe{})) {
 		return nil
 	}
 

--- a/controllers/humiocluster_pods.go
+++ b/controllers/humiocluster_pods.go
@@ -636,9 +636,7 @@ func constructPod(hc *humiov1alpha1.HumioCluster, humioNodeName string, attachme
 }
 
 func volumeSource(hc *humiov1alpha1.HumioCluster, podList []corev1.Pod, pvcList []corev1.PersistentVolumeClaim) (corev1.VolumeSource, error) {
-	emptyDataVolume := corev1.VolumeSource{}
-
-	if pvcsEnabled(hc) && !reflect.DeepEqual(hc.Spec.DataVolumeSource, emptyDataVolume) {
+	if pvcsEnabled(hc) && hc.Spec.DataVolumeSource != (corev1.VolumeSource{}) {
 		return corev1.VolumeSource{}, fmt.Errorf("cannot have both dataVolumePersistentVolumeClaimSpecTemplate and dataVolumeSource defined")
 	}
 	if pvcsEnabled(hc) {

--- a/controllers/humiocluster_status.go
+++ b/controllers/humiocluster_status.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"sort"
 	"strconv"
 
@@ -101,7 +100,7 @@ func (r *HumioClusterReconciler) setVersion(ctx context.Context, version string,
 }
 
 func (r *HumioClusterReconciler) setLicense(ctx context.Context, licenseStatus humiov1alpha1.HumioLicenseStatus, hc *humiov1alpha1.HumioCluster) error {
-	if reflect.DeepEqual(hc.Status.LicenseStatus, licenseStatus) {
+	if hc.Status.LicenseStatus == licenseStatus {
 		return nil
 	}
 	r.Log.Info(fmt.Sprintf("setting cluster license status to %v", licenseStatus))

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -330,10 +330,10 @@ var _ = AfterSuite(func() {
 		By(fmt.Sprintf("Removing test namespace: %s", testProcessID))
 		err := k8sClient.Delete(context.TODO(), &testNamespace)
 		Expect(err).ToNot(HaveOccurred())
-		By("Tearing down the test environment")
-		err = testEnv.Stop()
-		Expect(err).NotTo(HaveOccurred())
 	}
+	By("Tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getWatchNamespace returns the Namespace the operator should be watching for changes

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/shurcooL/graphql"
@@ -147,8 +148,9 @@ func IntPtr(val int) *int {
 	return &val
 }
 
-// MapToString prettifies a string map so it's more suitable for readability when logging
-func MapToString(m map[string]string) string {
+// MapToSortedString prettifies a string map, so it's more suitable for readability when logging.
+// The output is constructed by sorting the slice.
+func MapToSortedString(m map[string]string) string {
 	if len(m) == 0 {
 		return `"":""`
 	}
@@ -156,6 +158,9 @@ func MapToString(m map[string]string) string {
 	for k, v := range m {
 		a = append(a, fmt.Sprintf("%s=%s", k, v))
 	}
+	sort.SliceStable(a, func(i, j int) bool {
+		return a[i] > a[j]
+	})
 	return strings.Join(a, ",")
 }
 

--- a/pkg/humio/client.go
+++ b/pkg/humio/client.go
@@ -536,12 +536,7 @@ func getConnectionMap(viewConnections []humioapi.ViewConnection) map[string]stri
 }
 
 func (h *ClientConfig) GetLicense(config *humioapi.Config, req reconcile.Request) (humioapi.License, error) {
-	licensesClient := h.GetHumioClient(config, req).Licenses()
-	emptyConfig := humioapi.Config{}
-	if !reflect.DeepEqual(h.GetHumioClient(config, req).Config(), emptyConfig) && h.GetHumioClient(config, req).Config().Address != nil {
-		return licensesClient.Get()
-	}
-	return nil, fmt.Errorf("no api client configured yet")
+	return h.GetHumioClient(config, req).Licenses().Get()
 }
 
 func (h *ClientConfig) InstallLicense(config *humioapi.Config, req reconcile.Request, license string) error {

--- a/pkg/humio/client_mock.go
+++ b/pkg/humio/client_mock.go
@@ -162,8 +162,7 @@ func (h *MockClientConfig) UpdateIngestToken(config *humioapi.Config, req reconc
 }
 
 func (h *MockClientConfig) DeleteIngestToken(config *humioapi.Config, req reconcile.Request, hit *humiov1alpha1.HumioIngestToken) error {
-	updatedApiClient := h.apiClient
-	updatedApiClient.IngestToken = humioapi.IngestToken{}
+	h.apiClient.IngestToken = humioapi.IngestToken{}
 	return nil
 }
 
@@ -211,8 +210,7 @@ func (h *MockClientConfig) UpdateRepository(config *humioapi.Config, req reconci
 }
 
 func (h *MockClientConfig) DeleteRepository(config *humioapi.Config, req reconcile.Request, hr *humiov1alpha1.HumioRepository) error {
-	updatedApiClient := h.apiClient
-	updatedApiClient.Repository = humioapi.Repository{}
+	h.apiClient.Repository = humioapi.Repository{}
 	return nil
 }
 
@@ -221,8 +219,6 @@ func (h *MockClientConfig) GetView(config *humioapi.Config, req reconcile.Reques
 }
 
 func (h *MockClientConfig) AddView(config *humioapi.Config, req reconcile.Request, hv *humiov1alpha1.HumioView) (*humioapi.View, error) {
-	updatedApiClient := h.apiClient
-
 	connections := make([]humioapi.ViewConnection, 0)
 	for _, connection := range hv.Spec.Connections {
 		connections = append(connections, humioapi.ViewConnection{
@@ -231,7 +227,7 @@ func (h *MockClientConfig) AddView(config *humioapi.Config, req reconcile.Reques
 		})
 	}
 
-	updatedApiClient.View = humioapi.View{
+	h.apiClient.View = humioapi.View{
 		Name:        hv.Spec.Name,
 		Connections: connections,
 	}
@@ -280,13 +276,11 @@ func (h *MockClientConfig) GetNotifier(config *humioapi.Config, req reconcile.Re
 }
 
 func (h *MockClientConfig) AddNotifier(config *humioapi.Config, req reconcile.Request, ha *humiov1alpha1.HumioAction) (*humioapi.Notifier, error) {
-	updatedApiClient := h.apiClient
-
 	notifier, err := NotifierFromAction(ha)
 	if err != nil {
 		return notifier, err
 	}
-	updatedApiClient.Notifier = *notifier
+	h.apiClient.Notifier = *notifier
 	return &h.apiClient.Notifier, nil
 }
 
@@ -304,8 +298,6 @@ func (h *MockClientConfig) GetAlert(config *humioapi.Config, req reconcile.Reque
 }
 
 func (h *MockClientConfig) AddAlert(config *humioapi.Config, req reconcile.Request, ha *humiov1alpha1.HumioAlert) (*humioapi.Alert, error) {
-	updatedApiClient := h.apiClient
-
 	actionIdMap, err := h.GetActionIDsMapForAlerts(config, req, ha)
 	if err != nil {
 		return &humioapi.Alert{}, fmt.Errorf("could not get action id mapping: %s", err)
@@ -314,7 +306,7 @@ func (h *MockClientConfig) AddAlert(config *humioapi.Config, req reconcile.Reque
 	if err != nil {
 		return alert, err
 	}
-	updatedApiClient.Alert = *alert
+	h.apiClient.Alert = *alert
 	return &h.apiClient.Alert, nil
 }
 
@@ -323,8 +315,7 @@ func (h *MockClientConfig) UpdateAlert(config *humioapi.Config, req reconcile.Re
 }
 
 func (h *MockClientConfig) DeleteAlert(config *humioapi.Config, req reconcile.Request, ha *humiov1alpha1.HumioAlert) error {
-	updateApiClient := h.apiClient
-	updateApiClient.Alert = humioapi.Alert{}
+	h.apiClient.Alert = humioapi.Alert{}
 	return nil
 }
 


### PR DESCRIPTION
Removes ~25% of our use of `reflect.DeepEqual` outside our tests.