### PR TITLE
feat: Support admin defined affinity and tolerations

### DIFF
--- a/charts/humio-operator/templates/operator-deployment.yaml
+++ b/charts/humio-operator/templates/operator-deployment.yaml
@@ -42,20 +42,18 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
 {{- end }}
+{{- with .Values.tolerations }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+{{- end }}  
+{{- with .Values.affinity }}
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-            - matchExpressions:
-              - key: kubernetes.io/os
-                operator: In
-                values:
-                - linux
+        {{- toYaml . | nindent 8 }}
+{{- end }}        
+{{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+{{- end }}  
       serviceAccountName: {{ .Release.Name }}
       containers:
       - name: humio-operator

--- a/charts/humio-operator/values.yaml
+++ b/charts/humio-operator/values.yaml
@@ -20,5 +20,24 @@ operator:
       memory: 200Mi
   watchNamespaces: []
   podAnnotations: {}
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: 
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: kubernetes.io/arch
+            operator: In
+            values:
+            - amd64
+          - key: kubernetes.io/os
+            operator: In
+            values:
+            - linux
+  
 openshift: false
 certmanager: true


### PR DESCRIPTION
This PR moves the static affinity to values.yaml as the default to avoid breakage and correctly combines the requirements so arm64 and ppc nodes can not be selected.