### PR TITLE
Fix flaky test

### DIFF
--- a/controllers/humiocluster_controller_test.go
+++ b/controllers/humiocluster_controller_test.go
@@ -877,12 +877,6 @@ var _ = Describe("HumioCluster Controller", func() {
 					return k8sClient.Update(ctx, &updatedHumioCluster)
 				}, testTimeout, testInterval).Should(Succeed())
 
-				Eventually(func() string {
-					updatedHumioCluster = humiov1alpha1.HumioCluster{}
-					Expect(k8sClient.Get(ctx, key, &updatedHumioCluster)).Should(Succeed())
-					return updatedHumioCluster.Status.State
-				}, testTimeout, testInterval).Should(BeIdenticalTo(humiov1alpha1.HumioClusterStateRestarting))
-
 				ensurePodsSimultaneousRestart(ctx, NewHumioNodeManagerFromHumioCluster(&updatedHumioCluster), 2)
 
 				Eventually(func() string {


### PR DESCRIPTION
This test is intended to ensure the pods are restarted when the `EXTERNAL_URL` changes. This happens when migrating to the headless service or when tls is enabled or disabled. Occasionally there is an issue with enabling tls which appears related to the kind cluster, which results in the cluster going into a ConfigError state briefly before resolving itself. Since we're not actually testing the behavior of tls in this test and only testing the restart behavior, we can remove this check since it's followed by the actual test that ensures the pods are restarted.