### PR TITLE
Disable symbol table and DWARF generation

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -79,5 +79,8 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: docker tag
+      run: docker tag humio/humio-operator-helper:${{ env.RELEASE_VERSION }} humio/humio-operator-helper:${{ env.RELEASE_COMMIT }}
       - name: docker push
         run: make docker-push IMG=humio/humio-operator-helper:${{ env.RELEASE_VERSION }}
+        run: make docker-push IMG=humio/humio-operator-helper:${{ env.RELEASE_COMMIT }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -ldflags="-X 'main.version=$RELEASE_VERSION' -X 'main.commit=$RELEASE_COMMIT' -X 'main.date=$RELEASE_DATE'" -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -ldflags="-s -w -X 'main.version=$RELEASE_VERSION' -X 'main.commit=$RELEASE_COMMIT' -X 'main.date=$RELEASE_DATE'" -a -o manager main.go
 
 # Use ubi8 as base image to package the manager binary to comply with Red Hat image certification requirements
 FROM scratch

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ test: manifests generate fmt vet ginkgo ## Run tests.
 ##@ Build
 
 build: generate fmt vet ## Build manager binary.
-	go build -o bin/manager main.go
+	go build -ldflags="-s -w" -o bin/manager main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go

--- a/images/helper/Dockerfile
+++ b/images/helper/Dockerfile
@@ -6,7 +6,7 @@ ARG RELEASE_DATE=unknown
 
 WORKDIR /src
 COPY . /src
-RUN CGO_ENABLED=0 go build -ldflags="-X 'main.version=$RELEASE_VERSION' -X 'main.commit=$RELEASE_COMMIT' -X 'main.date=$RELEASE_DATE'" -o /app /src/*.go
+RUN CGO_ENABLED=0 go build -ldflags="-s -w -X 'main.version=$RELEASE_VERSION' -X 'main.commit=$RELEASE_COMMIT' -X 'main.date=$RELEASE_DATE'" -o /app /src/*.go
 
 FROM scratch
 


### PR DESCRIPTION
This helps cut down binary sizes. Quick tests showed the operator binary
drop from 48 MB to 35 MB.