### PR TITLE
HumioAction: How to improve secret handling?

### DIFF
--- a/controllers/humioaction_annotations.go
+++ b/controllers/humioaction_annotations.go
@@ -33,6 +33,7 @@ func (r *HumioActionReconciler) reconcileHumioActionAnnotations(ctx context.Cont
 	}
 
 	// TODO: Hack it here
+	ha.Spec.SlackPostMessageProperties.ApiToken = ""
 	err = r.Update(ctx, actionCR)
 	if err != nil {
 		return reconcile.Result{}, r.logErrorAndReturn(err, "failed to add ID annotation to action")

--- a/controllers/humioaction_annotations.go
+++ b/controllers/humioaction_annotations.go
@@ -32,6 +32,7 @@ func (r *HumioActionReconciler) reconcileHumioActionAnnotations(ctx context.Cont
 		actionCR.ObjectMeta.Annotations[k] = v
 	}
 
+	// TODO: Hack it here
 	err = r.Update(ctx, actionCR)
 	if err != nil {
 		return reconcile.Result{}, r.logErrorAndReturn(err, "failed to add ID annotation to action")

--- a/controllers/humioaction_annotations.go
+++ b/controllers/humioaction_annotations.go
@@ -32,7 +32,7 @@ func (r *HumioActionReconciler) reconcileHumioActionAnnotations(ctx context.Cont
 		actionCR.ObjectMeta.Annotations[k] = v
 	}
 
-	// TODO: Hack it here
+	// Remove token to hide it from Kubernetes
 	ha.Spec.SlackPostMessageProperties.ApiToken = ""
 	err = r.Update(ctx, actionCR)
 	if err != nil {

--- a/controllers/humioaction_controller.go
+++ b/controllers/humioaction_controller.go
@@ -196,6 +196,7 @@ func (r *HumioActionReconciler) reconcileHumioAction(ctx context.Context, config
 func (r *HumioActionReconciler) resolveSecrets(ctx context.Context, ha *humiov1alpha1.HumioAction) error {
 	var err error
 
+	// TODO: Add logic here
 	if ha.Spec.SlackPostMessageProperties != nil {
 		ha.Spec.SlackPostMessageProperties.ApiToken, err = r.resolveField(ctx, ha.Namespace, ha.Spec.SlackPostMessageProperties.ApiToken, ha.Spec.SlackPostMessageProperties.ApiTokenSource)
 		if err != nil {

--- a/controllers/humioaction_controller.go
+++ b/controllers/humioaction_controller.go
@@ -127,7 +127,8 @@ func (r *HumioActionReconciler) reconcileHumioAction(ctx context.Context, config
 
 			r.Log.Info("Action Deleted. Removing finalizer")
 			ha.SetFinalizers(helpers.RemoveElement(ha.GetFinalizers(), humioFinalizer))
-			// TODO: hack here
+
+			// Remove token to hide it from Kubernetes
 			ha.Spec.SlackPostMessageProperties.ApiToken = ""
 			err := r.Update(ctx, ha)
 			if err != nil {
@@ -143,7 +144,8 @@ func (r *HumioActionReconciler) reconcileHumioAction(ctx context.Context, config
 	if !helpers.ContainsElement(ha.GetFinalizers(), humioFinalizer) {
 		r.Log.Info("Finalizer not present, adding finalizer to Action")
 		ha.SetFinalizers(append(ha.GetFinalizers(), humioFinalizer))
-		// TODO: hack here
+
+		// Remove token to hide it from Kubernetes
 		ha.Spec.SlackPostMessageProperties.ApiToken = ""
 		err := r.Update(ctx, ha)
 		if err != nil {

--- a/pkg/humio/action_transform.go
+++ b/pkg/humio/action_transform.go
@@ -292,7 +292,6 @@ func slackAction(hn *humiov1alpha1.HumioAction) (*humioapi.Action, error) {
 		return ifErrors(action, ActionTypeSlack, errorList)
 	}
 	action.Type = humioapi.ActionTypeSlack
-	// TODO: SlackProperties.Url should be a secret
 	action.SlackAction.Url = hn.Spec.SlackProperties.Url
 	action.SlackAction.UseProxy = hn.Spec.SlackProperties.UseProxy
 	action.SlackAction.Fields = []humioapi.SlackFieldEntryInput{}

--- a/pkg/humio/action_transform.go
+++ b/pkg/humio/action_transform.go
@@ -292,6 +292,7 @@ func slackAction(hn *humiov1alpha1.HumioAction) (*humioapi.Action, error) {
 		return ifErrors(action, ActionTypeSlack, errorList)
 	}
 	action.Type = humioapi.ActionTypeSlack
+	// TODO: SlackProperties.Url should be a secret
 	action.SlackAction.Url = hn.Spec.SlackProperties.Url
 	action.SlackAction.UseProxy = hn.Spec.SlackProperties.UseProxy
 	action.SlackAction.Fields = []humioapi.SlackFieldEntryInput{}


### PR DESCRIPTION
Both [issue 636](https://github.com/humio/humio-operator/issues/636) as well as [479](https://github.com/humio/humio-operator/issues/479) point out that the current implementation of Humio Action CRs causes secrets to be exposed as plaintext values in the resources.

I had a few hours to look into how this could be improved and I made this PR mostly to spark some discussion. This PR is not meant to be merged as-is. I just wanted to get the maintainer's thoughts on it before going too far in either direction.

# My thoughts on the topic
I just spent a little time looking into it, and it seems like the issue comes from the pattern of resolving secrets into the plaintext fields of the `ha` objects as is done [here](https://github.com/humio/humio-operator/blob/9d939614048952c4dfbf5938eff60ab6ee5cb473/controllers/humioaction_controller.go#L196).

In my opinion, this can be fixed in a couple of ways:

1) Switch pattern so the secret is passed along with the `ha` object down to the point where the HumioClient can reconcile with Humio, such that the `ha` object only ever has a reference to the secret and the secret is never set on the actual `ha` resource. This would mean removing the plaintext fields such as `ha.Spec.SlackPostMessageProperties.ApiToken` from the resources altogether.
2) Make a "hack" where the secrets are removed just before updating the resource's definitions on the kubernetes side. This way, fields like `ha.Spec.SlackPostMessageProperties.ApiToken` never make it into kubernetes, but they can still be used for DTO.

In my opinion 1) would be the cleaner solution. However, it would require some changes in how secrets are handled in the Humio Actions and it would be a breaking change 🙁 It should be noted that this is the recommended way of handling this from a kubernetes point of view.

Option 2) is much less clean, but it would likely be quicker to implement, and it is not a breaking change as it allows people to continue using the plain text versions of the secrets if they so choose.


# What I actually implemented

I wanted to get a feel for what option 2) would look like, even though I don't feel like it is the best solution. As such, I added a hack to `ha.Spec.SlackPostMessageProperties.ApiToken` a few places just before `r.Update` is called. It is definitely the ugly way to solve the issue.

What do the maintainers think? Should something like 2) be made for backward compatibility, should 1) be considered, or am I just completely off base here? 😄 