### PR TITLE
Stop printing node details for all cluster nodes

### DIFF
--- a/controllers/humiocluster_controller.go
+++ b/controllers/humiocluster_controller.go
@@ -1356,7 +1356,6 @@ func (r *HumioClusterReconciler) ensureLabels(ctx context.Context, config *humio
 		return r.logErrorAndReturn(err, "failed to list pvcs to assign labels")
 	}
 
-	r.Log.Info(fmt.Sprintf("cluster node details: %#+v", cluster.Nodes))
 	for idx, pod := range foundPodList {
 		// Skip pods that already have a label. Check that the pvc also has the label if applicable
 		if kubernetes.LabelListContainsLabel(pod.GetLabels(), kubernetes.NodeIdLabelName) {


### PR DESCRIPTION
Due to the size of the details for large clusters, this ends up being split into multiple log lines causing log shipping to ship the log line as multiple events, which breaks parsing of each event since they are not valid JSON events.

So far, we've not had a case where this log line was important to us, so let's remove it.