### PR TITLE
fix: do not set ZOOKEEPER_URL_FOR_NODE_UUID unless ZOOKEEPER_URL is set

### DIFF
--- a/controllers/humiocluster_defaults.go
+++ b/controllers/humiocluster_defaults.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -388,7 +389,9 @@ func (hnp HumioNodePool) GetEnvironmentVariables() []corev1.EnvVar {
 		})
 	}
 
-	if EnvVarHasValue(hnp.humioNodeSpec.EnvironmentVariables, "USING_EPHEMERAL_DISKS", "true") {
+	// Starting with 1.70 this is not needed and should only be set if the URL is set
+	_, zk_url_present := os.LookupEnv("ZOOKEEPER_URL")
+	if EnvVarHasValue(hnp.humioNodeSpec.EnvironmentVariables, "USING_EPHEMERAL_DISKS", "true") && zk_url_present {
 		envDefaults = append(envDefaults, corev1.EnvVar{
 			Name:  "ZOOKEEPER_URL_FOR_NODE_UUID",
 			Value: "$(ZOOKEEPER_URL)",

--- a/controllers/humiocluster_pods.go
+++ b/controllers/humiocluster_pods.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"os"
 	"reflect"
 	"sort"
 	"strconv"
@@ -79,7 +80,11 @@ func ConstructContainerArgs(hnp *HumioNodePool, podEnvVars []corev1.EnvVar) ([]s
 		if err != nil {
 			return []string{""}, fmt.Errorf("unable to construct node UUID: %w", err)
 		}
-		shellCommands = append(shellCommands, fmt.Sprintf("export ZOOKEEPER_PREFIX_FOR_NODE_UUID=%s", nodeUUIDPrefix))
+		//Starting with 1.70 this is not needed and should only be set if the URL is set
+		_, zk_url_present := os.LookupEnv("ZOOKEEPER_URL_FOR_NODE_UUID")
+		if zk_url_present {
+			shellCommands = append(shellCommands, fmt.Sprintf("export ZOOKEEPER_PREFIX_FOR_NODE_UUID=%s", nodeUUIDPrefix))
+		}
 	}
 
 	if !hnp.InitContainerDisabled() {


### PR DESCRIPTION
Starting with Logscale 1.70 we no longer directly depend on zookeeper the vars are deprecated and should only be set when the URL is set to support transition