### PR TITLE
feat: Add TopologySpreadConstraints support to the humiocluster CRD

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,86 +5,107 @@ jobs:
     name: Run Tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
-      with:
-        go-version: '1.18.7'
-    - shell: bash
-      run: |
-        make manifests
-        if [[ -n $(git status -s) ]] ; then
-          echo "Generating manifests leaves tracked fiels in a modified state."
-          echo "Ensure to include updated manifests in this PR."
-          echo "This is usually done by running 'make manifests' and running 'git add ...' for the files that was modified by generating manifests."
-          git status -s
-          git diff
-          exit 1
-        fi
-    - shell: bash
-      run: |
-        make test
-      env:
-        HUMIO_E2E_LICENSE: ${{ secrets.HUMIO_E2E_LICENSE }}
-    - name: Publish Test Report
-      uses: mikepenz/action-junit-report@v2
-      if: always() # always run even if the previous step fails
-      with:
-        report_paths: '*-results-junit.xml'
-# Disable olm checks until we have a new bundle we want to validate against
-#  olm-checks:
-#    name: Run OLM Checks
-#    runs-on: ubuntu-latest
-#    steps:
-#    - uses: actions/checkout@v2
-#    - name: operator-sdk lint
-#      env:
-#        GO111MODULE: "on"
-#      uses: ./.github/action/operator-sdk
-#      with:
-#        args: operator-courier --verbose verify --ui_validate_io deploy/olm-catalog/humio-operator
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.18.7"
+      - shell: bash
+        run: |
+          make manifests
+          if [[ -n $(git status -s) ]] ; then
+            echo "Generating manifests leaves tracked fiels in a modified state."
+            echo "Ensure to include updated manifests in this PR."
+            echo "This is usually done by running 'make manifests' and running 'git add ...' for the files that was modified by generating manifests."
+            git status -s
+            git diff
+            exit 1
+          fi
+      - shell: bash
+        run: |
+          make test
+        env:
+          HUMIO_E2E_LICENSE: ${{ secrets.HUMIO_E2E_LICENSE }}
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v2
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: "*-results-junit.xml"
+  # Disable olm checks until we have a new bundle we want to validate against
+  #  olm-checks:
+  #    name: Run OLM Checks
+  #    runs-on: ubuntu-latest
+  #    steps:
+  #    - uses: actions/checkout@v2
+  #    - name: operator-sdk lint
+  #      env:
+  #        GO111MODULE: "on"
+  #      uses: ./.github/action/operator-sdk
+  #      with:
+  #        args: operator-courier --verbose verify --ui_validate_io deploy/olm-catalog/humio-operator
   build:
     needs: checks
     name: Run Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
