### PR TITLE
Remove remaining HUMIO_JVM_ARGS env var

### DIFF
--- a/controllers/humiocluster_defaults.go
+++ b/controllers/humiocluster_defaults.go
@@ -351,7 +351,6 @@ func (hnp HumioNodePool) GetEnvironmentVariables() []corev1.EnvVar {
 			},
 		},
 
-		{Name: "HUMIO_JVM_ARGS", Value: "-Xss2m -Xms256m -Xmx1536m -server -XX:+UseParallelGC -XX:+ScavengeBeforeFullGC -XX:+DisableExplicitGC -Dlog4j2.formatMsgNoLookups=true"},
 		{Name: "HUMIO_PORT", Value: strconv.Itoa(humioPort)},
 		{Name: "ELASTIC_PORT", Value: strconv.Itoa(elasticPort)},
 		{Name: "DIGEST_REPLICATION_FACTOR", Value: strconv.Itoa(hnp.GetTargetReplicationFactor())},


### PR DESCRIPTION
I believe it was intended to remove this as part of https://github.com/humio/humio-operator/pull/497.