### PR TITLE
feat: Use Helm 3 best practice for CRD creation

### DIFF
--- a/charts/humio-operator/templates/crds.yaml
+++ b/charts/humio-operator/templates/crds.yaml
@@ -1,5 +1,3 @@
-{{- if .Values.installCRDs -}}
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -14457,4 +14455,3 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end }}

--- a/charts/humio-operator/values.yaml
+++ b/charts/humio-operator/values.yaml
@@ -20,6 +20,5 @@ operator:
       memory: 200Mi
   watchNamespaces: []
   podAnnotations: {}
-installCRDs: false
 openshift: false
 certmanager: true

--- a/hack/gen-crds.sh
+++ b/hack/gen-crds.sh
@@ -6,7 +6,6 @@ echo "detected OSTYPE = $OSTYPE"
 
 export RELEASE_VERSION=$(cat VERSION)
 
-echo "{{- if .Values.installCRDs -}}" > charts/humio-operator/templates/crds.yaml
 for c in $(find config/crd/bases/ -iname '*.yaml' | sort); do
   # Write base CRD to helm chart file
   cat $c >> charts/humio-operator/templates/crds.yaml
@@ -30,7 +29,6 @@ for c in $(find config/crd/bases/ -iname '*.yaml' | sort); do
     exit 1
   fi
 done
-echo "{{- end }}" >> charts/humio-operator/templates/crds.yaml
 
 # Update helm chart CRD's with additional chart install values.
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then

--- a/hack/test-helm-chart-crc.sh
+++ b/hack/test-helm-chart-crc.sh
@@ -59,7 +59,6 @@ $kubectl create namespace $operator_namespace
 helm upgrade --install humio-operator $helm_chart_dir \
   --namespace $operator_namespace \
   --set operator.image.tag=local-$git_rev \
-  --set installCRDs=true \
   --set openshift=true \
   --values $helm_chart_dir/$helm_chart_values_file
 

--- a/hack/test-helm-chart-kind-shared-serviceaccount-linkerd.sh
+++ b/hack/test-helm-chart-kind-shared-serviceaccount-linkerd.sh
@@ -61,7 +61,6 @@ $kubectl create namespace $operator_namespace
 helm upgrade --install humio-operator $helm_chart_dir \
   --namespace $operator_namespace \
   --set operator.image.tag=local-$git_rev \
-  --set installCRDs=true \
   --values $helm_chart_dir/$helm_chart_values_file
 
 # Install linkerd and verify the control plane is up and running

--- a/hack/test-helm-chart-kind.sh
+++ b/hack/test-helm-chart-kind.sh
@@ -56,7 +56,6 @@ $kubectl create namespace $operator_namespace
 helm upgrade --install humio-operator $helm_chart_dir \
   --namespace $operator_namespace \
   --set operator.image.tag=${operator_image_tag} \
-  --set installCRDs=true \
   --values $helm_chart_dir/$helm_chart_values_file
 
 


### PR DESCRIPTION
Helm3 creates CRD records first which can be skipped using --skipCRDs flag the current method used in the helm chart is based on a defunct Helm2 best practice

Signed-off-by: Ryan Faircloth <ryan@dss-i.com>