### PR TITLE
Support podAnnotations in humio operator helm charts 

### DIFF
--- a/charts/humio-operator/templates/operator-deployment.yaml
+++ b/charts/humio-operator/templates/operator-deployment.yaml
@@ -28,9 +28,9 @@ spec:
         productID: "none"
         productName: "humio-operator"
         productVersion: {{ .Values.operator.image.tag | quote }}
-        {{- if .Values.operator.podAnnotations }}
-{{ toYaml .Values.operator.podAnnotations | nindent 8 }}
-        {{- end }}
+{{- if .Values.operator.podAnnotations }}
+        {{- toYaml .Values.operator.podAnnotations | nindent 8 }}
+{{- end }}
       labels:
         app: '{{ .Chart.Name }}'
         app.kubernetes.io/name: '{{ .Chart.Name }}'

--- a/charts/humio-operator/templates/operator-deployment.yaml
+++ b/charts/humio-operator/templates/operator-deployment.yaml
@@ -28,6 +28,9 @@ spec:
         productID: "none"
         productName: "humio-operator"
         productVersion: {{ .Values.operator.image.tag | quote }}
+        {{- if .Values.operator.podAnnotations }}
+{{ toYaml .Values.operator.podAnnotations | nindent 8 }}
+        {{- end }}
       labels:
         app: '{{ .Chart.Name }}'
         app.kubernetes.io/name: '{{ .Chart.Name }}'

--- a/charts/humio-operator/values.yaml
+++ b/charts/humio-operator/values.yaml
@@ -19,6 +19,7 @@ operator:
       cpu: 250m
       memory: 200Mi
   watchNamespaces: []
+  podAnnotations: {}
 installCRDs: false
 openshift: false
 certmanager: true


### PR DESCRIPTION
Allow specifying annotations for the humio operator pod through values file.

### Use case
Prometheus server requires pods to be annotated like below to scrape metrics automatically. The ServiceMonitor CR is only supported by prometheus operator.

```
prometheus.io/scrape: 'true'
prometheus.io/port: '9102'
```

Signed-off-by: Jayadeep KM <kmjayadeep@gmail.com>