### PR TITLE
feat: Change container names in pod

### DIFF
--- a/controllers/humiocluster_defaults.go
+++ b/controllers/humiocluster_defaults.go
@@ -46,8 +46,8 @@ const (
 	ViewGroupPermissionsFilename = "view-group-permissions.json"
 	nodeUUIDPrefix               = "humio_"
 	HumioContainerName           = "humio"
-	AuthContainerName            = "auth"
-	InitContainerName            = "init"
+	AuthContainerName            = "humio-auth"
+	InitContainerName            = "humio-init"
 
 	// cluster-wide resources:
 	initClusterRoleSuffix        = "init"


### PR DESCRIPTION
original names "init" and "auth" are generic its common to prefer names that a unique and meaningful.