### PR TITLE
Get rid of preview/stable logic for RollingUpdateBestEffort

### DIFF
--- a/config/samples/core_v1alpha1_humiocluster.yaml
+++ b/config/samples/core_v1alpha1_humiocluster.yaml
@@ -11,7 +11,7 @@ spec:
   extraKafkaConfigs: "security.protocol=PLAINTEXT"
   tls:
     enabled: false
-  image: "humio/humio-core:1.70.0"
+  image: "humio/humio-core:1.76.2"
   nodeCount: 1
   targetReplicationFactor: 1
   environmentVariables:

--- a/config/samples/core_v1alpha1_humiocluster_shared_serviceaccount.yaml
+++ b/config/samples/core_v1alpha1_humiocluster_shared_serviceaccount.yaml
@@ -11,7 +11,7 @@ spec:
   extraKafkaConfigs: "security.protocol=PLAINTEXT"
   tls:
     enabled: false
-  image: "humio/humio-core:1.70.0"
+  image: "humio/humio-core:1.76.2"
   humioServiceAccountName: humio
   initServiceAccountName: humio
   authServiceAccountName: humio

--- a/controllers/humiocluster_defaults.go
+++ b/controllers/humiocluster_defaults.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	Image                        = "humio/humio-core:1.70.0"
+	Image                        = "humio/humio-core:1.76.2"
 	HelperImage                  = "humio/humio-operator-helper:85bed4456d6eb580d655ad462afad1ec6e6aef22"
 	targetReplicationFactor      = 2
 	storagePartitionsCount       = 24

