### PR TITLE
Anchor variables to root scope in range template

### DIFF
--- a/charts/humio-operator/templates/operator-rbac.yaml
+++ b/charts/humio-operator/templates/operator-rbac.yaml
@@ -97,7 +97,7 @@ rules:
   - patch
   - update
   - watch
-{{- if .Values.operator.rbac.allowManageRoles }}
+{{- if $.Values.operator.rbac.allowManageRoles }}
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -124,7 +124,7 @@ rules:
   - patch
   - update
   - watch
-{{- if .Values.certmanager }}
+{{- if $.Values.certmanager }}
 - apiGroups:
   - cert-manager.io
   resources:


### PR DESCRIPTION
If `operator.watchNamespaces` is not empty the operator-rbac.yaml has a `range` template for each namespace. The variables inside are scoped to the `watchNamespaces` variable rather than the root which causes exceptions from the Go parser.

    Error: template: humio-operator/templates/operator-rbac.yaml:100:14: executing "humio-operator/templates/operator-rbac.yaml" at <.Values.operator.rbac.allowManageRoles>: can't evaluate field Values in type interface {}