### PR TITLE
nodeSelector fix

### DIFF
--- a/charts/humio-operator/templates/operator-deployment.yaml
+++ b/charts/humio-operator/templates/operator-deployment.yaml
@@ -34,7 +34,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
 {{- end }}
-{{- with .Values.operator.nodeSelectors }}
+{{- with .Values.operator.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
 {{- end }}  


### PR DESCRIPTION
[nodeSelector](https://github.com/humio/humio-operator/blob/fac3ed3b75de8f77262dbf5e7efcf5d216825ac0/charts/humio-operator/values.yaml#L24C5-L24C5) is mentioned in values file, but in deployment template nodeSelectors is required. Small fix to unify naming with k8s.