### PR TITLE
Disable logging stdout from reports

### DIFF
--- a/controllers/suite/clusters/suite_test.go
+++ b/controllers/suite/clusters/suite_test.go
@@ -358,8 +358,14 @@ var _ = ReportAfterSuite("HumioCluster Controller Suite", func(suiteReport ginkg
 	for _, r := range suiteReport.SpecReports {
 		testRunID := fmt.Sprintf("ReportAfterSuite-%s", kubernetes.RandomString())
 
-		suite.PrintLinesWithRunID(testRunID, strings.Split(r.CapturedGinkgoWriterOutput, "\n"), r.State)
-		suite.PrintLinesWithRunID(testRunID, strings.Split(r.CapturedStdOutErr, "\n"), r.State)
+		// Don't print CapturedGinkgoWriterOutput and CapturedStdOutErr for now as they end up being logged 3 times.
+		// Ginkgo captures the stdout of anything it spawns and populates that into the reports, which results in stdout
+		// being logged from these locations:
+		// 1. regular container stdout
+		// 2. ReportAfterEach
+		// 3. ReportAfterSuite
+		//suite.PrintLinesWithRunID(testRunID, strings.Split(r.CapturedGinkgoWriterOutput, "\n"), r.State)
+		//suite.PrintLinesWithRunID(testRunID, strings.Split(r.CapturedStdOutErr, "\n"), r.State)
 
 		r.CapturedGinkgoWriterOutput = testRunID
 		r.CapturedStdOutErr = testRunID
@@ -372,8 +378,14 @@ var _ = ReportAfterSuite("HumioCluster Controller Suite", func(suiteReport ginkg
 var _ = ReportAfterEach(func(specReport ginkgotypes.SpecReport) {
 	testRunID := fmt.Sprintf("ReportAfterEach-%s", kubernetes.RandomString())
 
-	suite.PrintLinesWithRunID(testRunID, strings.Split(specReport.CapturedGinkgoWriterOutput, "\n"), specReport.State)
-	suite.PrintLinesWithRunID(testRunID, strings.Split(specReport.CapturedStdOutErr, "\n"), specReport.State)
+	// Don't print CapturedGinkgoWriterOutput and CapturedStdOutErr for now as they end up being logged 3 times.
+	// Ginkgo captures the stdout of anything it spawns and populates that into the reports, which results in stdout
+	// being logged from these locations:
+	// 1. regular container stdout
+	// 2. ReportAfterEach
+	// 3. ReportAfterSuite
+	//suite.PrintLinesWithRunID(testRunID, strings.Split(specReport.CapturedGinkgoWriterOutput, "\n"), specReport.State)
+	//suite.PrintLinesWithRunID(testRunID, strings.Split(specReport.CapturedStdOutErr, "\n"), specReport.State)
 
 	specReport.CapturedGinkgoWriterOutput = testRunID
 	specReport.CapturedStdOutErr = testRunID

--- a/controllers/suite/resources/suite_test.go
+++ b/controllers/suite/resources/suite_test.go
@@ -352,8 +352,14 @@ var _ = ReportAfterSuite("HumioCluster Controller Suite", func(suiteReport ginkg
 	for _, r := range suiteReport.SpecReports {
 		testRunID := fmt.Sprintf("ReportAfterSuite-%s", kubernetes.RandomString())
 
-		suite.PrintLinesWithRunID(testRunID, strings.Split(r.CapturedGinkgoWriterOutput, "\n"), r.State)
-		suite.PrintLinesWithRunID(testRunID, strings.Split(r.CapturedStdOutErr, "\n"), r.State)
+		// Don't print CapturedGinkgoWriterOutput and CapturedStdOutErr for now as they end up being logged 3 times.
+		// Ginkgo captures the stdout of anything it spawns and populates that into the reports, which results in stdout
+		// being logged from these locations:
+		// 1. regular container stdout
+		// 2. ReportAfterEach
+		// 3. ReportAfterSuite
+		//suite.PrintLinesWithRunID(testRunID, strings.Split(r.CapturedGinkgoWriterOutput, "\n"), r.State)
+		//suite.PrintLinesWithRunID(testRunID, strings.Split(r.CapturedStdOutErr, "\n"), r.State)
 
 		r.CapturedGinkgoWriterOutput = testRunID
 		r.CapturedStdOutErr = testRunID
@@ -366,8 +372,14 @@ var _ = ReportAfterSuite("HumioCluster Controller Suite", func(suiteReport ginkg
 var _ = ReportAfterEach(func(specReport ginkgotypes.SpecReport) {
 	testRunID := fmt.Sprintf("ReportAfterEach-%s", kubernetes.RandomString())
 
-	suite.PrintLinesWithRunID(testRunID, strings.Split(specReport.CapturedGinkgoWriterOutput, "\n"), specReport.State)
-	suite.PrintLinesWithRunID(testRunID, strings.Split(specReport.CapturedStdOutErr, "\n"), specReport.State)
+	// Don't print CapturedGinkgoWriterOutput and CapturedStdOutErr for now as they end up being logged 3 times.
+	// Ginkgo captures the stdout of anything it spawns and populates that into the reports, which results in stdout
+	// being logged from these locations:
+	// 1. regular container stdout
+	// 2. ReportAfterEach
+	// 3. ReportAfterSuite
+	//suite.PrintLinesWithRunID(testRunID, strings.Split(specReport.CapturedGinkgoWriterOutput, "\n"), specReport.State)
+	//suite.PrintLinesWithRunID(testRunID, strings.Split(specReport.CapturedStdOutErr, "\n"), specReport.State)
 
 	specReport.CapturedGinkgoWriterOutput = testRunID
 	specReport.CapturedStdOutErr = testRunID


### PR DESCRIPTION
Right now we end up logging everything 3 times, which isn't exactly what
we want. The idea was to make it easy to go from test result to related
log lines, but we shouldn't do that by duplicating all logs.

This disables the 2 additional copies so we only have one copy of
stdout. This does however mean we won't have a direct link from the test
report being logged out to the relevant log entries, but perhaps we can
find another solution to that.