### PR TITLE
Skip ZK node UUID URL for new logscale versions

### DIFF
--- a/api/v1alpha1/humiocluster_types.go
+++ b/api/v1alpha1/humiocluster_types.go
@@ -189,6 +189,7 @@ type HumioNodeSpec struct {
 	// NodeUUIDPrefix is the prefix for the Humio Node's UUID. By default this does not include the zone. If it's
 	// necessary to include zone, there is a special `Zone` variable that can be used. To use this, set `{{.Zone}}`. For
 	// compatibility with pre-0.0.14 spec defaults, this should be set to `humio_{{.Zone}}`
+	// Deprecated: LogScale 1.70.0 deprecated this option, and was later removed in LogScale 1.80.0
 	NodeUUIDPrefix string `json:"nodeUUIDPrefix,omitempty"`
 
 	// ExtraKafkaConfigs is a multi-line string containing kafka properties

--- a/charts/humio-operator/crds/core.humio.com_humioclusters.yaml
+++ b/charts/humio-operator/crds/core.humio.com_humioclusters.yaml
@@ -10326,12 +10326,14 @@ spec:
                             nodes
                           type: integer
                         nodeUUIDPrefix:
-                          description: NodeUUIDPrefix is the prefix for the Humio
-                            Node's UUID. By default this does not include the zone.
-                            If it's necessary to include zone, there is a special
+                          description: 'NodeUUIDPrefix is the prefix for the Humio
+                            Node''s UUID. By default this does not include the zone.
+                            If it''s necessary to include zone, there is a special
                             `Zone` variable that can be used. To use this, set `{{.Zone}}`.
                             For compatibility with pre-0.0.14 spec defaults, this
-                            should be set to `humio_{{.Zone}}`
+                            should be set to `humio_{{.Zone}}` Deprecated: LogScale
+                            1.70.0 deprecated this option, and was later removed in
+                            LogScale 1.80.0'
                           type: string
                         podAnnotations:
                           additionalProperties:
@@ -12096,11 +12098,13 @@ spec:
                   type: object
                 type: array
               nodeUUIDPrefix:
-                description: NodeUUIDPrefix is the prefix for the Humio Node's UUID.
-                  By default this does not include the zone. If it's necessary to
+                description: 'NodeUUIDPrefix is the prefix for the Humio Node''s UUID.
+                  By default this does not include the zone. If it''s necessary to
                   include zone, there is a special `Zone` variable that can be used.
                   To use this, set `{{.Zone}}`. For compatibility with pre-0.0.14
-                  spec defaults, this should be set to `humio_{{.Zone}}`
+                  spec defaults, this should be set to `humio_{{.Zone}}` Deprecated:
+                  LogScale 1.70.0 deprecated this option, and was later removed in
+                  LogScale 1.80.0'
                 type: string
               path:
                 description: Path is the root URI path of the Humio cluster

--- a/config/crd/bases/core.humio.com_humioclusters.yaml
+++ b/config/crd/bases/core.humio.com_humioclusters.yaml
@@ -10326,12 +10326,14 @@ spec:
                             nodes
                           type: integer
                         nodeUUIDPrefix:
-                          description: NodeUUIDPrefix is the prefix for the Humio
-                            Node's UUID. By default this does not include the zone.
-                            If it's necessary to include zone, there is a special
+                          description: 'NodeUUIDPrefix is the prefix for the Humio
+                            Node''s UUID. By default this does not include the zone.
+                            If it''s necessary to include zone, there is a special
                             `Zone` variable that can be used. To use this, set `{{.Zone}}`.
                             For compatibility with pre-0.0.14 spec defaults, this
-                            should be set to `humio_{{.Zone}}`
+                            should be set to `humio_{{.Zone}}` Deprecated: LogScale
+                            1.70.0 deprecated this option, and was later removed in
+                            LogScale 1.80.0'
                           type: string
                         podAnnotations:
                           additionalProperties:
@@ -12096,11 +12098,13 @@ spec:
                   type: object
                 type: array
               nodeUUIDPrefix:
-                description: NodeUUIDPrefix is the prefix for the Humio Node's UUID.
-                  By default this does not include the zone. If it's necessary to
+                description: 'NodeUUIDPrefix is the prefix for the Humio Node''s UUID.
+                  By default this does not include the zone. If it''s necessary to
                   include zone, there is a special `Zone` variable that can be used.
                   To use this, set `{{.Zone}}`. For compatibility with pre-0.0.14
-                  spec defaults, this should be set to `humio_{{.Zone}}`
+                  spec defaults, this should be set to `humio_{{.Zone}}` Deprecated:
+                  LogScale 1.70.0 deprecated this option, and was later removed in
+                  LogScale 1.80.0'
                 type: string
               path:
                 description: Path is the root URI path of the Humio cluster

--- a/controllers/humiocluster_defaults_test.go
+++ b/controllers/humiocluster_defaults_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -199,6 +200,7 @@ func Test_constructContainerArgs(t *testing.T) {
 				&humiov1alpha1.HumioCluster{
 					Spec: humiov1alpha1.HumioClusterSpec{
 						HumioNodeSpec: humiov1alpha1.HumioNodeSpec{
+							Image: fmt.Sprintf("humio/humio-core:%s", HumioVersionWithNewVhostSelection),
 							EnvironmentVariables: []corev1.EnvVar{
 								{
 									Name:  "USING_EPHEMERAL_DISKS",
@@ -271,12 +273,12 @@ func Test_constructContainerArgs(t *testing.T) {
 					},
 				},
 				[]string{
-					"export ZOOKEEPER_PREFIX_FOR_NODE_UUID=",
 					"export ZONE=",
 				},
 				[]string{
 					"export CORES=",
 					"export HUMIO_OPTS=",
+					"export ZOOKEEPER_PREFIX_FOR_NODE_UUID=",
 				},
 			},
 		},
@@ -303,10 +305,10 @@ func Test_constructContainerArgs(t *testing.T) {
 				[]string{
 					"export CORES=",
 					"export HUMIO_OPTS=",
-					"export ZOOKEEPER_PREFIX_FOR_NODE_UUID=",
 				},
 				[]string{
 					"export ZONE=",
+					"export ZOOKEEPER_PREFIX_FOR_NODE_UUID=",
 				},
 			},
 		},
@@ -335,13 +337,12 @@ func Test_constructContainerArgs(t *testing.T) {
 						},
 					},
 				},
-				[]string{
-					"export ZOOKEEPER_PREFIX_FOR_NODE_UUID=",
-				},
+				[]string{},
 				[]string{
 					"export CORES=",
 					"export HUMIO_OPTS=",
 					"export ZONE=",
+					"export ZOOKEEPER_PREFIX_FOR_NODE_UUID=",
 				},
 			},
 		},
