### PR TITLE
remove duplicate value in operator deploy

### DIFF
--- a/charts/humio-operator/templates/operator-deployment.yaml
+++ b/charts/humio-operator/templates/operator-deployment.yaml
@@ -99,4 +99,3 @@ spec:
           capabilities:
             drop:
             - ALL
-          runAsNonRoot: true


### PR DESCRIPTION
There is a duplicate value "runAsNonRoot: true" in the latest release.