--- a/controllers/humiocluster_pod_lifecycle.go
+++ b/controllers/humiocluster_pod_lifecycle.go
@@ -1,10 +1,11 @@
 package controllers
 
 import (
+	"time"
+
 	humiov1alpha1 "github.com/humio/humio-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 )
 
 type podLifecycleState struct {
@@ -44,20 +45,6 @@ func (p *podLifecycleState) ShouldRollingRestart() bool {
 				// allow rolling upgrades and downgrades for patch releases
 				if p.versionDifference.from.SemVer().Minor() == p.versionDifference.to.SemVer().Minor() {
 					return true
-				}
-				// only allow rolling upgrades for stable releases (non-preview)
-				if p.versionDifference.to.IsStable() {
-					// only allow rolling upgrades that are changing by one minor version
-					if p.versionDifference.from.SemVer().Minor()+1 == p.versionDifference.to.SemVer().Minor() {
-						return true
-					}
-				}
-				// only allow rolling downgrades for stable versions (non-preview)
-				if p.versionDifference.from.IsStable() {
-					// only allow rolling downgrades that are changing by one minor version
-					if p.versionDifference.from.SemVer().Minor()-1 == p.versionDifference.to.SemVer().Minor() {
-						return true
-					}
 				}
 			}
 		}

--- a/controllers/humiocluster_version.go
+++ b/controllers/humiocluster_version.go
@@ -64,13 +64,6 @@ func (hv *HumioVersion) IsLatest() bool {
 	return hv.assumeLatest
 }
 
-func (hv *HumioVersion) IsStable() bool {
-	if hv.SemVer().Minor() == 0 {
-		return true
-	}
-	return hv.SemVer().Minor()%2 == 0
-}
-
 func (hv *HumioVersion) constraint(constraintStr string) (bool, error) {
 	constraint, err := semver.NewConstraint(constraintStr)
 	return constraint.Check(hv.version), err

--- a/examples/humiocluster-affinity-and-tolerations.yaml
+++ b/examples/humiocluster-affinity-and-tolerations.yaml
@@ -7,7 +7,7 @@ spec:
     secretKeyRef:
       name: example-humiocluster-license
       key: data
-  image: "humio/humio-core:1.70.0"
+  image: "humio/humio-core:1.76.2"
   environmentVariables:
     - name: "ZOOKEEPER_URL"
       value: "humio-cp-zookeeper-0.humio-cp-zookeeper-headless:2181"

--- a/examples/humiocluster-data-volume-persistent-volume-claim-policy-kind-local.yaml
+++ b/examples/humiocluster-data-volume-persistent-volume-claim-policy-kind-local.yaml
@@ -7,7 +7,7 @@ spec:
     secretKeyRef:
       name: example-humiocluster-license
       key: data
-  image: "humio/humio-core:1.70.0"
+  image: "humio/humio-core:1.76.2"
   nodeCount: 1
   tls:
     enabled: false

--- a/examples/humiocluster-ephemeral-with-gcs-storage.yaml
+++ b/examples/humiocluster-ephemeral-with-gcs-storage.yaml
@@ -7,7 +7,7 @@ spec:
     secretKeyRef:
       name: example-humiocluster-license
       key: data
-  image: "humio/humio-core:1.70.0"
+  image: "humio/humio-core:1.76.2"
   targetReplicationFactor: 2
   storagePartitionsCount: 24
   digestPartitionsCount: 24

--- a/examples/humiocluster-ephemeral-with-s3-storage.yaml
+++ b/examples/humiocluster-ephemeral-with-s3-storage.yaml
@@ -7,7 +7,7 @@ spec:
     secretKeyRef:
       name: example-humiocluster-license
       key: data
-  image: "humio/humio-core:1.70.0"
+  image: "humio/humio-core:1.76.2"
   targetReplicationFactor: 2
   storagePartitionsCount: 24
   digestPartitionsCount: 24

--- a/examples/humiocluster-kind-local.yaml
+++ b/examples/humiocluster-kind-local.yaml
@@ -7,7 +7,7 @@ spec:
     secretKeyRef:
       name: example-humiocluster-license
       key: data
-  image: "humio/humio-core:1.70.0"
+  image: "humio/humio-core:1.76.2"
   nodeCount: 1
   tls:
     enabled: false

--- a/examples/humiocluster-multi-nodepool-kind-local.yaml
+++ b/examples/humiocluster-multi-nodepool-kind-local.yaml
@@ -6,7 +6,7 @@ spec:
   nodePools:
     - name: ingest-only
       spec:
-        image: "humio/humio-core:1.70.0"
+        image: "humio/humio-core:1.76.2"
         nodeCount: 1
         dataVolumePersistentVolumeClaimSpecTemplate:
           storageClassName: standard
@@ -32,7 +32,7 @@ spec:
     secretKeyRef:
       name: example-humiocluster-license
       key: data
-  image: "humio/humio-core:1.70.0"
+  image: "humio/humio-core:1.76.2"
   nodeCount: 1
   tls:
     enabled: false

--- a/examples/humiocluster-nginx-ingress-with-cert-manager.yaml
+++ b/examples/humiocluster-nginx-ingress-with-cert-manager.yaml
@@ -7,7 +7,7 @@ spec:
     secretKeyRef:
       name: example-humiocluster-license
       key: data
-  image: "humio/humio-core:1.70.0"
+  image: "humio/humio-core:1.76.2"
   environmentVariables:
     - name: "ZOOKEEPER_URL"
       value: "humio-cp-zookeeper-0.humio-cp-zookeeper-headless:2181"

--- a/examples/humiocluster-nginx-ingress-with-custom-path.yaml
+++ b/examples/humiocluster-nginx-ingress-with-custom-path.yaml
@@ -7,7 +7,7 @@ spec:
     secretKeyRef:
       name: example-humiocluster-license
       key: data
-  image: "humio/humio-core:1.70.0"
+  image: "humio/humio-core:1.76.2"
   environmentVariables:
     - name: "ZOOKEEPER_URL"
       value: "humio-cp-zookeeper-0.humio-cp-zookeeper-headless:2181"

--- a/examples/humiocluster-nginx-ingress-with-hostname-secrets.yaml
+++ b/examples/humiocluster-nginx-ingress-with-hostname-secrets.yaml
@@ -7,7 +7,7 @@ spec:
     secretKeyRef:
       name: example-humiocluster-license
       key: data
-  image: "humio/humio-core:1.70.0"
+  image: "humio/humio-core:1.76.2"
   environmentVariables:
     - name: "ZOOKEEPER_URL"
       value: "humio-cp-zookeeper-0.humio-cp-zookeeper-headless:2181"

--- a/examples/humiocluster-persistent-volumes.yaml
+++ b/examples/humiocluster-persistent-volumes.yaml
@@ -7,7 +7,7 @@ spec:
     secretKeyRef:
       name: example-humiocluster-license
       key: data
-  image: "humio/humio-core:1.70.0"
+  image: "humio/humio-core:1.76.2"
   targetReplicationFactor: 2
   storagePartitionsCount: 24
   digestPartitionsCount: 24


### PR DESCRIPTION
This also adds update strategy to a test, since the default is `HumioClusterUpdateStrategyReplaceAllOnUpdate` but the test seems to be trying to test the behavior of `HumioClusterUpdateStrategyRollingUpdateBestEffort` and thus is the cause of a bunch of flakiness.