### PR TITLE
Refactor Helm chart resources

### DIFF
--- a/charts/humio-operator/templates/_helpers.tpl
+++ b/charts/humio-operator/templates/_helpers.tpl
@@ -1,6 +1,29 @@
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "humio.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- define "operator.chart" -}}
+  {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Name of the operator which is used to construct operator.fullname.
+*/}}
+{{- define "operator.name" -}}
+  {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Construct fullname used to name resources created by the chart.
+*/}}
+{{- define "operator.fullname" -}}
+  {{- if .Values.fullnameOverride -}}
+    {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+  {{- else -}}
+    {{- $name := default .Chart.Name .Values.nameOverride -}}
+    {{- if contains $name .Release.Name -}}
+      {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+    {{- else -}}
+      {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}

--- a/charts/humio-operator/templates/crds.yaml
+++ b/charts/humio-operator/templates/crds.yaml
@@ -9,11 +9,11 @@ metadata:
   creationTimestamp: null
   name: humioactions.core.humio.com
   labels:
-    app: '{{ .Chart.Name }}'
-    app.kubernetes.io/name: '{{ .Chart.Name }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    helm.sh/chart: '{{ template "humio.chart" . }}'
+    app: {{ .Chart.Name }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "operator.chart" . }}
 spec:
   group: core.humio.com
   names:
@@ -259,11 +259,11 @@ metadata:
   creationTimestamp: null
   name: humioalerts.core.humio.com
   labels:
-    app: '{{ .Chart.Name }}'
-    app.kubernetes.io/name: '{{ .Chart.Name }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    helm.sh/chart: '{{ template "humio.chart" . }}'
+    app: {{ .Chart.Name }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "operator.chart" . }}
 spec:
   group: core.humio.com
   names:
@@ -387,11 +387,11 @@ metadata:
   creationTimestamp: null
   name: humioclusters.core.humio.com
   labels:
-    app: '{{ .Chart.Name }}'
-    app.kubernetes.io/name: '{{ .Chart.Name }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    helm.sh/chart: '{{ template "humio.chart" . }}'
+    app: {{ .Chart.Name }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "operator.chart" . }}
 spec:
   group: core.humio.com
   names:
@@ -13956,11 +13956,11 @@ metadata:
   creationTimestamp: null
   name: humioexternalclusters.core.humio.com
   labels:
-    app: '{{ .Chart.Name }}'
-    app.kubernetes.io/name: '{{ .Chart.Name }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    helm.sh/chart: '{{ template "humio.chart" . }}'
+    app: {{ .Chart.Name }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "operator.chart" . }}
 spec:
   group: core.humio.com
   names:
@@ -14049,11 +14049,11 @@ metadata:
   creationTimestamp: null
   name: humioingesttokens.core.humio.com
   labels:
-    app: '{{ .Chart.Name }}'
-    app.kubernetes.io/name: '{{ .Chart.Name }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    helm.sh/chart: '{{ template "humio.chart" . }}'
+    app: {{ .Chart.Name }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "operator.chart" . }}
 spec:
   group: core.humio.com
   names:
@@ -14153,11 +14153,11 @@ metadata:
   creationTimestamp: null
   name: humioparsers.core.humio.com
   labels:
-    app: '{{ .Chart.Name }}'
-    app.kubernetes.io/name: '{{ .Chart.Name }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    helm.sh/chart: '{{ template "humio.chart" . }}'
+    app: {{ .Chart.Name }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "operator.chart" . }}
 spec:
   group: core.humio.com
   names:
@@ -14253,11 +14253,11 @@ metadata:
   creationTimestamp: null
   name: humiorepositories.core.humio.com
   labels:
-    app: '{{ .Chart.Name }}'
-    app.kubernetes.io/name: '{{ .Chart.Name }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    helm.sh/chart: '{{ template "humio.chart" . }}'
+    app: {{ .Chart.Name }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "operator.chart" . }}
 spec:
   group: core.humio.com
   names:
@@ -14360,11 +14360,11 @@ metadata:
   creationTimestamp: null
   name: humioviews.core.humio.com
   labels:
-    app: '{{ .Chart.Name }}'
-    app.kubernetes.io/name: '{{ .Chart.Name }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    helm.sh/chart: '{{ template "humio.chart" . }}'
+    app: {{ .Chart.Name }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "operator.chart" . }}
 spec:
   group: core.humio.com
   names:

--- a/charts/humio-operator/templates/operator-deployment.yaml
+++ b/charts/humio-operator/templates/operator-deployment.yaml
@@ -1,27 +1,27 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
   annotations:
     productID: "none"
     productName: "humio-operator"
     productVersion: {{ .Values.operator.image.tag | quote }}
   labels:
-    app: '{{ .Chart.Name }}'
-    app.kubernetes.io/name: '{{ .Chart.Name }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    helm.sh/chart: '{{ template "humio.chart" . }}'
+    app: {{ .Chart.Name }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "operator.chart" . }}
 spec:
   replicas: 1
   strategy:
     type: Recreate
   selector:
     matchLabels:
-      app: '{{ .Chart.Name }}'
-      app.kubernetes.io/name: '{{ .Chart.Name }}'
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
+      app: {{ .Chart.Name }}
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       annotations:
@@ -32,11 +32,11 @@ spec:
         {{- toYaml .Values.operator.podAnnotations | nindent 8 }}
 {{- end }}
       labels:
