### PR TITLE
fix: NET_BIND_SERVICE is not required for operator deployment

### DIFF
--- a/charts/humio-operator/templates/operator-deployment.yaml
+++ b/charts/humio-operator/templates/operator-deployment.yaml
@@ -97,8 +97,6 @@ spec:
           runAsNonRoot: true
           runAsUser: 65534
           capabilities:
-            add:
-            - NET_BIND_SERVICE
             drop:
             - ALL
       securityContext:


### PR DESCRIPTION
NET_BIND_SERVICE allows the container to open privileged ports i.e <1024 the container does not actually do this so it is not required