### PR TITLE
refactor common labels and new feature set additionnal common labels

### DIFF
--- a/charts/humio-operator/Chart.yaml
+++ b/charts/humio-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: humio-operator
-version: 0.18.0
+version: 0.17.0
 appVersion: 0.17.0
 home: https://github.com/humio/humio-operator
 description: Kubernetes Operator for running Humio on top of Kubernetes

--- a/charts/humio-operator/Chart.yaml
+++ b/charts/humio-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: humio-operator
-version: 0.17.0
+version: 0.18.0
 appVersion: 0.17.0
 home: https://github.com/humio/humio-operator
 description: Kubernetes Operator for running Humio on top of Kubernetes

--- a/charts/humio-operator/templates/_helpers.tpl
+++ b/charts/humio-operator/templates/_helpers.tpl
@@ -4,3 +4,17 @@ Create chart name and version as used by the chart label.
 {{- define "humio.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "humio.labels" -}}
+app: '{{ .Chart.Name }}'
+app.kubernetes.io/name: '{{ .Chart.Name }}'
+app.kubernetes.io/instance: '{{ .Release.Name }}'
+app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+helm.sh/chart: '{{ include "humio.chart" . }}'
+{{- if .Values.commonLabels }}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
+{{- end }}

--- a/charts/humio-operator/templates/operator-deployment.yaml
+++ b/charts/humio-operator/templates/operator-deployment.yaml
@@ -8,11 +8,7 @@ metadata:
     productName: "humio-operator"
     productVersion: {{ .Values.operator.image.tag | quote }}
   labels:
-    app: '{{ .Chart.Name }}'
-    app.kubernetes.io/name: '{{ .Chart.Name }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    helm.sh/chart: '{{ template "humio.chart" . }}'
+    {{- include "humio.labels" . | nindent 4 }}
 spec:
   replicas: 1
   strategy:
@@ -32,11 +28,7 @@ spec:
         {{- toYaml .Values.operator.podAnnotations | nindent 8 }}
 {{- end }}
       labels:
-        app: '{{ .Chart.Name }}'
-        app.kubernetes.io/name: '{{ .Chart.Name }}'
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-        helm.sh/chart: '{{ template "humio.chart" . }}'
+        {{- include "humio.labels" . | nindent 8 }}
     spec:
 {{- with .Values.operator.image.pullSecrets }}
       imagePullSecrets:

--- a/charts/humio-operator/templates/operator-rbac.yaml
+++ b/charts/humio-operator/templates/operator-rbac.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.operator.rbac.create -}}
+{{- $commonLabels := include "humio.labels" . }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -6,11 +7,7 @@ metadata:
   name: '{{ .Release.Name }}'
   namespace: '{{ default "default" .Release.Namespace }}'
   labels:
-    app: '{{ .Chart.Name }}'
-    app.kubernetes.io/name: '{{ .Chart.Name }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    helm.sh/chart: '{{ template "humio.chart" . }}'
+    {{- $commonLabels | nindent 4 }}
 
 {{- range .Values.operator.watchNamespaces }}
 ---
@@ -20,11 +17,7 @@ metadata:
   name: '{{ $.Release.Name }}'
   namespace: '{{ . }}'
   labels:
-    app: '{{ $.Chart.Name }}'
-    app.kubernetes.io/name: '{{ $.Chart.Name }}'
-    app.kubernetes.io/instance: '{{ $.Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ $.Release.Service }}'
-    helm.sh/chart: '{{ template "humio.chart" $ }}'
+    {{- $commonLabels | nindent 4 }}
 rules:
 - apiGroups:
   - ""
@@ -147,11 +140,7 @@ metadata:
   name: '{{ $.Release.Name }}'
   namespace: '{{ . }}'
   labels:
-    app: '{{ $.Chart.Name }}'
-    app.kubernetes.io/name: '{{ $.Chart.Name }}'
-    app.kubernetes.io/instance: '{{ $.Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ $.Release.Service }}'
-    helm.sh/chart: '{{ template "humio.chart" $ }}'
+    {{- $commonLabels | nindent 4 }}
 subjects:
 - kind: ServiceAccount
   name: '{{ $.Release.Name }}'
@@ -168,11 +157,7 @@ kind: ClusterRole
 metadata:
   name: '{{ default "default" .Release.Namespace }}-{{ .Release.Name }}'
   labels:
-    app: '{{ .Chart.Name }}'
-    app.kubernetes.io/name: '{{ .Chart.Name }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    helm.sh/chart: '{{ template "humio.chart" . }}'
+    {{- $commonLabels | nindent 4 }}
 rules:
 {{- if not .Values.operator.watchNamespaces }}
 - apiGroups:
@@ -353,11 +338,7 @@ kind: ClusterRoleBinding
 metadata:
   name: '{{ default "default" .Release.Namespace }}-{{ .Release.Name }}'
   labels:
-    app: '{{ .Chart.Name }}'
-    app.kubernetes.io/name: '{{ .Chart.Name }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    helm.sh/chart: '{{ template "humio.chart" . }}'
+    {{- $commonLabels | nindent 4 }}
 subjects:
 - kind: ServiceAccount
   name: '{{ .Release.Name }}'
@@ -374,11 +355,7 @@ kind: SecurityContextConstraints
 metadata:
   name: '{{ default "default" .Release.Namespace }}-{{ .Release.Name }}'
   labels:
-    app: '{{ .Chart.Name }}'
-    app.kubernetes.io/name: '{{ .Chart.Name }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    helm.sh/chart: '{{ template "humio.chart" . }}'
+    {{- $commonLabels | nindent 4 }}
 allowPrivilegedContainer: true
 allowHostDirVolumePlugin: true
 allowHostIPC: false

--- a/charts/humio-operator/templates/operator-service.yaml
+++ b/charts/humio-operator/templates/operator-service.yaml
@@ -4,9 +4,7 @@ metadata:
   name: '{{ .Release.Name }}'
   namespace: '{{ .Release.Namespace }}'
   labels:
-    app: '{{ .Chart.Name }}'
-    app.kubernetes.io/name: '{{ .Chart.Name }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    {{- include "humio.labels" . | nindent 4 }}
 spec:
   ports:
   - name: metrics

--- a/charts/humio-operator/templates/operator-servicemonitor.yaml
+++ b/charts/humio-operator/templates/operator-servicemonitor.yaml
@@ -5,9 +5,7 @@ metadata:
   name: '{{ .Release.Name }}'
   namespace: '{{ .Release.Namespace }}'
   labels:
-    app: '{{ .Chart.Name }}'
-    app.kubernetes.io/name: '{{ .Chart.Name }}'
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    {{- include "humio.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
1. Refactor common labels with the `_helper.tpl` template
2. Allows us to set extra labels in `commonLabels`. Those labels would be propagated to all k8s objects (as the name implies, they are "labels common to all objects".
3. This does not mess with the `Selector` on the k8s service object so there's no breaking change.

When doing `helm diff` I notice the following:

* there was some generic/common labels missing on the k8s `ServiceMonitor` and `Service` objects. This PR would add them. Here in for the svc:

```diff
logging, humio-operator, Service (v1) has changed:
...
    labels:
      app: 'humio-operator'
      app.kubernetes.io/name: 'humio-operator'
      app.kubernetes.io/instance: 'humio-operator'
+     app.kubernetes.io/managed-by: 'Helm'
+     helm.sh/chart: 'humio-operator-0.18.0'
  spec:
    ports:
```

This is the only non-transparent change, but not a breaking change IMO.

* New feature: if we set the following in our `values.yaml` and deploy, it will add labels everywhere:

`values.yaml`:
```yaml
commonLabels:
  generic_label: everywhere
  foo: bar
```

Helm diff will show the addition of labels. For instance, on the deploy k8s object:
```diff
logging, humio-operator, Deployment (apps) has changed:
...
      app: 'humio-operator'
      app.kubernetes.io/name: 'humio-operator'
      app.kubernetes.io/instance: 'humio-operator'
      app.kubernetes.io/managed-by: 'Helm'
      helm.sh/chart: 'humio-operator-0.18.0'
+     generic_label: everywhere
+     foo: bar
  spec:
    replicas: 1
    strategy:
      type: Recreate
    selector:
...
          app: 'humio-operator'
          app.kubernetes.io/name: 'humio-operator'
          app.kubernetes.io/instance: 'humio-operator'
          app.kubernetes.io/managed-by: 'Helm'
          helm.sh/chart: 'humio-operator-0.18.0'
+         generic_label: everywhere
+         foo: bar
      spec:
        affinity:
          nodeAffinity:
            requiredDuringSchedulingIgnoredDuringExecution:
              nodeSelectorTerms:
```