### PR TITLE
Add support for role-permissions.json file

### DIFF
--- a/api/v1alpha1/humiocluster_types.go
+++ b/api/v1alpha1/humiocluster_types.go
@@ -62,8 +62,11 @@ type HumioClusterSpec struct {
 	License HumioClusterLicenseSpec `json:"license,omitempty"`
 	// IdpCertificateSecretName is the name of the secret that contains the IDP Certificate when using SAML authentication
 	IdpCertificateSecretName string `json:"idpCertificateSecretName,omitempty"`
-	// ViewGroupPermissions is a multi-line string containing view-group-permissions.json
+	// ViewGroupPermissions is a multi-line string containing view-group-permissions.json.
+	// Deprecated: Use RolePermissions instead.
 	ViewGroupPermissions string `json:"viewGroupPermissions,omitempty"`
+	// RolePermissions is a multi-line string containing role-permissions.json
+	RolePermissions string `json:"rolePermissions,omitempty"`
 	// Hostname is the public hostname used by clients to access Humio
 	Hostname string `json:"hostname,omitempty"`
 	// ESHostname is the public hostname used by log shippers with support for ES bulk API to access Humio

--- a/charts/humio-operator/crds/core.humio.com_humioclusters.yaml
+++ b/charts/humio-operator/crds/core.humio.com_humioclusters.yaml
@@ -12312,6 +12312,9 @@ spec:
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
+              rolePermissions:
+                description: RolePermissions is a multi-line string containing role-permissions.json
+                type: string
               shareProcessNamespace:
                 description: ShareProcessNamespace can be useful in combination with
                   SidecarContainers to be able to inspect the main Humio process.
@@ -13746,8 +13749,8 @@ spec:
                     type: string
                 type: object
               viewGroupPermissions:
-                description: ViewGroupPermissions is a multi-line string containing
-                  view-group-permissions.json
+                description: 'ViewGroupPermissions is a multi-line string containing
+                  view-group-permissions.json. Deprecated: Use RolePermissions instead.'
                 type: string
             type: object
           status:

--- a/config/crd/bases/core.humio.com_humioclusters.yaml
+++ b/config/crd/bases/core.humio.com_humioclusters.yaml
@@ -12312,6 +12312,9 @@ spec:
                       to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
+              rolePermissions:
+                description: RolePermissions is a multi-line string containing role-permissions.json
+                type: string
               shareProcessNamespace:
                 description: ShareProcessNamespace can be useful in combination with
                   SidecarContainers to be able to inspect the main Humio process.
@@ -13746,8 +13749,8 @@ spec:
                     type: string
                 type: object
               viewGroupPermissions:
-                description: ViewGroupPermissions is a multi-line string containing
-                  view-group-permissions.json
+                description: 'ViewGroupPermissions is a multi-line string containing
+                  view-group-permissions.json. Deprecated: Use RolePermissions instead.'
                 type: string
             type: object
           status:

--- a/controllers/humiocluster_defaults.go
+++ b/controllers/humiocluster_defaults.go
@@ -44,6 +44,7 @@ const (
 	idpCertificateFilename       = "idp-certificate.pem"
 	ExtraKafkaPropertiesFilename = "extra-kafka-properties.properties"
 	ViewGroupPermissionsFilename = "view-group-permissions.json"
+	RolePermissionsFilename      = "role-permissions.json"
 	nodeUUIDPrefix               = "humio_"
 	HumioContainerName           = "humio"
 	AuthContainerName            = "humio-auth"
@@ -63,6 +64,7 @@ const (
 	authRoleBindingSuffix                   = "auth"
 	extraKafkaConfigsConfigMapNameSuffix    = "extra-kafka-configs"
 	viewGroupPermissionsConfigMapNameSuffix = "view-group-permissions"
+	rolePermissionsConfigMapNameSuffix      = "role-permissions"
 	idpCertificateSecretNameSuffix          = "idp-certificate"
 )
 
@@ -78,6 +80,7 @@ type HumioNodePool struct {
 	tls                      *humiov1alpha1.HumioClusterTLSSpec
 	idpCertificateSecretName string
 	viewGroupPermissions     string
+	rolePermissions          string
 	targetReplicationFactor  int
 	storagePartitionsCount   int
 	digestPartitionsCount    int
@@ -141,6 +144,7 @@ func NewHumioNodeManagerFromHumioCluster(hc *humiov1alpha1.HumioCluster) *HumioN
 		tls:                      hc.Spec.TLS,
 		idpCertificateSecretName: hc.Spec.IdpCertificateSecretName,
 		viewGroupPermissions:     hc.Spec.ViewGroupPermissions,
+		rolePermissions:          hc.Spec.RolePermissions,
 		targetReplicationFactor:  hc.Spec.TargetReplicationFactor,
 		storagePartitionsCount:   hc.Spec.StoragePartitionsCount,
 		digestPartitionsCount:    hc.Spec.DigestPartitionsCount,
@@ -204,6 +208,7 @@ func NewHumioNodeManagerFromHumioNodePool(hc *humiov1alpha1.HumioCluster, hnp *h
 		tls:                      hc.Spec.TLS,
 		idpCertificateSecretName: hc.Spec.IdpCertificateSecretName,
 		viewGroupPermissions:     hc.Spec.ViewGroupPermissions,
+		rolePermissions:          hc.Spec.RolePermissions,
 		targetReplicationFactor:  hc.Spec.TargetReplicationFactor,
 		storagePartitionsCount:   hc.Spec.StoragePartitionsCount,
 		digestPartitionsCount:    hc.Spec.DigestPartitionsCount,
@@ -743,6 +748,14 @@ func (hnp HumioNodePool) GetViewGroupPermissionsConfigMapName() string {
 	return fmt.Sprintf("%s-%s", hnp.GetClusterName(), viewGroupPermissionsConfigMapNameSuffix)
 }
 
+func (hnp HumioNodePool) GetRolePermissions() string {
+	return hnp.rolePermissions
+}
+
+func (hnp HumioNodePool) GetRolePermissionsConfigMapName() string {
+	return fmt.Sprintf("%s-%s", hnp.GetClusterName(), rolePermissionsConfigMapNameSuffix)
+}
+
 func (hnp HumioNodePool) GetPath() string {
 	if hnp.path != "" {
 		if strings.HasPrefix(hnp.path, "/") {
@@ -866,6 +879,14 @@ func viewGroupPermissionsOrDefault(hc *humiov1alpha1.HumioCluster) string {
 
 func ViewGroupPermissionsConfigMapName(hc *humiov1alpha1.HumioCluster) string {
 	return fmt.Sprintf("%s-%s", hc.Name, viewGroupPermissionsConfigMapNameSuffix)
+}
+
+func rolePermissionsOrDefault(hc *humiov1alpha1.HumioCluster) string {
+	return hc.Spec.RolePermissions
+}
+
+func RolePermissionsConfigMapName(hc *humiov1alpha1.HumioCluster) string {
+	return fmt.Sprintf("%s-%s", hc.Name, rolePermissionsConfigMapNameSuffix)
 }
 
 func AppendEnvVarToEnvVarsIfNotAlreadyPresent(envVars []corev1.EnvVar, defaultEnvVar corev1.EnvVar) []corev1.EnvVar {

--- a/pkg/kubernetes/configmaps.go
+++ b/pkg/kubernetes/configmaps.go
@@ -52,6 +52,19 @@ func ConstructViewGroupPermissionsConfigMap(viewGroupPermissionsConfigMapName, v
 	}
 }
 
+// ConstructRolePermissionsConfigMap constructs a ConfigMap object used to store the file which Humio uses when
+// enabling READ_GROUP_PERMISSIONS_FROM_FILE to control RBAC using a file rather than the Humio UI
+func ConstructRolePermissionsConfigMap(rolePermissionsConfigMapName, rolePermissionsFilename, rolePermissionsConfigMapData, humioClusterName, humioClusterNamespace string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rolePermissionsConfigMapName,
+			Namespace: humioClusterNamespace,
+			Labels:    LabelsForHumio(humioClusterName),
+		},
+		Data: map[string]string{rolePermissionsFilename: rolePermissionsConfigMapData},
+	}
+}
+
 // GetConfigMap returns the configmap for the given configmap name if it exists
 func GetConfigMap(ctx context.Context, c client.Client, configMapName, humioClusterNamespace string) (*corev1.ConfigMap, error) {
 	var existingConfigMap corev1.ConfigMap


### PR DESCRIPTION
This replaced the even older view-group-permissions.json file years ago.

Official docs on the feature: https://library.humio.com/falcon-logscale/security-authorization-roles-in-file.html

---

Given how long time ago the old format was replaced, perhaps we could even consider removing support for that soon.