### PR TITLE
Only append AUTHENTICATION_METHOD for versions prior to 1.68.0

### DIFF
--- a/controllers/humiocluster_defaults.go
+++ b/controllers/humiocluster_defaults.go
@@ -359,7 +359,6 @@ func (hnp HumioNodePool) GetEnvironmentVariables() []corev1.EnvVar {
 		{Name: "DEFAULT_PARTITION_COUNT", Value: strconv.Itoa(hnp.GetStoragePartitionsCount())},
 		{Name: "INGEST_QUEUE_INITIAL_PARTITIONS", Value: strconv.Itoa(hnp.GetDigestPartitionsCount())},
 		{Name: "KAFKA_MANAGED_BY_HUMIO", Value: "true"},
-		{Name: "AUTHENTICATION_METHOD", Value: "single-user"},
 		{Name: "HUMIO_LOG4J_CONFIGURATION", Value: "log4j2-json-stdout.xml"},
 		{
 			Name:  "EXTERNAL_URL", // URL used by other Humio hosts.
@@ -368,6 +367,13 @@ func (hnp HumioNodePool) GetEnvironmentVariables() []corev1.EnvVar {
 	}
 
 	humioVersion, _ := HumioVersionFromString(hnp.GetImage())
+	if ok, _ := humioVersion.AtLeast(HumioVersionWithDefaultSingleUserAuth); !ok {
+		envDefaults = append(envDefaults, corev1.EnvVar{
+			Name:  "AUTHENTICATION_METHOD",
+			Value: "single-user",
+		})
+	}
+
 	if ok, _ := humioVersion.AtLeast(HumioVersionWithLauncherScript); ok {
 		envDefaults = append(envDefaults, corev1.EnvVar{
 			Name:  "HUMIO_GC_OPTS",

--- a/controllers/humiocluster_version.go
+++ b/controllers/humiocluster_version.go
@@ -8,10 +8,11 @@ import (
 )
 
 const (
-	HumioVersionMinimumSupported      = "1.30.0"
-	HumioVersionWithLauncherScript    = "1.32.0"
-	HumioVersionWithNewTmpDir         = "1.33.0"
-	HumioVersionWithNewVhostSelection = "1.70.0"
+	HumioVersionMinimumSupported          = "1.30.0"
+	HumioVersionWithLauncherScript        = "1.32.0"
+	HumioVersionWithNewTmpDir             = "1.33.0"
+	HumioVersionWithDefaultSingleUserAuth = "1.68.0"
+	HumioVersionWithNewVhostSelection     = "1.70.0"
 )
 
 type HumioVersion struct {

--- a/examples/humiocluster-data-volume-persistent-volume-claim-policy-kind-local.yaml
+++ b/examples/humiocluster-data-volume-persistent-volume-claim-policy-kind-local.yaml
@@ -36,7 +36,3 @@ spec:
       value: "humio-cp-zookeeper-0.humio-cp-zookeeper-headless.default:2181"
     - name: "KAFKA_SERVERS"
       value: "humio-cp-kafka-0.humio-cp-kafka-headless.default:9092"
-    - name: AUTHENTICATION_METHOD
-      value: "single-user"
-    - name: SINGLE_USER_PASSWORD
-      value: "password"

--- a/examples/humiocluster-kind-local.yaml
+++ b/examples/humiocluster-kind-local.yaml
@@ -34,7 +34,3 @@ spec:
       value: "humio-cp-zookeeper-0.humio-cp-zookeeper-headless.default:2181"
     - name: "KAFKA_SERVERS"
       value: "humio-cp-kafka-0.humio-cp-kafka-headless.default:9092"
-    - name: AUTHENTICATION_METHOD
-      value: "single-user"
-    - name: SINGLE_USER_PASSWORD
-      value: "password"

--- a/examples/humiocluster-multi-nodepool-kind-local.yaml
+++ b/examples/humiocluster-multi-nodepool-kind-local.yaml
@@ -28,10 +28,6 @@ spec:
             value: "humio-cp-zookeeper-0.humio-cp-zookeeper-headless.default:2181"
           - name: "KAFKA_SERVERS"
             value: "humio-cp-kafka-0.humio-cp-kafka-headless.default:9092"
-          - name: AUTHENTICATION_METHOD
-            value: "single-user"
-          - name: SINGLE_USER_PASSWORD
-            value: "password"
   license:
     secretKeyRef:
       name: example-humiocluster-license
@@ -63,7 +59,3 @@ spec:
       value: "humio-cp-zookeeper-0.humio-cp-zookeeper-headless.default:2181"
     - name: "KAFKA_SERVERS"
       value: "humio-cp-kafka-0.humio-cp-kafka-headless.default:9092"
-    - name: AUTHENTICATION_METHOD
-      value: "single-user"
-    - name: SINGLE_USER_PASSWORD
-      value: "password"


### PR DESCRIPTION
From 1.68.0 the default is now single-user auth, so there's no need to explicitly set it in the operator code base.

https://library.humio.com/falcon-logscale/release-notes-all.html#release-notes-all-1-68-0

I'm also removing the auth env vars from the examples as they don't seem relevant for what the examples are trying to show.