-        app: '{{ .Chart.Name }}'
-        app.kubernetes.io/name: '{{ .Chart.Name }}'
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-        helm.sh/chart: '{{ template "humio.chart" . }}'
+        app: {{ .Chart.Name }}
+        app.kubernetes.io/name: {{ .Chart.Name }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        helm.sh/chart: {{ template "operator.chart" . }}
     spec:
 {{- with .Values.operator.image.pullSecrets }}
       imagePullSecrets:
@@ -51,12 +51,11 @@ spec:
                 operator: In
                 values:
                 - amd64
-            - matchExpressions:
               - key: kubernetes.io/os
                 operator: In
                 values:
                 - linux
-      serviceAccountName: {{ .Release.Name }}
+      serviceAccountName: {{ include "operator.fullname" . }}
       containers:
       - name: humio-operator
         image: {{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag }}
@@ -70,13 +69,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: OPERATOR_NAME
-          value: "humio-operator"
         - name: USE_CERTMANAGER
           value: {{ .Values.certmanager | quote }}
 {{- if .Values.openshift }}
         - name: OPENSHIFT_SCC_NAME
-          value: '{{ default "default" .Release.Namespace }}-{{ .Release.Name }}'
+          value: {{ include "operator.fullname" . }}-{{ default "default" .Release.Namespace }}
 {{- end }}
         livenessProbe:
           httpGet:

--- a/charts/humio-operator/templates/operator-rbac.yaml
+++ b/charts/humio-operator/templates/operator-rbac.yaml
@@ -3,28 +3,28 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: '{{ .Release.Name }}'
-  namespace: '{{ default "default" .Release.Namespace }}'
+  name: {{ include "operator.fullname" . }}
+  namespace: {{ default "default" .Release.Namespace }}
   labels:
-    app: '{{ .Chart.Name }}'
-    app.kubernetes.io/name: '{{ .Chart.Name }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    helm.sh/chart: '{{ template "humio.chart" . }}'
+    app: {{ .Chart.Name }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "operator.chart" . }}
 
 {{- range .Values.operator.watchNamespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: '{{ $.Release.Name }}'
-  namespace: '{{ . }}'
+  name: {{ include "operator.fullname" . }}
+  namespace: {{ . }}
   labels:
-    app: '{{ $.Chart.Name }}'
-    app.kubernetes.io/name: '{{ $.Chart.Name }}'
-    app.kubernetes.io/instance: '{{ $.Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ $.Release.Service }}'
-    helm.sh/chart: '{{ template "humio.chart" $ }}'
+    app: {{ $.Chart.Name }}
+    app.kubernetes.io/name: {{ $.Chart.Name }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    helm.sh/chart: {{ template "operator.chart" $ }}
 rules:
 - apiGroups:
   - ""
@@ -144,21 +144,21 @@ verbs:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: '{{ $.Release.Name }}'
-  namespace: '{{ . }}'
+  name: {{ $.Release.Name }}
+  namespace: {{ . }}
   labels:
-    app: '{{ $.Chart.Name }}'
-    app.kubernetes.io/name: '{{ $.Chart.Name }}'
-    app.kubernetes.io/instance: '{{ $.Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ $.Release.Service }}'
-    helm.sh/chart: '{{ template "humio.chart" $ }}'
+    app: {{ $.Chart.Name }}
+    app.kubernetes.io/name: {{ $.Chart.Name }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    helm.sh/chart: {{ template "operator.chart" $ }}
 subjects:
 - kind: ServiceAccount
-  name: '{{ $.Release.Name }}'
-  namespace: '{{ default "default" $.Release.Namespace }}'
+  name: {{ include "operator.fullname" . }}
+  namespace: {{ default "default" $.Release.Namespace }}
 roleRef:
   kind: Role
-  name: '{{ $.Release.Name }}'
+  name: {{ include "operator.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 
 {{- end }}
@@ -166,13 +166,13 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ default "default" .Release.Namespace }}-{{ .Release.Name }}'
+  name: {{ include "operator.fullname" . }}-{{ default "default" .Release.Namespace }}
   labels:
-    app: '{{ .Chart.Name }}'
-    app.kubernetes.io/name: '{{ .Chart.Name }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    helm.sh/chart: '{{ template "humio.chart" . }}'
+    app: {{ .Chart.Name }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "operator.chart" . }}
 rules:
 {{- if not .Values.operator.watchNamespaces }}
 - apiGroups:
@@ -322,7 +322,7 @@ rules:
 - apiGroups:
   - security.openshift.io
   resourceNames:
-  - '{{ default "default" .Release.Namespace }}-{{ .Release.Name }}'
+  - {{ include "operator.fullname" . }}-{{ default "default" .Release.Namespace }}
   resources:
   - securitycontextconstraints
   verbs:
@@ -343,20 +343,20 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: '{{ default "default" .Release.Namespace }}-{{ .Release.Name }}'
+  name: {{ include "operator.fullname" . }}-{{ default "default" .Release.Namespace }}
   labels:
-    app: '{{ .Chart.Name }}'
-    app.kubernetes.io/name: '{{ .Chart.Name }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    helm.sh/chart: '{{ template "humio.chart" . }}'
+    app: {{ .Chart.Name }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "operator.chart" . }}
 subjects:
 - kind: ServiceAccount
-  name: '{{ .Release.Name }}'
-  namespace: '{{ default "default" .Release.Namespace }}'
+  name: {{ include "operator.fullname" . }}
+  namespace: {{ default "default" .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: '{{ default "default" .Release.Namespace }}-{{ .Release.Name }}'
+  name: {{ include "operator.fullname" . }}-{{ default "default" .Release.Namespace }}
   apiGroup: rbac.authorization.k8s.io
 
 {{- if .Values.openshift }}
@@ -364,13 +364,13 @@ roleRef:
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
-  name: '{{ default "default" .Release.Namespace }}-{{ .Release.Name }}'
+  name: {{ include "operator.fullname" . }}-{{ default "default" .Release.Namespace }}
   labels:
-    app: '{{ .Chart.Name }}'
-    app.kubernetes.io/name: '{{ .Chart.Name }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    helm.sh/chart: '{{ template "humio.chart" . }}'
+    app: {{ .Chart.Name }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "operator.chart" . }}
 allowPrivilegedContainer: true
 allowHostDirVolumePlugin: true
 allowHostIPC: false

--- a/charts/humio-operator/templates/operator-service.yaml
+++ b/charts/humio-operator/templates/operator-service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: '{{ .Release.Name }}'
-  namespace: '{{ .Release.Namespace }}'
+  name: {{ include "operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
-    app: '{{ .Chart.Name }}'
-    app.kubernetes.io/name: '{{ .Chart.Name }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app: {{ .Chart.Name }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   ports:
   - name: metrics
@@ -14,6 +14,6 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    app: '{{ .Chart.Name }}'
-    app.kubernetes.io/name: '{{ .Chart.Name }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app: {{ .Chart.Name }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/humio-operator/templates/operator-servicemonitor.yaml
+++ b/charts/humio-operator/templates/operator-servicemonitor.yaml
@@ -2,22 +2,22 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: '{{ .Release.Name }}'
-  namespace: '{{ .Release.Namespace }}'
+  name: {{ include "operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
-    app: '{{ .Chart.Name }}'
-    app.kubernetes.io/name: '{{ .Chart.Name }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app: {{ .Chart.Name }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   selector:
     matchLabels:
-      app: '{{ .Chart.Name }}'
-      app.kubernetes.io/name: '{{ .Chart.Name }}'
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
+      app: {{ .Chart.Name }}
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   endpoints:
   - port: metrics
     path: /metrics
   namespaceSelector:
     matchNames:
-    - '{{ .Release.Namespace }}'
+    - {{ .Release.Namespace }}
 {{- end }}

--- a/config/crd/bases/core.humio.com_humioactions.yaml
+++ b/config/crd/bases/core.humio.com_humioactions.yaml
@@ -8,11 +8,11 @@ metadata:
   creationTimestamp: null
   name: humioactions.core.humio.com
   labels:
-    app: 'humio-operator'
-    app.kubernetes.io/name: 'humio-operator'
-    app.kubernetes.io/instance: 'humio-operator'
-    app.kubernetes.io/managed-by: 'Helm'
-    helm.sh/chart: 'humio-operator-0.14.1'
+    app: humio-operator
+    app.kubernetes.io/name: humio-operator
+    app.kubernetes.io/instance: humio-operator
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: humio-operator-0.14.1
 spec:
   group: core.humio.com
   names:

--- a/config/crd/bases/core.humio.com_humioalerts.yaml
+++ b/config/crd/bases/core.humio.com_humioalerts.yaml
@@ -8,11 +8,11 @@ metadata:
   creationTimestamp: null
   name: humioalerts.core.humio.com
   labels:
-    app: 'humio-operator'
-    app.kubernetes.io/name: 'humio-operator'
-    app.kubernetes.io/instance: 'humio-operator'
-    app.kubernetes.io/managed-by: 'Helm'
-    helm.sh/chart: 'humio-operator-0.14.1'
+    app: humio-operator
+    app.kubernetes.io/name: humio-operator
+    app.kubernetes.io/instance: humio-operator
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: humio-operator-0.14.1
 spec:
   group: core.humio.com
   names:

--- a/config/crd/bases/core.humio.com_humioclusters.yaml
+++ b/config/crd/bases/core.humio.com_humioclusters.yaml
@@ -8,11 +8,11 @@ metadata:
   creationTimestamp: null
   name: humioclusters.core.humio.com
   labels:
-    app: 'humio-operator'
-    app.kubernetes.io/name: 'humio-operator'
-    app.kubernetes.io/instance: 'humio-operator'
-    app.kubernetes.io/managed-by: 'Helm'
-    helm.sh/chart: 'humio-operator-0.14.1'
+    app: humio-operator
+    app.kubernetes.io/name: humio-operator
+    app.kubernetes.io/instance: humio-operator
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: humio-operator-0.14.1
 spec:
   group: core.humio.com
   names:

--- a/config/crd/bases/core.humio.com_humioexternalclusters.yaml
+++ b/config/crd/bases/core.humio.com_humioexternalclusters.yaml
@@ -8,11 +8,11 @@ metadata:
   creationTimestamp: null
   name: humioexternalclusters.core.humio.com
   labels:
-    app: 'humio-operator'
-    app.kubernetes.io/name: 'humio-operator'
-    app.kubernetes.io/instance: 'humio-operator'
-    app.kubernetes.io/managed-by: 'Helm'
-    helm.sh/chart: 'humio-operator-0.14.1'
+    app: humio-operator
+    app.kubernetes.io/name: humio-operator
+    app.kubernetes.io/instance: humio-operator
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: humio-operator-0.14.1
 spec:
   group: core.humio.com
   names:

--- a/config/crd/bases/core.humio.com_humioingesttokens.yaml
+++ b/config/crd/bases/core.humio.com_humioingesttokens.yaml
@@ -8,11 +8,11 @@ metadata:
   creationTimestamp: null
   name: humioingesttokens.core.humio.com
   labels:
-    app: 'humio-operator'
-    app.kubernetes.io/name: 'humio-operator'
-    app.kubernetes.io/instance: 'humio-operator'
-    app.kubernetes.io/managed-by: 'Helm'
-    helm.sh/chart: 'humio-operator-0.14.1'
+    app: humio-operator
+    app.kubernetes.io/name: humio-operator
+    app.kubernetes.io/instance: humio-operator
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: humio-operator-0.14.1
 spec:
   group: core.humio.com
   names:

--- a/config/crd/bases/core.humio.com_humioparsers.yaml
+++ b/config/crd/bases/core.humio.com_humioparsers.yaml
@@ -8,11 +8,11 @@ metadata:
   creationTimestamp: null
   name: humioparsers.core.humio.com
   labels:
-    app: 'humio-operator'
-    app.kubernetes.io/name: 'humio-operator'
-    app.kubernetes.io/instance: 'humio-operator'
-    app.kubernetes.io/managed-by: 'Helm'
-    helm.sh/chart: 'humio-operator-0.14.1'
+    app: humio-operator
+    app.kubernetes.io/name: humio-operator
+    app.kubernetes.io/instance: humio-operator
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: humio-operator-0.14.1
 spec:
   group: core.humio.com
   names:

--- a/config/crd/bases/core.humio.com_humiorepositories.yaml
+++ b/config/crd/bases/core.humio.com_humiorepositories.yaml
@@ -8,11 +8,11 @@ metadata:
   creationTimestamp: null
   name: humiorepositories.core.humio.com
   labels:
-    app: 'humio-operator'
-    app.kubernetes.io/name: 'humio-operator'
-    app.kubernetes.io/instance: 'humio-operator'
-    app.kubernetes.io/managed-by: 'Helm'
-    helm.sh/chart: 'humio-operator-0.14.1'
+    app: humio-operator
+    app.kubernetes.io/name: humio-operator
+    app.kubernetes.io/instance: humio-operator
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: humio-operator-0.14.1
 spec:
   group: core.humio.com
   names:

--- a/config/crd/bases/core.humio.com_humioviews.yaml
+++ b/config/crd/bases/core.humio.com_humioviews.yaml
@@ -8,11 +8,11 @@ metadata:
   creationTimestamp: null
   name: humioviews.core.humio.com
   labels:
-    app: 'humio-operator'
-    app.kubernetes.io/name: 'humio-operator'
-    app.kubernetes.io/instance: 'humio-operator'
-    app.kubernetes.io/managed-by: 'Helm'
-    helm.sh/chart: 'humio-operator-0.14.1'
+    app: humio-operator
+    app.kubernetes.io/name: humio-operator
+    app.kubernetes.io/instance: humio-operator
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: humio-operator-0.14.1
 spec:
   group: core.humio.com
   names:

--- a/hack/gen-crds.sh
+++ b/hack/gen-crds.sh
@@ -13,17 +13,17 @@ for c in $(find config/crd/bases/ -iname '*.yaml' | sort); do
 
   # Update base CRD's in-place with static values
   if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    sed -i "/^spec:/i \  labels:\n    app: 'humio-operator'\n    app.kubernetes.io/name: 'humio-operator'\n    app.kubernetes.io/instance: 'humio-operator'\n    app.kubernetes.io/managed-by: 'Helm'\n    helm.sh/chart: 'humio-operator-$RELEASE_VERSION'" $c
+    sed -i "/^spec:/i \  labels:\n    app: humio-operator\n    app.kubernetes.io/name: humio-operator\n    app.kubernetes.io/instance: humio-operator\n    app.kubernetes.io/managed-by: Helm\n    helm.sh/chart: humio-operator-$RELEASE_VERSION" $c
   elif [[ "$OSTYPE" == "darwin"* ]]; then
     if [[ $(which gsed) ]]; then
-      gsed -i "/^spec:/i \  labels:\n    app: 'humio-operator'\n    app.kubernetes.io/name: 'humio-operator'\n    app.kubernetes.io/instance: 'humio-operator'\n    app.kubernetes.io/managed-by: 'Helm'\n    helm.sh/chart: 'humio-operator-$RELEASE_VERSION'" $c
+      gsed -i "/^spec:/i \  labels:\n    app: humio-operator\n    app.kubernetes.io/name: humio-operator\n    app.kubernetes.io/instance: humio-operator\n    app.kubernetes.io/managed-by: Helm\n    helm.sh/chart: humio-operator-$RELEASE_VERSION" $c
     else
       sed -i '' -E '/^spec:/i\ '$'\n''\  labels:'$'\n' $c
-      sed -i '' -E '/^spec:/i\ '$'\n''\    app: '"'humio-operator'"$'\n' $c
-      sed -i '' -E '/^spec:/i\ '$'\n''\    app.kubernetes.io/name: '"'humio-operator'"$'\n' $c
-      sed -i '' -E '/^spec:/i\ '$'\n''\    app.kubernetes.io/instance: '"'humio-operator'"$'\n' $c
-      sed -i '' -E '/^spec:/i\ '$'\n''\    app.kubernetes.io/managed-by: '"'Helm'"$'\n' $c
-      sed -i '' -E '/^spec:/i\ '$'\n''\    helm.sh/chart: '"'humio-operator-$RELEASE_VERSION'"$'\n' $c
+      sed -i '' -E '/^spec:/i\ '$'\n''\    app: '"humio-operator"$'\n' $c
+      sed -i '' -E '/^spec:/i\ '$'\n''\    app.kubernetes.io/name: '"humio-operator"$'\n' $c
+      sed -i '' -E '/^spec:/i\ '$'\n''\    app.kubernetes.io/instance: '"humio-operator"$'\n' $c
+      sed -i '' -E '/^spec:/i\ '$'\n''\    app.kubernetes.io/managed-by: '"Helm"$'\n' $c
+      sed -i '' -E '/^spec:/i\ '$'\n''\    helm.sh/chart: '"humio-operator-$RELEASE_VERSION"$'\n' $c
     fi
   else
     echo "$OSTYPE not supported"
@@ -34,17 +34,17 @@ echo "{{- end }}" >> charts/humio-operator/templates/crds.yaml
 
 # Update helm chart CRD's with additional chart install values.
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-	sed -i "/^spec:/i \  labels:\n    app: '{{ .Chart.Name }}'\n    app.kubernetes.io/name: '{{ .Chart.Name }}'\n    app.kubernetes.io/instance: '{{ .Release.Name }}'\n    app.kubernetes.io/managed-by: '{{ .Release.Service }}'\n    helm.sh/chart: '{{ template \"humio.chart\" . }}'" charts/humio-operator/templates/crds.yaml
+	sed -i "/^spec:/i \  labels:\n    app: {{ .Chart.Name }}\n    app.kubernetes.io/name: {{ .Chart.Name }}\n    app.kubernetes.io/instance: {{ .Release.Name }}\n    app.kubernetes.io/managed-by: {{ .Release.Service }}\n    helm.sh/chart: {{ template \"operator.chart\" . }}" charts/humio-operator/templates/crds.yaml
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   if [[ $(which gsed) ]]; then
-	  gsed -i "/^spec:/i \  labels:\n    app: '{{ .Chart.Name }}'\n    app.kubernetes.io/name: '{{ .Chart.Name }}'\n    app.kubernetes.io/instance: '{{ .Release.Name }}'\n    app.kubernetes.io/managed-by: '{{ .Release.Service }}'\n    helm.sh/chart: '{{ template \"humio.chart\" . }}'" charts/humio-operator/templates/crds.yaml
+	  gsed -i "/^spec:/i \  labels:\n    app: {{ .Chart.Name }}\n    app.kubernetes.io/name: {{ .Chart.Name }}\n    app.kubernetes.io/instance: {{ .Release.Name }}\n    app.kubernetes.io/managed-by: {{ .Release.Service }}\n    helm.sh/chart: {{ template \"operator.chart\" . }}" charts/humio-operator/templates/crds.yaml
   else
     sed -i '' -E '/^spec:/i\ '$'\n''\  labels:'$'\n' charts/humio-operator/templates/crds.yaml
-    sed -i '' -E '/^spec:/i\ '$'\n''\    app: '"'{{ .Chart.Name }}'"$'\n' charts/humio-operator/templates/crds.yaml
-    sed -i '' -E '/^spec:/i\ '$'\n''\    app.kubernetes.io/name: '"'{{ .Chart.Name }}'"$'\n' charts/humio-operator/templates/crds.yaml
-    sed -i '' -E '/^spec:/i\ '$'\n''\    app.kubernetes.io/instance: '"'{{ .Release.Name }}'"$'\n' charts/humio-operator/templates/crds.yaml
-    sed -i '' -E '/^spec:/i\ '$'\n''\    app.kubernetes.io/managed-by: '"'{{ .Release.Service }}'"$'\n' charts/humio-operator/templates/crds.yaml
-    sed -i '' -E '/^spec:/i\ '$'\n''\    helm.sh/chart: '"'{{ template \"humio.chart\" . }}'"$'\n' charts/humio-operator/templates/crds.yaml
+    sed -i '' -E '/^spec:/i\ '$'\n''\    app: '"{{ .Chart.Name }}"$'\n' charts/humio-operator/templates/crds.yaml
+    sed -i '' -E '/^spec:/i\ '$'\n''\    app.kubernetes.io/name: '"{{ .Chart.Name }}"$'\n' charts/humio-operator/templates/crds.yaml
+    sed -i '' -E '/^spec:/i\ '$'\n''\    app.kubernetes.io/instance: '"{{ .Release.Name }}"$'\n' charts/humio-operator/templates/crds.yaml
+    sed -i '' -E '/^spec:/i\ '$'\n''\    app.kubernetes.io/managed-by: '"{{ .Release.Service }}"$'\n' charts/humio-operator/templates/crds.yaml
+    sed -i '' -E '/^spec:/i\ '$'\n''\    helm.sh/chart: '"{{ template \"operator.chart\" . }}"$'\n' charts/humio-operator/templates/crds.yaml
   fi
 else
   echo "$OSTYPE not supported"

--- a/hack/run-e2e-tests-crc.sh
+++ b/hack/run-e2e-tests-crc.sh
@@ -43,4 +43,4 @@ do
 done
 
 # We skip the helpers package as those tests assumes the environment variable USE_CERT_MANAGER is not set.
-OPENSHIFT_SCC_NAME=default-humio-operator KUBECONFIG=$tmp_kubeconfig USE_CERTMANAGER=true TEST_USE_EXISTING_CLUSTER=true $ginkgo -timeout 90m --skip-package helpers -v ./... -covermode=count -coverprofile cover.out -progress
+OPENSHIFT_SCC_NAME=release-name-humio-operator-default KUBECONFIG=$tmp_kubeconfig USE_CERTMANAGER=true TEST_USE_EXISTING_CLUSTER=true $ginkgo -timeout 90m --skip-package helpers -v ./... -covermode=count -coverprofile cover.out -progress


### PR DESCRIPTION
The main change here is to better generate resource names for the
resources created by installing the Helm chart.

This also removes the unnecessary single quote characters around values
in the YAML files, which makes syntax highlighting slightly better for
some editors.

Ideally we'd also change it so that the resource labels would use the
names that can now be overridden, but I'm leaving that out for now.
This also removes the `OPERATOR_NAME` environment variable from the
Deployment resource as we don't use it at all, but perhaps we should
later consider adding it back again and populating it e.g. `fullname`
such that any resources created by this operator installation would
create and only touch resources that it itself installed. This may make
it easier for us to better support running multiple operators on the
same Kubernetes cluster.

Fixes: https://github.com/humio/humio-operator/issues/574