### PR TITLE
Run storage validation on all node pools and allow to run clusters wi…

### DIFF
--- a/api/v1alpha1/humiocluster_types.go
+++ b/api/v1alpha1/humiocluster_types.go
@@ -112,7 +112,7 @@ type HumioNodeSpec struct {
 	AuthServiceAccountName string `json:"authServiceAccountName,omitempty"`
 
 	// DisableInitContainer is used to disable the init container completely which collects the availability zone from the Kubernetes worker node.
-	// This is not recommended, unless you are using auto rebalancing partitions and are running in a single single availability zone.
+	// This is not recommended, unless you are using auto rebalancing partitions and are running in a single availability zone.
 	DisableInitContainer bool `json:"disableInitContainer,omitempty"`
 
 	// EnvironmentVariablesSource is the reference to an external source of environment variables that will be merged with environmentVariables

--- a/charts/humio-operator/crds/core.humio.com_humioclusters.yaml
+++ b/charts/humio-operator/crds/core.humio.com_humioclusters.yaml
@@ -3108,7 +3108,7 @@ spec:
                 description: DisableInitContainer is used to disable the init container
                   completely which collects the availability zone from the Kubernetes
                   worker node. This is not recommended, unless you are using auto
-                  rebalancing partitions and are running in a single single availability
+                  rebalancing partitions and are running in a single availability
                   zone.
                 type: boolean
               environmentVariables:
@@ -8375,7 +8375,7 @@ spec:
                             init container completely which collects the availability
                             zone from the Kubernetes worker node. This is not recommended,
                             unless you are using auto rebalancing partitions and are
-                            running in a single single availability zone.
+                            running in a single availability zone.
                           type: boolean
                         environmentVariables:
                           description: EnvironmentVariables that will be merged with

--- a/config/crd/bases/core.humio.com_humioclusters.yaml
+++ b/config/crd/bases/core.humio.com_humioclusters.yaml
@@ -3108,7 +3108,7 @@ spec:
                 description: DisableInitContainer is used to disable the init container
                   completely which collects the availability zone from the Kubernetes
                   worker node. This is not recommended, unless you are using auto
-                  rebalancing partitions and are running in a single single availability
+                  rebalancing partitions and are running in a single availability
                   zone.
                 type: boolean
               environmentVariables:
@@ -8375,7 +8375,7 @@ spec:
                             init container completely which collects the availability
                             zone from the Kubernetes worker node. This is not recommended,
                             unless you are using auto rebalancing partitions and are
-                            running in a single single availability zone.
+                            running in a single availability zone.
                           type: boolean
                         environmentVariables:
                           description: EnvironmentVariables that will be merged with

--- a/controllers/humiocluster_services.go
+++ b/controllers/humiocluster_services.go
@@ -91,8 +91,8 @@ func constructHeadlessService(hc *humiov1alpha1.HumioCluster) *corev1.Service {
 	}
 }
 
-func headlessServiceName(prefix string) string {
-	return fmt.Sprintf("%s-headless", prefix)
+func headlessServiceName(clusterName string) string {
+	return fmt.Sprintf("%s-headless", clusterName)
 }
 
 func servicesMatch(existingService *corev1.Service, service *corev1.Service) (bool, error) {

--- a/controllers/suite/clusters/humiocluster_controller_test.go
+++ b/controllers/suite/clusters/humiocluster_controller_test.go
@@ -100,6 +100,25 @@ var _ = Describe("HumioCluster Controller", func() {
 		})
 	})
 
