### PR TITLE
Change behavior of when we automatically append ZOOKEEPER_URL_FOR_NODE_UUID config

### DIFF
--- a/config/samples/core_v1alpha1_humiocluster.yaml
+++ b/config/samples/core_v1alpha1_humiocluster.yaml
@@ -11,7 +11,7 @@ spec:
   extraKafkaConfigs: "security.protocol=PLAINTEXT"
   tls:
     enabled: false
-  image: "humio/humio-core:1.56.3"
+  image: "humio/humio-core:1.70.0"
   nodeCount: 1
   targetReplicationFactor: 1
   environmentVariables:

--- a/config/samples/core_v1alpha1_humiocluster_shared_serviceaccount.yaml
+++ b/config/samples/core_v1alpha1_humiocluster_shared_serviceaccount.yaml
@@ -11,7 +11,7 @@ spec:
   extraKafkaConfigs: "security.protocol=PLAINTEXT"
   tls:
     enabled: false
-  image: "humio/humio-core:1.56.3"
+  image: "humio/humio-core:1.70.0"
   humioServiceAccountName: humio
   initServiceAccountName: humio
   authServiceAccountName: humio

--- a/controllers/humiocluster_defaults.go
+++ b/controllers/humiocluster_defaults.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -388,7 +389,9 @@ func (hnp HumioNodePool) GetEnvironmentVariables() []corev1.EnvVar {
 		})
 	}
 
