### PR TITLE
Retry failed reconciles when managing humio resources

### DIFF
--- a/controllers/humioparser_controller.go
+++ b/controllers/humioparser_controller.go
@@ -20,14 +20,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
+	"time"
+
 	"github.com/google/go-cmp/cmp"
 	humioapi "github.com/humio/cli/api"
 	"github.com/humio/humio-operator/pkg/helpers"
 	"github.com/humio/humio-operator/pkg/kubernetes"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sort"
-	"time"
 
 	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -81,7 +82,7 @@ func (r *HumioParserReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		if err != nil {
 			return reconcile.Result{}, r.logErrorAndReturn(err, "unable to set cluster state")
 		}
-		return reconcile.Result{}, err
+		return reconcile.Result{RequeueAfter: time.Second * 15}, nil
 	}
 
 	r.Log.Info("Checking if parser is marked to be deleted")

--- a/controllers/humiorepository_controller.go
+++ b/controllers/humiorepository_controller.go
@@ -19,13 +19,14 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"time"
+
 	humioapi "github.com/humio/cli/api"
 	"github.com/humio/humio-operator/pkg/helpers"
 	"github.com/humio/humio-operator/pkg/kubernetes"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"time"
 
 	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -79,7 +80,7 @@ func (r *HumioRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		if err != nil {
 			return reconcile.Result{}, r.logErrorAndReturn(err, "unable to set cluster state")
 		}
-		return reconcile.Result{}, err
+		return reconcile.Result{RequeueAfter: time.Second * 15}, nil
 	}
 
 	r.Log.Info("Checking if repository is marked to be deleted")

--- a/controllers/humioview_controller.go
+++ b/controllers/humioview_controller.go
@@ -80,7 +80,7 @@ func (r *HumioViewReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if err != nil {
 			return reconcile.Result{}, r.logErrorAndReturn(err, "unable to set cluster state")
 		}
-		return reconcile.Result{}, err
+		return reconcile.Result{RequeueAfter: time.Second * 15}, nil
 	}
 
 	defer func(ctx context.Context, humioClient humio.Client, hv *humiov1alpha1.HumioView) {


### PR DESCRIPTION
Fixes an issue where if a humio resource such as a repo is created before the cluster is ready, the resource will fail to be created and not retry until the operator is restarted. This will force a retry after 15 seconds.