@@ -453,12 +454,12 @@ func Test_constructContainerArgs(t *testing.T) {
 					},
 				},
 				[]string{
-					"export ZOOKEEPER_PREFIX_FOR_NODE_UUID=",
 					"export ZONE=",
 				},
 				[]string{
 					"export CORES=",
 					"export HUMIO_OPTS=",
+					"export ZOOKEEPER_PREFIX_FOR_NODE_UUID=",
 				},
 			},
 		},
@@ -486,13 +487,12 @@ func Test_constructContainerArgs(t *testing.T) {
 						},
 					},
 				},
-				[]string{
-					"export ZOOKEEPER_PREFIX_FOR_NODE_UUID=",
-				},
+				[]string{},
 				[]string{
 					"export CORES=",
 					"export HUMIO_OPTS=",
 					"export ZONE=",
+					"export ZOOKEEPER_PREFIX_FOR_NODE_UUID=",
 				},
 			},
 		},

--- a/controllers/humiocluster_version.go
+++ b/controllers/humiocluster_version.go
@@ -11,6 +11,7 @@ const (
 	HumioVersionMinimumSupported                 = "1.36.0"
 	HumioVersionWithDefaultSingleUserAuth        = "1.68.0"
 	HumioVersionWithNewVhostSelection            = "1.70.0"
+	HumioVersionWithoutOldVhostSelection         = "1.80.0"
 	HumioVersionWithAutomaticPartitionManagement = "1.89.0"
 )
 

--- a/controllers/suite/clusters/humiocluster_controller_test.go
+++ b/controllers/suite/clusters/humiocluster_controller_test.go
@@ -2149,6 +2149,7 @@ var _ = Describe("HumioCluster Controller", func() {
 				Namespace: testProcessNamespace,
 			}
 			toCreate := suite.ConstructBasicSingleNodeHumioCluster(key, true)
+			toCreate.Spec.Image = oldSupportedHumioVersion
 			// ZOOKEEPER_URL gets filtered out by default in the call to ConstructBasicSingleNodeHumioCluster, so we add it back here
 			toCreate.Spec.EnvironmentVariables = append([]corev1.EnvVar{{
 				Name:  "ZOOKEEPER_URL",


### PR DESCRIPTION
This stops automatically appending `ZOOKEEPER_PREFIX_FOR_NODE_UUID` and `ZOOKEEPER_URL_FOR_NODE_UUID` if the user configured environment variables to contain`USING_EPHEMERAL_DISKS=true` and some value for `ZOOKEEPER_URL`.

Given the scenario described above, the list of environment variables for pods will be different, and thus pods will be replaced when upgrading the operator to a version that includes these changes.