-	if EnvVarHasValue(hnp.humioNodeSpec.EnvironmentVariables, "USING_EPHEMERAL_DISKS", "true") {
+	// Starting with 1.70 this is not needed and should only be set if the URL is set
+	_, zk_url_present := os.LookupEnv("ZOOKEEPER_URL")
+	if EnvVarHasValue(hnp.humioNodeSpec.EnvironmentVariables, "USING_EPHEMERAL_DISKS", "true") && zk_url_present {
 		envDefaults = append(envDefaults, corev1.EnvVar{
 			Name:  "ZOOKEEPER_URL_FOR_NODE_UUID",
 			Value: "$(ZOOKEEPER_URL)",

--- a/controllers/humiocluster_defaults.go
+++ b/controllers/humiocluster_defaults.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"fmt"
-	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -389,9 +388,8 @@ func (hnp HumioNodePool) GetEnvironmentVariables() []corev1.EnvVar {
 		})
 	}
 
-	// Starting with 1.70 this is not needed and should only be set if the URL is set
-	_, zk_url_present := os.LookupEnv("ZOOKEEPER_URL")
-	if EnvVarHasValue(hnp.humioNodeSpec.EnvironmentVariables, "USING_EPHEMERAL_DISKS", "true") && zk_url_present {
+	if EnvVarHasValue(hnp.humioNodeSpec.EnvironmentVariables, "USING_EPHEMERAL_DISKS", "true") &&
+		EnvVarHasKey(hnp.humioNodeSpec.EnvironmentVariables, "ZOOKEEPER_URL") {
 		envDefaults = append(envDefaults, corev1.EnvVar{
 			Name:  "ZOOKEEPER_URL_FOR_NODE_UUID",
 			Value: "$(ZOOKEEPER_URL)",

--- a/controllers/humiocluster_defaults.go
+++ b/controllers/humiocluster_defaults.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	Image                        = "humio/humio-core:1.56.3"
+	Image                        = "humio/humio-core:1.70.0"
 	HelperImage                  = "humio/humio-operator-helper:85bed4456d6eb580d655ad462afad1ec6e6aef22"
 	targetReplicationFactor      = 2
 	storagePartitionsCount       = 24

--- a/controllers/humiocluster_defaults_test.go
+++ b/controllers/humiocluster_defaults_test.go
@@ -194,15 +194,75 @@ func Test_constructContainerArgs(t *testing.T) {
 		fields fields
 	}{
 		{
-			"no cpu resource settings, ephemeral disks and init container",
+			"no cpu resource settings, ephemeral disks and init container, using zk and version 1.56.3",
 			fields{
 				&humiov1alpha1.HumioCluster{
 					Spec: humiov1alpha1.HumioClusterSpec{
 						HumioNodeSpec: humiov1alpha1.HumioNodeSpec{
+							Image: "humio/humio-core:1.56.3",
 							EnvironmentVariables: []corev1.EnvVar{
 								{
 									Name:  "USING_EPHEMERAL_DISKS",
 									Value: "true",
+								},
+								{
+									Name:  "ZOOKEEPER_URL",
+									Value: "dummy",
+								},
+							},
+						},
+					},
+				},
+				[]string{
+					"export CORES=",
+					"export HUMIO_OPTS=",
+					"export ZOOKEEPER_PREFIX_FOR_NODE_UUID=",
+					"export ZONE=",
+				},
+				[]string{},
+			},
+		},
+		{
+			"no cpu resource settings, ephemeral disks and init container, without zk and version 1.70.0",
+			fields{
+				&humiov1alpha1.HumioCluster{
+					Spec: humiov1alpha1.HumioClusterSpec{
+						HumioNodeSpec: humiov1alpha1.HumioNodeSpec{
+							Image: "humio/humio-core:1.70.0",
+							EnvironmentVariables: []corev1.EnvVar{
+								{
+									Name:  "USING_EPHEMERAL_DISKS",
+									Value: "true",
+								},
+							},
+						},
+					},
+				},
+				[]string{
+					"export CORES=",
+					"export HUMIO_OPTS=",
+					"export ZONE=",
+				},
+				[]string{
+					"export ZOOKEEPER_PREFIX_FOR_NODE_UUID=",
+				},
+			},
+		},
+		{
+			"no cpu resource settings, ephemeral disks and init container, using zk and version 1.70.0",
+			fields{
+				&humiov1alpha1.HumioCluster{
+					Spec: humiov1alpha1.HumioClusterSpec{
+						HumioNodeSpec: humiov1alpha1.HumioNodeSpec{
+							Image: "humio/humio-core:1.70.0",
+							EnvironmentVariables: []corev1.EnvVar{
+								{
+									Name:  "USING_EPHEMERAL_DISKS",
+									Value: "true",
+								},
+								{
+									Name:  "ZOOKEEPER_URL",
+									Value: "dummy",
 								},
 							},
 						},
@@ -227,6 +287,10 @@ func Test_constructContainerArgs(t *testing.T) {
 								{
 									Name:  "USING_EPHEMERAL_DISKS",
 									Value: "true",
+								},
+								{
+									Name:  "ZOOKEEPER_URL",
+									Value: "dummy",
 								},
 							},
 							Resources: corev1.ResourceRequirements{
@@ -258,6 +322,10 @@ func Test_constructContainerArgs(t *testing.T) {
 									Name:  "USING_EPHEMERAL_DISKS",
 									Value: "true",
 								},
+								{
+									Name:  "ZOOKEEPER_URL",
+									Value: "dummy",
+								},
 							},
 							DisableInitContainer: true,
 						},
@@ -283,6 +351,10 @@ func Test_constructContainerArgs(t *testing.T) {
 								{
 									Name:  "USING_EPHEMERAL_DISKS",
 									Value: "true",
+								},
+								{
+									Name:  "ZOOKEEPER_URL",
+									Value: "dummy",
 								},
 							},
 							DisableInitContainer: true,
@@ -400,6 +472,10 @@ func Test_constructContainerArgs(t *testing.T) {
 									Value: "true",
 								},
 								{
+									Name:  "ZOOKEEPER_URL",
+									Value: "dummy",
+								},
+								{
 									Name:  "CORES",
 									Value: "1",
 								},
@@ -427,6 +503,10 @@ func Test_constructContainerArgs(t *testing.T) {
 								{
 									Name:  "USING_EPHEMERAL_DISKS",
 									Value: "true",
+								},
+								{
+									Name:  "ZOOKEEPER_URL",
+									Value: "dummy",
 								},
 								{
 									Name:  "CORES",

--- a/controllers/humiocluster_defaults_test.go
+++ b/controllers/humiocluster_defaults_test.go
@@ -194,12 +194,11 @@ func Test_constructContainerArgs(t *testing.T) {
 		fields fields
 	}{
 		{
-			"no cpu resource settings, ephemeral disks and init container, using zk and version 1.56.3",
+			"no cpu resource settings, ephemeral disks and init container, using zk",
 			fields{
 				&humiov1alpha1.HumioCluster{
 					Spec: humiov1alpha1.HumioClusterSpec{
 						HumioNodeSpec: humiov1alpha1.HumioNodeSpec{
-							Image: "humio/humio-core:1.56.3",
 							EnvironmentVariables: []corev1.EnvVar{
 								{
 									Name:  "USING_EPHEMERAL_DISKS",
@@ -223,12 +222,11 @@ func Test_constructContainerArgs(t *testing.T) {
 			},
 		},
 		{
-			"no cpu resource settings, ephemeral disks and init container, without zk and version 1.70.0",
+			"no cpu resource settings, ephemeral disks and init container, without zk",
 			fields{
 				&humiov1alpha1.HumioCluster{
 					Spec: humiov1alpha1.HumioClusterSpec{
 						HumioNodeSpec: humiov1alpha1.HumioNodeSpec{
-							Image: "humio/humio-core:1.70.0",
 							EnvironmentVariables: []corev1.EnvVar{
 								{
 									Name:  "USING_EPHEMERAL_DISKS",
@@ -246,35 +244,6 @@ func Test_constructContainerArgs(t *testing.T) {
 				[]string{
 					"export ZOOKEEPER_PREFIX_FOR_NODE_UUID=",
 				},
-			},
-		},
-		{
-			"no cpu resource settings, ephemeral disks and init container, using zk and version 1.70.0",
-			fields{
-				&humiov1alpha1.HumioCluster{
-					Spec: humiov1alpha1.HumioClusterSpec{
-						HumioNodeSpec: humiov1alpha1.HumioNodeSpec{
-							Image: "humio/humio-core:1.70.0",
-							EnvironmentVariables: []corev1.EnvVar{
-								{
-									Name:  "USING_EPHEMERAL_DISKS",
-									Value: "true",
-								},
-								{
-									Name:  "ZOOKEEPER_URL",
-									Value: "dummy",
-								},
-							},
-						},
-					},
-				},
-				[]string{
-					"export CORES=",
-					"export HUMIO_OPTS=",
-					"export ZOOKEEPER_PREFIX_FOR_NODE_UUID=",
-					"export ZONE=",
-				},
-				[]string{},
 			},
 		},
 		{

--- a/controllers/humiocluster_pods.go
+++ b/controllers/humiocluster_pods.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"os"
 	"reflect"
 	"sort"
 	"strconv"
@@ -79,7 +80,11 @@ func ConstructContainerArgs(hnp *HumioNodePool, podEnvVars []corev1.EnvVar) ([]s
 		if err != nil {
 			return []string{""}, fmt.Errorf("unable to construct node UUID: %w", err)
 		}
-		shellCommands = append(shellCommands, fmt.Sprintf("export ZOOKEEPER_PREFIX_FOR_NODE_UUID=%s", nodeUUIDPrefix))
+		//Starting with 1.70 this is not needed and should only be set if the URL is set
+		_, zk_url_present := os.LookupEnv("ZOOKEEPER_URL_FOR_NODE_UUID")
+		if zk_url_present {
+			shellCommands = append(shellCommands, fmt.Sprintf("export ZOOKEEPER_PREFIX_FOR_NODE_UUID=%s", nodeUUIDPrefix))
+		}
 	}
 
 	if !hnp.InitContainerDisabled() {

--- a/controllers/humiocluster_pods.go
+++ b/controllers/humiocluster_pods.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
-	"os"
 	"reflect"
 	"sort"
 	"strconv"
@@ -80,9 +79,7 @@ func ConstructContainerArgs(hnp *HumioNodePool, podEnvVars []corev1.EnvVar) ([]s
 		if err != nil {
 			return []string{""}, fmt.Errorf("unable to construct node UUID: %w", err)
 		}
-		//Starting with 1.70 this is not needed and should only be set if the URL is set
-		_, zk_url_present := os.LookupEnv("ZOOKEEPER_URL_FOR_NODE_UUID")
-		if zk_url_present {
+		if EnvVarHasKey(podEnvVars, "ZOOKEEPER_URL") {
 			shellCommands = append(shellCommands, fmt.Sprintf("export ZOOKEEPER_PREFIX_FOR_NODE_UUID=%s", nodeUUIDPrefix))
 		}
 	}

--- a/controllers/humiocluster_version.go
+++ b/controllers/humiocluster_version.go
@@ -8,9 +8,10 @@ import (
 )
 
 const (
-	HumioVersionMinimumSupported   = "1.30.0"
-	HumioVersionWithLauncherScript = "1.32.0"
-	HumioVersionWithNewTmpDir      = "1.33.0"
+	HumioVersionMinimumSupported      = "1.30.0"
+	HumioVersionWithLauncherScript    = "1.32.0"
+	HumioVersionWithNewTmpDir         = "1.33.0"
+	HumioVersionWithNewVhostSelection = "1.70.0"
 )
 
 type HumioVersion struct {

--- a/controllers/suite/clusters/humiocluster_controller_test.go
+++ b/controllers/suite/clusters/humiocluster_controller_test.go
@@ -2267,7 +2267,7 @@ var _ = Describe("HumioCluster Controller", func() {
 	Context("Humio Cluster Container Arguments", func() {
 		It("Should correctly configure container arguments and ephemeral disks env var with deprecated zk node uuid", func() {
 			key := types.NamespacedName{
-				Name:      "humiocluster-container-args-deprecated-zk-uuid",
+				Name:      "humiocluster-container-args-zk-uuid",
 				Namespace: testProcessNamespace,
 			}
 			toCreate := suite.ConstructBasicSingleNodeHumioCluster(key, true)

--- a/controllers/suite/clusters/humiocluster_controller_test.go
+++ b/controllers/suite/clusters/humiocluster_controller_test.go
@@ -2378,10 +2378,17 @@ var _ = Describe("HumioCluster Controller", func() {
 			clusterPods, err := kubernetes.ListPods(ctx, k8sClient, key.Namespace, hnp.GetPodLabels())
 			Expect(err).ToNot(HaveOccurred())
 			humioIdx, _ := kubernetes.GetContainerIndexByName(clusterPods[0], controllers.HumioContainerName)
-			Expect(clusterPods[0].Spec.Containers[humioIdx].Env).To(ContainElement(corev1.EnvVar{
-				Name:  "ZOOKEEPER_URL_FOR_NODE_UUID",
-				Value: "$(ZOOKEEPER_URL)",
-			}))
+			if ok, _ := humioVersion.AtLeast(controllers.HumioVersionWithNewVhostSelection); !ok {
+				Expect(clusterPods[0].Spec.Containers[humioIdx].Env).To(ContainElement(corev1.EnvVar{
+					Name:  "ZOOKEEPER_URL_FOR_NODE_UUID",
+					Value: "$(ZOOKEEPER_URL)",
+				}))
+			} else {
+				Expect(clusterPods[0].Spec.Containers[humioIdx].Env).ToNot(ContainElement(corev1.EnvVar{
+					Name:  "ZOOKEEPER_URL_FOR_NODE_UUID",
+					Value: "$(ZOOKEEPER_URL)",
+				}))
+			}
 		})
 	})
 

--- a/controllers/suite/clusters/humiocluster_controller_test.go
+++ b/controllers/suite/clusters/humiocluster_controller_test.go
@@ -1383,7 +1383,7 @@ var _ = Describe("HumioCluster Controller", func() {
 			}
 			toCreate := suite.ConstructBasicSingleNodeHumioCluster(key, true)
 			toCreate.Spec.NodeCount = helpers.IntPtr(2)
-			toCreate.Spec.EnvironmentVariables = []corev1.EnvVar{
+			toCreate.Spec.EnvironmentVariables = suite.FilterZookeeperURLIfNeeded(controllers.NewHumioNodeManagerFromHumioCluster(toCreate).GetImage(), []corev1.EnvVar{
 				{
 					Name:  "test",
 					Value: "",
@@ -1408,7 +1408,7 @@ var _ = Describe("HumioCluster Controller", func() {
 					Name:  "ENABLE_IOC_SERVICE",
 					Value: "false",
 				},
-			}
+			})
 
 			humioVersion, _ := controllers.HumioVersionFromString(controllers.NewHumioNodeManagerFromHumioCluster(toCreate).GetImage())
 			if ok, _ := humioVersion.AtLeast(controllers.HumioVersionWithLauncherScript); ok {
@@ -1444,7 +1444,7 @@ var _ = Describe("HumioCluster Controller", func() {
 			}
 
 			suite.UsingClusterBy(key.Name, "Updating the environment variable successfully")
-			updatedEnvironmentVariables := []corev1.EnvVar{
+			updatedEnvironmentVariables := suite.FilterZookeeperURLIfNeeded(controllers.NewHumioNodeManagerFromHumioCluster(toCreate).GetImage(), []corev1.EnvVar{
 				{
 					Name:  "test",
 					Value: "update",
@@ -1469,7 +1469,7 @@ var _ = Describe("HumioCluster Controller", func() {
 					Name:  "ENABLE_IOC_SERVICE",
 					Value: "false",
 				},
-			}
+			})
 
 			humioVersion, _ = controllers.HumioVersionFromString(controllers.NewHumioNodeManagerFromHumioCluster(toCreate).GetImage())
 			if ok, _ := humioVersion.AtLeast(controllers.HumioVersionWithLauncherScript); ok {
@@ -1545,7 +1545,7 @@ var _ = Describe("HumioCluster Controller", func() {
 			toCreate := constructBasicMultiNodePoolHumioCluster(key, true, 1)
 			toCreate.Spec.NodeCount = helpers.IntPtr(1)
 			toCreate.Spec.NodePools[0].NodeCount = helpers.IntPtr(1)
-			toCreate.Spec.EnvironmentVariables = []corev1.EnvVar{
+			toCreate.Spec.EnvironmentVariables = suite.FilterZookeeperURLIfNeeded(controllers.NewHumioNodeManagerFromHumioCluster(toCreate).GetImage(), []corev1.EnvVar{
 				{
 					Name:  "test",
 					Value: "",
@@ -1574,8 +1574,8 @@ var _ = Describe("HumioCluster Controller", func() {
 					Name:  "ENABLE_IOC_SERVICE",
 					Value: "false",
 				},
-			}
-			toCreate.Spec.NodePools[0].EnvironmentVariables = []corev1.EnvVar{
+			})
+			toCreate.Spec.NodePools[0].EnvironmentVariables = suite.FilterZookeeperURLIfNeeded(controllers.NewHumioNodeManagerFromHumioNodePool(toCreate, &toCreate.Spec.NodePools[0]).GetImage(), []corev1.EnvVar{
 				{
 					Name:  "test",
 					Value: "",
@@ -1604,7 +1604,7 @@ var _ = Describe("HumioCluster Controller", func() {
 					Name:  "ENABLE_IOC_SERVICE",
 					Value: "false",
 				},
-			}
+			})
 
 			suite.UsingClusterBy(key.Name, "Creating the cluster successfully")
 			ctx := context.Background()
@@ -1621,7 +1621,7 @@ var _ = Describe("HumioCluster Controller", func() {
 			}
 
 			suite.UsingClusterBy(key.Name, "Updating the environment variable on main node pool successfully")
-			updatedEnvironmentVariables := []corev1.EnvVar{
+			updatedEnvironmentVariables := suite.FilterZookeeperURLIfNeeded(controllers.NewHumioNodeManagerFromHumioCluster(toCreate).GetImage(), []corev1.EnvVar{
 				{
 					Name:  "test",
 					Value: "update",
@@ -1650,7 +1650,7 @@ var _ = Describe("HumioCluster Controller", func() {
 					Name:  "ENABLE_IOC_SERVICE",
 					Value: "false",
 				},
-			}
+			})
 			Eventually(func() error {
 				updatedHumioCluster = humiov1alpha1.HumioCluster{}
 				err := k8sClient.Get(ctx, key, &updatedHumioCluster)
@@ -1719,7 +1719,7 @@ var _ = Describe("HumioCluster Controller", func() {
 			clusterPods, _ = kubernetes.ListPods(ctx, k8sClient, key.Namespace, additionalNodePoolManager.GetPodLabels())
 
 			suite.UsingClusterBy(key.Name, "Updating the environment variable on additional node pool successfully")
-			updatedEnvironmentVariables = []corev1.EnvVar{
+			updatedEnvironmentVariables = suite.FilterZookeeperURLIfNeeded(controllers.NewHumioNodeManagerFromHumioNodePool(toCreate, &toCreate.Spec.NodePools[0]).GetImage(), []corev1.EnvVar{
 				{
 					Name:  "test",
 					Value: "update",
@@ -1748,7 +1748,7 @@ var _ = Describe("HumioCluster Controller", func() {
 					Name:  "ENABLE_IOC_SERVICE",
 					Value: "false",
 				},
-			}
+			})
 			Eventually(func() error {
 				updatedHumioCluster = humiov1alpha1.HumioCluster{}
 				err := k8sClient.Get(ctx, key, &updatedHumioCluster)

--- a/controllers/suite/common.go
+++ b/controllers/suite/common.go
@@ -177,7 +177,7 @@ func ConstructBasicNodeSpecForHumioCluster(key types.NamespacedName) humiov1alph
 		Image:             controllers.Image,
 		ExtraKafkaConfigs: "security.protocol=PLAINTEXT",
 		NodeCount:         helpers.IntPtr(1),
-		EnvironmentVariables: FilterZookeeperURLIfNeeded(controllers.Image, []corev1.EnvVar{
+		EnvironmentVariables: FilterZookeeperURLIfVersionIsRecentEnough(controllers.Image, []corev1.EnvVar{
 			{
 				Name:  "ZOOKEEPER_URL",
 				Value: "humio-cp-zookeeper-0.humio-cp-zookeeper-headless.default:2181",
@@ -225,7 +225,7 @@ func ConstructBasicNodeSpecForHumioCluster(key types.NamespacedName) humiov1alph
 	return nodeSpec
 }
 
-func FilterZookeeperURLIfNeeded(image string, envVars []corev1.EnvVar) []corev1.EnvVar {
+func FilterZookeeperURLIfVersionIsRecentEnough(image string, envVars []corev1.EnvVar) []corev1.EnvVar {
 	var filteredEnvVars []corev1.EnvVar
 	for _, envVar := range envVars {
 		humioVersion, _ := controllers.HumioVersionFromString(image)

--- a/examples/humiocluster-affinity-and-tolerations.yaml
+++ b/examples/humiocluster-affinity-and-tolerations.yaml
@@ -7,7 +7,7 @@ spec:
     secretKeyRef:
       name: example-humiocluster-license
       key: data
-  image: "humio/humio-core:1.56.3"
+  image: "humio/humio-core:1.70.0"
   environmentVariables:
     - name: "ZOOKEEPER_URL"
       value: "humio-cp-zookeeper-0.humio-cp-zookeeper-headless:2181"

--- a/examples/humiocluster-data-volume-persistent-volume-claim-policy-kind-local.yaml
+++ b/examples/humiocluster-data-volume-persistent-volume-claim-policy-kind-local.yaml
@@ -7,7 +7,7 @@ spec:
     secretKeyRef:
       name: example-humiocluster-license
       key: data
-  image: "humio/humio-core:1.56.3"
+  image: "humio/humio-core:1.70.0"
   nodeCount: 1
   tls:
     enabled: false

--- a/examples/humiocluster-ephemeral-with-gcs-storage.yaml
+++ b/examples/humiocluster-ephemeral-with-gcs-storage.yaml
@@ -7,7 +7,7 @@ spec:
     secretKeyRef:
       name: example-humiocluster-license
       key: data
-  image: "humio/humio-core:1.56.3"
+  image: "humio/humio-core:1.70.0"
   targetReplicationFactor: 2
   storagePartitionsCount: 24
   digestPartitionsCount: 24

--- a/examples/humiocluster-ephemeral-with-s3-storage.yaml
+++ b/examples/humiocluster-ephemeral-with-s3-storage.yaml
@@ -7,7 +7,7 @@ spec:
     secretKeyRef:
       name: example-humiocluster-license
       key: data
-  image: "humio/humio-core:1.56.3"
+  image: "humio/humio-core:1.70.0"
   targetReplicationFactor: 2
   storagePartitionsCount: 24
   digestPartitionsCount: 24

--- a/examples/humiocluster-kind-local.yaml
+++ b/examples/humiocluster-kind-local.yaml
@@ -7,7 +7,7 @@ spec:
     secretKeyRef:
       name: example-humiocluster-license
       key: data
-  image: "humio/humio-core:1.56.3"
+  image: "humio/humio-core:1.70.0"
   nodeCount: 1
   tls:
     enabled: false

--- a/examples/humiocluster-multi-nodepool-kind-local.yaml
+++ b/examples/humiocluster-multi-nodepool-kind-local.yaml
@@ -6,7 +6,7 @@ spec:
   nodePools:
     - name: ingest-only
       spec:
-        image: "humio/humio-core:1.56.3"
+        image: "humio/humio-core:1.70.0"
         nodeCount: 1
         dataVolumePersistentVolumeClaimSpecTemplate:
           storageClassName: standard
@@ -36,7 +36,7 @@ spec:
     secretKeyRef:
       name: example-humiocluster-license
       key: data
-  image: "humio/humio-core:1.56.3"
+  image: "humio/humio-core:1.70.0"
   nodeCount: 1
   tls:
     enabled: false

--- a/examples/humiocluster-nginx-ingress-with-cert-manager.yaml
+++ b/examples/humiocluster-nginx-ingress-with-cert-manager.yaml
@@ -7,7 +7,7 @@ spec:
     secretKeyRef:
       name: example-humiocluster-license
       key: data
-  image: "humio/humio-core:1.56.3"
+  image: "humio/humio-core:1.70.0"
   environmentVariables:
     - name: "ZOOKEEPER_URL"
       value: "humio-cp-zookeeper-0.humio-cp-zookeeper-headless:2181"

--- a/examples/humiocluster-nginx-ingress-with-custom-path.yaml
+++ b/examples/humiocluster-nginx-ingress-with-custom-path.yaml
@@ -7,7 +7,7 @@ spec:
     secretKeyRef:
       name: example-humiocluster-license
       key: data
-  image: "humio/humio-core:1.56.3"
+  image: "humio/humio-core:1.70.0"
   environmentVariables:
     - name: "ZOOKEEPER_URL"
       value: "humio-cp-zookeeper-0.humio-cp-zookeeper-headless:2181"

--- a/examples/humiocluster-nginx-ingress-with-hostname-secrets.yaml
+++ b/examples/humiocluster-nginx-ingress-with-hostname-secrets.yaml
@@ -7,7 +7,7 @@ spec:
     secretKeyRef:
       name: example-humiocluster-license
       key: data
-  image: "humio/humio-core:1.56.3"
+  image: "humio/humio-core:1.70.0"
   environmentVariables:
     - name: "ZOOKEEPER_URL"
       value: "humio-cp-zookeeper-0.humio-cp-zookeeper-headless:2181"

--- a/examples/humiocluster-persistent-volumes.yaml
+++ b/examples/humiocluster-persistent-volumes.yaml
@@ -7,7 +7,7 @@ spec:
     secretKeyRef:
       name: example-humiocluster-license
       key: data
-  image: "humio/humio-core:1.56.3"
+  image: "humio/humio-core:1.70.0"
   targetReplicationFactor: 2
   storagePartitionsCount: 24
   digestPartitionsCount: 24


### PR DESCRIPTION
Previously we always added `ZOOKEEPER_URL_FOR_NODE_UUID` when running with `USING_EPHEMERAL_DISKS=true` but as of version 1.70.0, we don't need to leverage zookeeper anymore for determining node UUID's. Because we always added the `ZOOKEEPER_URL_FOR_NODE_UUID` option, this meant that adding `ZOOKEEPER_URL` was required by the user.

Instead of always adding the option when using `USING_EPHEMERAL_DISKS=true`, this changes it so that it also requires `ZOOKEEPER_URL` set, which the user explicitly had to set previously, but with this change it is possible to leave out `ZOOKEEPER_URL` which means the operator will not automatically add `ZOOKEEPER_URL_FOR_NODE_UUID` and thus switch away from using zookeeper to determine node UUID's.

This effectively means users that are running with `USING_EPHEMERAL_DISKS=true` can migrate to the new node UUID mechanism by:

1. Upgrading the operator to a version which includes this PR
2. Remove `ZOOKEEPER_*` configs from the user-defined env vars for a given `HumioCluster` resource
3. ... wait for operator to replace pods and migrate to the new mechanism
4. Done