### PR TITLE
Allow to change view's description

### DIFF
--- a/api/v1alpha1/humioview_types.go
+++ b/api/v1alpha1/humioview_types.go
@@ -51,6 +51,8 @@ type HumioViewSpec struct {
 	// Name is the name of the view inside Humio
 	Name string `json:"name,omitempty"`
 	// Connections contains the connections to the Humio repositories which is accessible in this view
+	// Description contains the description that will be set on this view
+	Description string `json:"description,omitempty"`
 	Connections []HumioViewConnection `json:"connections,omitempty"`
 }
 

--- a/api/v1alpha1/humioview_types.go
+++ b/api/v1alpha1/humioview_types.go
@@ -52,7 +52,7 @@ type HumioViewSpec struct {
 	Name string `json:"name,omitempty"`
 	// Connections contains the connections to the Humio repositories which is accessible in this view
 	// Description contains the description that will be set on this view
-	Description string `json:"description,omitempty"`
+	Description string                `json:"description,omitempty"`
 	Connections []HumioViewConnection `json:"connections,omitempty"`
 }
 

--- a/charts/humio-operator/templates/crds.yaml
+++ b/charts/humio-operator/templates/crds.yaml
@@ -14427,6 +14427,10 @@ spec:
               name:
                 description: Name is the name of the view inside Humio
                 type: string
+              description:
+                description: Description contains the description that will be set
+                  on this view
+                type: string
             type: object
           status:
             description: HumioViewStatus defines the observed state of HumioView

--- a/config/crd/bases/core.humio.com_humioviews.yaml
+++ b/config/crd/bases/core.humio.com_humioviews.yaml
@@ -75,6 +75,10 @@ spec:
               name:
                 description: Name is the name of the view inside Humio
                 type: string
+              description:
+                description: Description contains the description that will be set
+                  on this view
+                type: string
             type: object
           status:
             description: HumioViewStatus defines the observed state of HumioView

--- a/config/samples/core_v1alpha1_humioview.yaml
+++ b/config/samples/core_v1alpha1_humioview.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   managedClusterName: example-humiocluster
   name: "example-view"
+  description: "This is a view of many repositories"
   connections:
     - repositoryName: "example-repository"
       filter: "*"

--- a/controllers/humioview_controller.go
+++ b/controllers/humioview_controller.go
@@ -169,8 +169,8 @@ func (r *HumioViewReconciler) reconcileHumioView(ctx context.Context, config *hu
 	}
 
 	// Update View description
-	if viewDescriptionDiffer(curView.Description, hv.Description) {
-		r.Log.Info(fmt.Stringf("View description differs, triggering update."))
+	if viewDescriptionDiffer(curView.Description, hv.Spec.Description) {
+		r.Log.Info(fmt.Sprintf("View description differs, triggering update."))
 		_, err := r.HumioClient.UpdateView(config, req, hv)
 		if err != nil {
 			return reconcile.Result{}, r.logErrorAndReturn(err, "could not update view")

--- a/controllers/humioview_controller_test.go
+++ b/controllers/humioview_controller_test.go
@@ -120,3 +120,32 @@ func TestViewConnectionsDiffer(t *testing.T) {
 		})
 	}
 }
+
+func TestViewDescriptionDiffer(t *testing.T) {
+	tt := []struct {
+		name         string
+		current, new string
+		differ       bool
+	}{
+		{
+			name:    "no changes",
+			current: "Group of logs from all repositories",
+			new:     "Group of logs from all repositories",
+			differ:  false,
+		},
+		{
+			name:    "update description",
+			current: "Group of logs from all repositories",
+			new:     "Group of logs from multiple repositories",
+			differ:  true,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			result := viewDescriptionDiffer(tc.current, tc.new)
+			if result != tc.differ {
+				t.Errorf("viewDescriptionDiffer() got = %v, want %v", result, tc.differ)
+			}
+		})
+	}
+}

--- a/pkg/humio/client.go
+++ b/pkg/humio/client.go
@@ -440,6 +440,16 @@ func (h *ClientConfig) UpdateView(config *humioapi.Config, req reconcile.Request
 		return &humioapi.View{}, err
 	}
 
+	if curView.Description != hv.Spec.Description {
+		err = h.GetHumioClient(config, req).Views().UpdateDescription(
+			hv.Spec.Name,
+			hv.Spec.Description,
+		)
+		if err != nil {
+			return &humioapi.View{}, err
+		}
+	}
+
 	connections := hv.GetViewConnections()
 	if reflect.DeepEqual(curView.Connections, connections) {
 		return h.GetView(config, req, hv)


### PR DESCRIPTION
Signed-off-by: Nam Hai Nguyen <namhai.nguyen-ext@commercetools.com>

I'd like to use Humio operator to change a view's description. This action should be similar to changing a repo's description.