### PR TITLE
fix: runAsNonRoot should be container specific not pod

### DIFF
--- a/charts/humio-operator/templates/operator-deployment.yaml
+++ b/charts/humio-operator/templates/operator-deployment.yaml
@@ -101,5 +101,4 @@ spec:
             - NET_BIND_SERVICE
             drop:
             - ALL
-      securityContext:
-        runAsNonRoot: true
+          runAsNonRoot: true

--- a/charts/humio-operator/templates/operator-deployment.yaml
+++ b/charts/humio-operator/templates/operator-deployment.yaml
@@ -97,8 +97,6 @@ spec:
           runAsNonRoot: true
           runAsUser: 65534
           capabilities:
-            add:
-            - NET_BIND_SERVICE
             drop:
             - ALL
           runAsNonRoot: true

--- a/charts/humio-operator/templates/operator-rbac.yaml
+++ b/charts/humio-operator/templates/operator-rbac.yaml
@@ -379,9 +379,8 @@ allowHostPID: false
 allowHostPorts: false
 priority: 0
 allowedCapabilities:
-- NET_BIND_SERVICE
 - SYS_NICE
-readOnlyRootFilesystem: false
+readOnlyRootFilesystem: true
 requiredDropCapabilities:
 - KILL
 - MKNOD

--- a/controllers/humiocluster_defaults.go
+++ b/controllers/humiocluster_defaults.go
@@ -439,7 +439,6 @@ func (hnp HumioNodePool) GetContainerSecurityContext() *corev1.SecurityContext {
 			RunAsNonRoot:             helpers.BoolPtr(true),
 			Capabilities: &corev1.Capabilities{
 				Add: []corev1.Capability{
-					"NET_BIND_SERVICE",
 					"SYS_NICE",
 				},
 				Drop: []corev1.Capability{

--- a/controllers/suite/clusters/suite_test.go
+++ b/controllers/suite/clusters/suite_test.go
@@ -290,7 +290,6 @@ var _ = BeforeSuite(func() {
 					"SETGID",
 				},
 				AllowedCapabilities: []corev1.Capability{
-					"NET_BIND_SERVICE",
 					"SYS_NICE",
 				},
 				AllowHostDirVolumePlugin: true,

--- a/controllers/suite/resources/suite_test.go
+++ b/controllers/suite/resources/suite_test.go
@@ -271,7 +271,6 @@ var _ = BeforeSuite(func() {
 					"SETGID",
 				},
 				AllowedCapabilities: []corev1.Capability{
-					"NET_BIND_SERVICE",
 					"SYS_NICE",
 				},
 				AllowHostDirVolumePlugin: true,


### PR DESCRIPTION
It is possible some injected containers may require root move this setting to the humio-operator container