### PR TITLE
helper: Improve logging

### DIFF
--- a/images/helper/main.go
+++ b/images/helper/main.go
@@ -219,6 +219,7 @@ func validateAdminSecretContent(ctx context.Context, clientset *k8s.Clientset, n
 			humioClient.Token() != string(secret.Data["token"]) ||
 			humioClient.Address() == nil // Auth container uses pod name for the address, and pod names are immutable.
 		if clientNotReady {
+			fmt.Printf("Updating humioClient to use admin-token\n")
 			humioClient = humio.NewClient(humio.Config{
 				Address:   nodeURL,
 				UserAgent: fmt.Sprintf("humio-operator-helper/%s (%s on %s)", version, commit, date),
@@ -384,6 +385,7 @@ func authMode() {
 			humioClient.Token() != localAdminToken ||
 			humioClient.Address() == nil // Auth container uses pod name for the address, and pod names are immutable.
 		if clientNotReady {
+			fmt.Printf("Updating humioClient to use localAdminToken\n")
 			humioClient = humio.NewClient(humio.Config{
 				Address:   nodeURL,
 				UserAgent: fmt.Sprintf("humio-operator-helper/%s (%s on %s)", version, commit, date),

--- a/images/helper/main.go
+++ b/images/helper/main.go
@@ -86,7 +86,7 @@ func getApiTokenForUserID(client *humio.Client, userID string) (string, string, 
 		return token, apiTokenMethodFromAPI, nil
 	}
 
-	return "", "", fmt.Errorf("could not find apiToken for userID: %s", userID)
+	return "", "", fmt.Errorf("could not rotate apiToken for userID %s, err: %w", userID, err)
 }
 
 type user struct {


### PR DESCRIPTION
We've seen a few cases where the auth sidecar ends up continuously rotating the API token, which isn't what we want. The problem seems to be that we end up determining that the api token we try to validate is not valid, and thus rotate it over and over. Logs indicate that `getApiTokenForUserID` returns an error even if Humio logs indicate that the api token was rotated. To make this more clear, this includes information about what error happened when we try to rotate the api token, and also a few log statements to help understand when we flip between using the different API tokens.