-      with:
-        go-version: '1.18.7'
-    - name: operator image
-      run: make docker-build-operator IMG=humio/humio-operator:${{ github.sha }}
-    - name: helper image
-      run: make docker-build-helper IMG=humio/humio-operator-helper:${{ github.sha }}
-    - name: Set up Python
-      uses: actions/setup-python@v2
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install six
-    - name: CrowdStrike Container Image Scan Operator
-      uses: crowdstrike/container-image-scan-action@v0.7
-      with:
-        falcon_client_id: 1cd30708cb31442f85a6eec83279fe7b
-        container_repository: humio/humio-operator
-        container_tag: ${{ github.sha }}
-      env:
-        FALCON_CLIENT_SECRET: "${{ secrets.FALCON_CLIENT_SECRET }}"
-    - name: CrowdStrike Container Image Scan Operator Helper
-      uses: crowdstrike/container-image-scan-action@v0.7
-      with:
-        falcon_client_id: 1cd30708cb31442f85a6eec83279fe7b
-        container_repository: humio/humio-operator-helper
-        container_tag: ${{ github.sha }}
-      env:
-        FALCON_CLIENT_SECRET: "${{ secrets.FALCON_CLIENT_SECRET }}"
-    - name: Run Gosec Security Scanner
-      run: |
-        export PATH=$PATH:$(go env GOPATH)/bin
-        go get github.com/securego/gosec/cmd/gosec
-        go install github.com/securego/gosec/cmd/gosec
-        gosec ./...
-#    - name: Run Staticcheck
-#      uses: dominikh/staticcheck-action@v1.2.0
-#      with:
-#        version: "2022.1.3"
-#        install-go: false
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.18.7"
+      - name: operator image
+        run: make docker-build-operator IMG=humio/humio-operator:${{ github.sha }}
+      - name: helper image
+        run: make docker-build-helper IMG=humio/humio-operator-helper:${{ github.sha }}
+      - name: Set up Python
+        uses: actions/setup-python@v2
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install six
+      - name: CrowdStrike Container Image Scan Operator
+        if: github.event.repository.fork == false
+        uses: crowdstrike/container-image-scan-action@v0.7
+        with:
+          falcon_client_id: 1cd30708cb31442f85a6eec83279fe7b
+          container_repository: humio/humio-operator
+          container_tag: ${{ github.sha }}
+        env:
+          FALCON_CLIENT_SECRET: "${{ secrets.FALCON_CLIENT_SECRET }}"
+      - name: CrowdStrike Container Image Scan Operator Helper
+        if: github.event.repository.fork == false
+        uses: crowdstrike/container-image-scan-action@v0.7
+        with:
+          falcon_client_id: 1cd30708cb31442f85a6eec83279fe7b
+          container_repository: humio/humio-operator-helper
+          container_tag: ${{ github.sha }}
+        env:
+          FALCON_CLIENT_SECRET: "${{ secrets.FALCON_CLIENT_SECRET }}"
+      - name: Run Gosec Security Scanner
+        run: |
+          export PATH=$PATH:$(go env GOPATH)/bin
+          go get github.com/securego/gosec/cmd/gosec
+          go install github.com/securego/gosec/cmd/gosec
+          gosec ./...
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: push image
+        run: |
+          docker tag humio/humio-operator:${{ github.sha }} $IMG
+          docker rmi humio/humio-operator:${{ github.sha }}
+          make docker-push
+        env:
+          IMG: ghcr.io/${{ github.repository }}/humio-operator:${{ github.sha }}
+      - name: push image
+        run: |
+          docker tag humio/humio-operator-helper:${{ github.sha }} $IMG
+          docker rmi humio/humio-operator-helper:${{ github.sha }}
+          make docker-push
+        env:
+          IMG: ghcr.io/${{ github.repository }}/humio-operator-helper:${{ github.sha }}