+	Context("Humio Cluster With Node Pools Only", func() {
+		It("Should bootstrap nodepools only cluster correctly", func() {
+			key := types.NamespacedName{
+				Name:      "humiocluster-node-pool-only",
+				Namespace: testProcessNamespace,
+			}
+			nodeCount0 := 0
+			toCreate := constructBasicMultiNodePoolHumioCluster(key, true, 2)
+			toCreate.Spec.NodeCount = &nodeCount0
+			toCreate.Spec.DataVolumeSource = corev1.VolumeSource{}
+			toCreate.Spec.DataVolumePersistentVolumeClaimSpecTemplate = corev1.PersistentVolumeClaimSpec{}
+
+			suite.UsingClusterBy(key.Name, "Creating the cluster successfully")
+			ctx := context.Background()
+			createAndBootstrapMultiNodePoolCluster(ctx, k8sClient, humioClientForTestSuite, toCreate, true, humiov1alpha1.HumioClusterStateRunning)
+			defer suite.CleanupCluster(ctx, k8sClient, toCreate)
+		})
+	})
+
 	Context("Humio Cluster Without Init Container", func() {
 		It("Should bootstrap cluster correctly", func() {
 			key := types.NamespacedName{

--- a/controllers/suite/common.go
+++ b/controllers/suite/common.go
@@ -384,7 +384,7 @@ func CreateAndBootstrapCluster(ctx context.Context, k8sClient client.Client, hum
 		}, testTimeout, TestInterval).Should(HaveLen(*pool.NodeCount))
 	}
 
-	clusterPods, _ := kubernetes.ListPods(ctx, k8sClient, key.Namespace, controllers.NewHumioNodeManagerFromHumioCluster(&updatedHumioCluster).GetPodLabels())
+	clusterPods, _ := kubernetes.ListPods(ctx, k8sClient, key.Namespace, controllers.NewHumioNodeManagerFromHumioCluster(&updatedHumioCluster).GetCommonClusterLabels())
 	humioIdx, err := kubernetes.GetContainerIndexByName(clusterPods[0], controllers.HumioContainerName)
 	Expect(err).ToNot(HaveOccurred())
 	humioContainerArgs := strings.Join(clusterPods[0].Spec.Containers[humioIdx].Args, " ")
@@ -439,7 +439,7 @@ func CreateAndBootstrapCluster(ctx context.Context, k8sClient client.Client, hum
 
 	UsingClusterBy(key.Name, "Waiting for the auth sidecar to populate the secret containing the API token")
 	Eventually(func() error {
-		clusterPods, _ = kubernetes.ListPods(ctx, k8sClient, key.Namespace, controllers.NewHumioNodeManagerFromHumioCluster(&updatedHumioCluster).GetPodLabels())
+		clusterPods, _ = kubernetes.ListPods(ctx, k8sClient, key.Namespace, controllers.NewHumioNodeManagerFromHumioCluster(&updatedHumioCluster).GetCommonClusterLabels())
 		for idx := range clusterPods {
 			UsingClusterBy(key.Name, fmt.Sprintf("Pod status %s status: %v", clusterPods[idx].Name, clusterPods[idx].Status))
 		}

--- a/examples/humiocluster-nodepool-slice-only.yaml
+++ b/examples/humiocluster-nodepool-slice-only.yaml
@@ -1,0 +1,59 @@
+apiVersion: core.humio.com/v1alpha1
+kind: HumioCluster
+metadata:
+  name: example-humiocluster
+spec:
+  license:
+    secretKeyRef:
+      name: example-humiocluster-license
+      key: data
+  targetReplicationFactor: 2
+  storagePartitionsCount: 720
+  digestPartitionsCount: 720
+  nodeCount: 0
+
+  nodePools:
+    - name: "segments"
+      spec:
+        image: "humio/humio-core:1.76.2"
+        nodeCount: 1
+        extraKafkaConfigs: "security.protocol=PLAINTEXT"
+        dataVolumePersistentVolumeClaimPolicy:
+          reclaimType: OnNodeDelete
+        dataVolumePersistentVolumeClaimSpecTemplate:
+          storageClassName: standard
+          accessModes: [ReadWriteOnce]
+          resources:
+            requests:
+              storage: 10Gi
+        environmentVariables:
+          - name: QUERY_COORDINATOR
+            value: "false"
+          - name: HUMIO_MEMORY_OPTS
+            value: "-Xss2m -Xms1g -Xmx2g -XX:MaxDirectMemorySize=1g"
+          - name: ZOOKEEPER_URL
+            value: "humio-cp-zookeeper-0.humio-cp-zookeeper-headless.default:2181"
+          - name: KAFKA_SERVERS
+            value: "humio-cp-kafka-0.humio-cp-kafka-headless.default:9092"
+    - name: "httponly"
+      spec:
+        image: "humio/humio-core:1.76.2"
+        nodeCount: 1
+        extraKafkaConfigs: "security.protocol=PLAINTEXT"
+        dataVolumePersistentVolumeClaimPolicy:
+          reclaimType: OnNodeDelete
+        dataVolumePersistentVolumeClaimSpecTemplate:
+          storageClassName: standard
+          accessModes: [ReadWriteOnce]
+          resources:
+            requests:
+              storage: 10Gi
+        environmentVariables:
+          - name: NODE_ROLES
+            value: "httponly"
+          - name: HUMIO_MEMORY_OPTS
+            value: "-Xss2m -Xms1g -Xmx2g -XX:MaxDirectMemorySize=1g"
+          - name: ZOOKEEPER_URL
+            value: "humio-cp-zookeeper-0.humio-cp-zookeeper-headless.default:2181"
+          - name: KAFKA_SERVERS
+            value: "humio-cp-kafka-0.humio-cp-kafka-headless.default:9092"

--- a/hack/run-e2e-tests-kind.sh
+++ b/hack/run-e2e-tests-kind.sh
@@ -23,7 +23,7 @@ kubectl create -k config/crd/
 kubectl label node --overwrite --all topology.kubernetes.io/zone=az1
 
 # We skip the helpers package as those tests assumes the environment variable USE_CERT_MANAGER is not set.
-USE_CERTMANAGER=true TEST_USE_EXISTING_CLUSTER=true $ginkgo --always-emit-ginkgo-writer -slow-spec-threshold=5s --output-interceptor-mode=none -timeout 90m -nodes=$ginkgo_nodes --skip-package helpers -race -v ./testbindir/* -covermode=count -coverprofile cover.out -progress | tee /proc/1/fd/1
+USE_CERTMANAGER=true TEST_USE_EXISTING_CLUSTER=true $ginkgo --always-emit-ginkgo-writer -slow-spec-threshold=5s -timeout 90m -nodes=$ginkgo_nodes --skip-package helpers -race -v ./testbindir/* -covermode=count -coverprofile cover.out -progress | tee /proc/1/fd/1
 TEST_EXIT_CODE=$?
 
 end=$(date +%s)

--- a/pkg/helpers/clusterinterface.go
+++ b/pkg/helpers/clusterinterface.go
@@ -97,7 +97,7 @@ func (c Cluster) Url(ctx context.Context, k8sClient client.Client) (*url.URL, er
 			log.Infof("humio managed cluster configured as insecure, using http")
 			protocol = "http"
 		}
-		baseURL, _ := url.Parse(fmt.Sprintf("%s://%s.%s:%d/", protocol, c.managedClusterName, c.namespace, 8080))
+		baseURL, _ := url.Parse(fmt.Sprintf("%s://%s-headless.%s:%d/", protocol, c.managedClusterName, c.namespace, 8080))
 		return baseURL, nil
 	}
 

--- a/pkg/helpers/clusterinterface_test.go
+++ b/pkg/helpers/clusterinterface_test.go
@@ -19,14 +19,15 @@ package helpers
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"testing"
+
 	humiov1alpha1 "github.com/humio/humio-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"net/url"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 )
 
 func TestCluster_HumioConfig_managedHumioCluster(t *testing.T) {
@@ -188,7 +189,7 @@ func TestCluster_HumioConfig_managedHumioCluster(t *testing.T) {
 			if !TLSEnabled(&tt.managedHumioCluster) {
 				protocol = "http"
 			}
-			expectedURL := fmt.Sprintf("%s://%s.%s:8080/", protocol, tt.managedHumioCluster.Name, tt.managedHumioCluster.Namespace)
+			expectedURL := fmt.Sprintf("%s://%s-headless.%s:8080/", protocol, tt.managedHumioCluster.Name, tt.managedHumioCluster.Namespace)
 			if cluster.Config().Address.String() != expectedURL {
 				t.Errorf("url not correct, expected: %s, got: %s", expectedURL, cluster.Config().Address)
 			}

--- a/pkg/humio/client.go
+++ b/pkg/humio/client.go
@@ -248,7 +248,7 @@ func (h *ClientConfig) GetBaseURL(config *humioapi.Config, req reconcile.Request
 	if !helpers.TLSEnabled(hc) {
 		protocol = "http"
 	}
-	baseURL, _ := url.Parse(fmt.Sprintf("%s://%s.%s:%d/", protocol, hc.Name, hc.Namespace, 8080))
+	baseURL, _ := url.Parse(fmt.Sprintf("%s://%s-headless.%s:%d/", protocol, hc.Name, hc.Namespace, 8080))
 	return baseURL
 
 }

--- a/pkg/humio/client_mock.go
+++ b/pkg/humio/client_mock.go
@@ -133,7 +133,7 @@ func (h *MockClientConfig) SuggestedIngestPartitions(config *humioapi.Config, re
 }
 
 func (h *MockClientConfig) GetBaseURL(config *humioapi.Config, req reconcile.Request, hc *humiov1alpha1.HumioCluster) *url.URL {
-	baseURL, _ := url.Parse(fmt.Sprintf("http://%s.%s:%d/", hc.Name, hc.Namespace, 8080))
+	baseURL, _ := url.Parse(fmt.Sprintf("http://%s-headless.%s:%d/", hc.Name, hc.Namespace, 8080))
 	return baseURL
 }
 

--- a/pkg/kubernetes/certificates.go
+++ b/pkg/kubernetes/certificates.go
@@ -18,6 +18,7 @@ package kubernetes
 
 import (
 	"context"
+
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )


### PR DESCRIPTION
…th pods spawned entirely through nodePools slice

Previously, we only did storage config validation on the HumioCluster "node pool", and not all the node pools. We can also skip storage validation if we don't have a nodeCount > 0.