--- a/api/v1alpha1/humiocluster_types.go
+++ b/api/v1alpha1/humiocluster_types.go
@@ -176,6 +176,9 @@ type HumioNodeSpec struct {
 	// Tolerations defines the tolerations that will be attached to the humio pods
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
+	// TopologySpreadConstraints defines the topologySpreadConstraints that will be attached to the humio pods
+	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
+
 	// SidecarContainers can be used in advanced use-cases where you want one or more sidecar container added to the
 	// Humio pod to help out in debugging purposes.
 	SidecarContainers []corev1.Container `json:"sidecarContainer,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -991,6 +991,13 @@ func (in *HumioNodeSpec) DeepCopyInto(out *HumioNodeSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.TopologySpreadConstraints != nil {
+		in, out := &in.TopologySpreadConstraints, &out.TopologySpreadConstraints
+		*out = make([]v1.TopologySpreadConstraint, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.SidecarContainers != nil {
 		in, out := &in.SidecarContainers, &out.SidecarContainers
 		*out = make([]v1.Container, len(*in))

--- a/charts/humio-operator/crds/core.humio.com_humioclusters.yaml
+++ b/charts/humio-operator/crds/core.humio.com_humioclusters.yaml
@@ -11938,6 +11938,116 @@ spec:
                                 type: string
                             type: object
                           type: array
+                        topologySpreadConstraints:
+                          description: TopologySpreadConstraints defines the topologySpreadConstraints
+                            that will be attached to the humio pods
+                          items:
+                            description: TopologySpreadConstraint specifies how to
+                              spread matching pods among the given topology.
+                            properties:
+                              labelSelector:
+                                description: LabelSelector is used to find matching
+                                  pods. Pods that match this label selector are counted
+                                  to determine the number of pods in their corresponding
+                                  topology domain.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              maxSkew:
+                                description: 'MaxSkew describes the degree to which
+                                  pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                                  it is the maximum permitted difference between the
+                                  number of matching pods in the target topology and
+                                  the global minimum. For example, in a 3-zone cluster,
+                                  MaxSkew is set to 1, and pods with the same labelSelector
+                                  spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                                  - if MaxSkew is 1, incoming pod can only be scheduled
+                                  to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
+                                  would make the ActualSkew(2-0) on zone1(zone2) violate
+                                  MaxSkew(1). - if MaxSkew is 2, incoming pod can
+                                  be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                  it is used to give higher precedence to topologies
+                                  that satisfy it. It''s a required field. Default
+                                  value is 1 and 0 is not allowed.'
+                                format: int32
+                                type: integer
+                              topologyKey:
+                                description: TopologyKey is the key of node labels.
+                                  Nodes that have a label with this key and identical
+                                  values are considered to be in the same topology.
+                                  We consider each <key, value> as a "bucket", and
+                                  try to put balanced number of pods into each bucket.
+                                  It's a required field.
+                                type: string
+                              whenUnsatisfiable:
+                                description: 'WhenUnsatisfiable indicates how to deal
+                                  with a pod if it doesn''t satisfy the spread constraint.
+                                  - DoNotSchedule (default) tells the scheduler not
+                                  to schedule it. - ScheduleAnyway tells the scheduler
+                                  to schedule the pod in any location,   but giving
+                                  higher precedence to topologies that would help
+                                  reduce the   skew. A constraint is considered "Unsatisfiable"
+                                  for an incoming pod if and only if every possible
+                                  node assignment for that pod would violate "MaxSkew"
+                                  on some topology. For example, in a 3-zone cluster,
+                                  MaxSkew is set to 1, and pods with the same labelSelector
+                                  spread as 3/1/1: | zone1 | zone2 | zone3 | | P P
+                                  P |   P   |   P   | If WhenUnsatisfiable is set
+                                  to DoNotSchedule, incoming pod can only be scheduled
+                                  to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1)
+                                  on zone2(zone3) satisfies MaxSkew(1). In other words,
+                                  the cluster can still be imbalanced, but scheduler
+                                  won''t make it *more* imbalanced. It''s a required
+                                  field.'
+                                type: string
+                            required:
+                            - maxSkew
+                            - topologyKey
+                            - whenUnsatisfiable
+                            type: object
+                          type: array
                         updateStrategy:
                           description: UpdateStrategy controls how Humio pods are
                             updated when changes are made to the HumioCluster resource
@@ -13488,6 +13598,107 @@ spec:
                         to. If the operator is Exists, the value should be empty,
                         otherwise just a regular string.
                       type: string
+                  type: object
+                type: array
+              topologySpreadConstraints:
+                description: TopologySpreadConstraints defines the topologySpreadConstraints
+                  that will be attached to the humio pods
+                items:
+                  description: TopologySpreadConstraint specifies how to spread matching
+                    pods among the given topology.
+                  properties:
+                    labelSelector:
+                      description: LabelSelector is used to find matching pods. Pods
+                        that match this label selector are counted to determine the
+                        number of pods in their corresponding topology domain.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    maxSkew:
+                      description: 'MaxSkew describes the degree to which pods may
+                        be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                        it is the maximum permitted difference between the number
+                        of matching pods in the target topology and the global minimum.
+                        For example, in a 3-zone cluster, MaxSkew is set to 1, and
+                        pods with the same labelSelector spread as 1/1/0: | zone1
+                        | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is
+                        1, incoming pod can only be scheduled to zone3 to become 1/1/1;
+                        scheduling it onto zone1(zone2) would make the ActualSkew(2-0)
+                        on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming
+                        pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                        it is used to give higher precedence to topologies that satisfy
+                        it. It''s a required field. Default value is 1 and 0 is not
+                        allowed.'
+                      format: int32
+                      type: integer
+                    topologyKey:
+                      description: TopologyKey is the key of node labels. Nodes that
+                        have a label with this key and identical values are considered
+                        to be in the same topology. We consider each <key, value>
+                        as a "bucket", and try to put balanced number of pods into
+                        each bucket. It's a required field.
+                      type: string
+                    whenUnsatisfiable:
+                      description: 'WhenUnsatisfiable indicates how to deal with a
+                        pod if it doesn''t satisfy the spread constraint. - DoNotSchedule
+                        (default) tells the scheduler not to schedule it. - ScheduleAnyway
+                        tells the scheduler to schedule the pod in any location,   but
+                        giving higher precedence to topologies that would help reduce
+                        the   skew. A constraint is considered "Unsatisfiable" for
+                        an incoming pod if and only if every possible node assignment
+                        for that pod would violate "MaxSkew" on some topology. For
+                        example, in a 3-zone cluster, MaxSkew is set to 1, and pods
+                        with the same labelSelector spread as 3/1/1: | zone1 | zone2
+                        | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is
+                        set to DoNotSchedule, incoming pod can only be scheduled to
+                        zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on
+                        zone2(zone3) satisfies MaxSkew(1). In other words, the cluster
+                        can still be imbalanced, but scheduler won''t make it *more*
+                        imbalanced. It''s a required field.'
+                      type: string
+                  required:
+                  - maxSkew
+                  - topologyKey
+                  - whenUnsatisfiable
                   type: object
                 type: array
               updateStrategy:

--- a/charts/humio-operator/templates/operator-deployment.yaml
+++ b/charts/humio-operator/templates/operator-deployment.yaml
@@ -42,20 +42,18 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
 {{- end }}
+{{- with .Values.tolerations }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+{{- end }}  
+{{- with .Values.affinity }}
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-            - matchExpressions:
-              - key: kubernetes.io/os
-                operator: In
-                values:
-                - linux
+        {{- toYaml . | nindent 8 }}
+{{- end }}        
+{{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+{{- end }}  
       serviceAccountName: {{ .Release.Name }}
       containers:
       - name: humio-operator

--- a/charts/humio-operator/values.yaml
+++ b/charts/humio-operator/values.yaml
@@ -20,5 +20,24 @@ operator:
       memory: 200Mi
   watchNamespaces: []
   podAnnotations: {}
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: 
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: kubernetes.io/arch
+            operator: In
+            values:
+            - amd64
+          - key: kubernetes.io/os
+            operator: In
+            values:
+            - linux
+  
 openshift: false
 certmanager: true

--- a/config/crd/bases/core.humio.com_humioclusters.yaml
+++ b/config/crd/bases/core.humio.com_humioclusters.yaml
@@ -11938,6 +11938,116 @@ spec:
                                 type: string
                             type: object
                           type: array
+                        topologySpreadConstraints:
+                          description: TopologySpreadConstraints defines the topologySpreadConstraints
+                            that will be attached to the humio pods
+                          items:
+                            description: TopologySpreadConstraint specifies how to
+                              spread matching pods among the given topology.
+                            properties:
+                              labelSelector:
+                                description: LabelSelector is used to find matching
+                                  pods. Pods that match this label selector are counted
+                                  to determine the number of pods in their corresponding
+                                  topology domain.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              maxSkew:
+                                description: 'MaxSkew describes the degree to which
+                                  pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                                  it is the maximum permitted difference between the
+                                  number of matching pods in the target topology and
+                                  the global minimum. For example, in a 3-zone cluster,
+                                  MaxSkew is set to 1, and pods with the same labelSelector
+                                  spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                                  - if MaxSkew is 1, incoming pod can only be scheduled
+                                  to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
+                                  would make the ActualSkew(2-0) on zone1(zone2) violate
+                                  MaxSkew(1). - if MaxSkew is 2, incoming pod can
+                                  be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                  it is used to give higher precedence to topologies
+                                  that satisfy it. It''s a required field. Default
+                                  value is 1 and 0 is not allowed.'
+                                format: int32
+                                type: integer
+                              topologyKey:
+                                description: TopologyKey is the key of node labels.
+                                  Nodes that have a label with this key and identical
+                                  values are considered to be in the same topology.
+                                  We consider each <key, value> as a "bucket", and
+                                  try to put balanced number of pods into each bucket.
+                                  It's a required field.
+                                type: string
+                              whenUnsatisfiable:
+                                description: 'WhenUnsatisfiable indicates how to deal
+                                  with a pod if it doesn''t satisfy the spread constraint.
+                                  - DoNotSchedule (default) tells the scheduler not
+                                  to schedule it. - ScheduleAnyway tells the scheduler
+                                  to schedule the pod in any location,   but giving
+                                  higher precedence to topologies that would help
+                                  reduce the   skew. A constraint is considered "Unsatisfiable"
+                                  for an incoming pod if and only if every possible
+                                  node assignment for that pod would violate "MaxSkew"
+                                  on some topology. For example, in a 3-zone cluster,
+                                  MaxSkew is set to 1, and pods with the same labelSelector
+                                  spread as 3/1/1: | zone1 | zone2 | zone3 | | P P
+                                  P |   P   |   P   | If WhenUnsatisfiable is set
+                                  to DoNotSchedule, incoming pod can only be scheduled
+                                  to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1)
+                                  on zone2(zone3) satisfies MaxSkew(1). In other words,
+                                  the cluster can still be imbalanced, but scheduler
+                                  won''t make it *more* imbalanced. It''s a required
+                                  field.'
+                                type: string
+                            required:
+                            - maxSkew
+                            - topologyKey
+                            - whenUnsatisfiable
+                            type: object
+                          type: array
                         updateStrategy:
                           description: UpdateStrategy controls how Humio pods are
                             updated when changes are made to the HumioCluster resource
@@ -13488,6 +13598,107 @@ spec:
                         to. If the operator is Exists, the value should be empty,
                         otherwise just a regular string.
                       type: string
+                  type: object
+                type: array
+              topologySpreadConstraints:
+                description: TopologySpreadConstraints defines the topologySpreadConstraints
+                  that will be attached to the humio pods
+                items:
+                  description: TopologySpreadConstraint specifies how to spread matching
+                    pods among the given topology.
+                  properties:
+                    labelSelector:
+                      description: LabelSelector is used to find matching pods. Pods
+                        that match this label selector are counted to determine the
+                        number of pods in their corresponding topology domain.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    maxSkew:
+                      description: 'MaxSkew describes the degree to which pods may
+                        be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                        it is the maximum permitted difference between the number
+                        of matching pods in the target topology and the global minimum.
+                        For example, in a 3-zone cluster, MaxSkew is set to 1, and
+                        pods with the same labelSelector spread as 1/1/0: | zone1
+                        | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is
+                        1, incoming pod can only be scheduled to zone3 to become 1/1/1;
+                        scheduling it onto zone1(zone2) would make the ActualSkew(2-0)
+                        on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming
+                        pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                        it is used to give higher precedence to topologies that satisfy
+                        it. It''s a required field. Default value is 1 and 0 is not
+                        allowed.'
+                      format: int32
+                      type: integer
+                    topologyKey:
+                      description: TopologyKey is the key of node labels. Nodes that
+                        have a label with this key and identical values are considered
+                        to be in the same topology. We consider each <key, value>
+                        as a "bucket", and try to put balanced number of pods into
+                        each bucket. It's a required field.
+                      type: string
+                    whenUnsatisfiable:
+                      description: 'WhenUnsatisfiable indicates how to deal with a
+                        pod if it doesn''t satisfy the spread constraint. - DoNotSchedule
+                        (default) tells the scheduler not to schedule it. - ScheduleAnyway
+                        tells the scheduler to schedule the pod in any location,   but
+                        giving higher precedence to topologies that would help reduce
+                        the   skew. A constraint is considered "Unsatisfiable" for
+                        an incoming pod if and only if every possible node assignment
+                        for that pod would violate "MaxSkew" on some topology. For
+                        example, in a 3-zone cluster, MaxSkew is set to 1, and pods
+                        with the same labelSelector spread as 3/1/1: | zone1 | zone2
+                        | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is
+                        set to DoNotSchedule, incoming pod can only be scheduled to
+                        zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on
+                        zone2(zone3) satisfies MaxSkew(1). In other words, the cluster
+                        can still be imbalanced, but scheduler won''t make it *more*
+                        imbalanced. It''s a required field.'
+                      type: string
+                  required:
+                  - maxSkew
+                  - topologyKey
+                  - whenUnsatisfiable
                   type: object
                 type: array
               updateStrategy:

--- a/controllers/humiocluster_defaults.go
+++ b/controllers/humiocluster_defaults.go
@@ -116,6 +116,7 @@ func NewHumioNodeManagerFromHumioCluster(hc *humiov1alpha1.HumioCluster) *HumioN
 			PodSecurityContext:                          hc.Spec.PodSecurityContext,
 			Resources:                                   hc.Spec.Resources,
 			Tolerations:                                 hc.Spec.Tolerations,
+			TopologySpreadConstraints:                   hc.Spec.TopologySpreadConstraints,
 			TerminationGracePeriodSeconds:               hc.Spec.TerminationGracePeriodSeconds,
 			Affinity:                                    hc.Spec.Affinity,
 			SidecarContainers:                           hc.Spec.SidecarContainers,
@@ -177,6 +178,7 @@ func NewHumioNodeManagerFromHumioNodePool(hc *humiov1alpha1.HumioCluster, hnp *h
 			PodSecurityContext:             hnp.PodSecurityContext,
 			Resources:                      hnp.Resources,
 			Tolerations:                    hnp.Tolerations,
+			TopologySpreadConstraints:      hnp.TopologySpreadConstraints,
 			TerminationGracePeriodSeconds:  hnp.TerminationGracePeriodSeconds,
 			Affinity:                       hnp.Affinity,
 			SidecarContainers:              hnp.SidecarContainers,
@@ -724,6 +726,10 @@ func (hnp HumioNodePool) GetSidecarContainers() []corev1.Container {
 
 func (hnp HumioNodePool) GetTolerations() []corev1.Toleration {
 	return hnp.humioNodeSpec.Tolerations
+}
+
+func (hnp HumioNodePool) GetTopologySpreadConstraints() []corev1.TopologySpreadConstraint {
+	return hnp.humioNodeSpec.TopologySpreadConstraints
 }
 
 func (hnp HumioNodePool) GetResources() corev1.ResourceRequirements {

--- a/controllers/humiocluster_pods.go
+++ b/controllers/humiocluster_pods.go
@@ -303,6 +303,7 @@ func ConstructPod(hnp *HumioNodePool, humioNodeName string, attachments *podAtta
 			},
 			Affinity:                      hnp.GetAffinity(),
 			Tolerations:                   hnp.GetTolerations(),
+			TopologySpreadConstraints:     hnp.GetTopologySpreadConstraints(),
 			SecurityContext:               hnp.GetPodSecurityContext(),
 			TerminationGracePeriodSeconds: hnp.GetTerminationGracePeriodSeconds(),
 		},
@@ -768,6 +769,8 @@ func sanitizePod(hnp *HumioNodePool, pod *corev1.Pod) *corev1.Pod {
 	pod.Spec.PreemptionPolicy = nil
 	pod.Spec.DeprecatedServiceAccount = ""
 	pod.Spec.Tolerations = hnp.GetTolerations()
+	pod.Spec.TopologySpreadConstraints = hnp.GetTopologySpreadConstraints()
+
 	for i := range pod.Spec.InitContainers {
 		pod.Spec.InitContainers[i].ImagePullPolicy = hnp.GetImagePullPolicy()
 		pod.Spec.InitContainers[i].TerminationMessagePath = ""


### PR DESCRIPTION
This PR fixes #342 with the addition of TopologySpreadConstraints to the CR. Node instances of operator deployed by helm will not automatically update the CR for those instances the CR must be applied manually