### PR TITLE
Replace all if ReplaceAllOnUpdate strategy is set

### DIFF
--- a/api/v1alpha1/humiocluster_types.go
+++ b/api/v1alpha1/humiocluster_types.go
@@ -36,7 +36,7 @@ const (
 	HumioClusterUpdateStrategyOnDelete = "OnDelete"
 	// HumioClusterUpdateStrategyRollingUpdate is the update strategy that will always cause pods to be replaced one at a time
 	HumioClusterUpdateStrategyRollingUpdate = "RollingUpdate"
-	// HumioClusterUpdateStrategyReplaceAllOnUpdate is the update strategy that will replace all pods at the same time during an update.
+	// HumioClusterUpdateStrategyReplaceAllOnUpdate is the update strategy that will replace all pods at the same time during an update of either image or configuration.
 	HumioClusterUpdateStrategyReplaceAllOnUpdate = "ReplaceAllOnUpdate"
 	// HumioClusterUpdateStrategyRollingUpdateBestEffort is the update strategy where the operator will evaluate the Humio version change and determine if the
 	// Humio pods can be updated in a rolling fashion or if they must be replaced at the same time

--- a/controllers/humiocluster_pod_lifecycle.go
+++ b/controllers/humiocluster_pod_lifecycle.go
@@ -32,6 +32,9 @@ func NewPodLifecycleState(hnp HumioNodePool, pod corev1.Pod) *podLifecycleState 
 }
 
 func (p *podLifecycleState) ShouldRollingRestart() bool {
+	if p.nodePool.GetUpdateStrategy().Type == humiov1alpha1.HumioClusterUpdateStrategyReplaceAllOnUpdate {
+		return false
+	}
 	if p.nodePool.GetUpdateStrategy().Type == humiov1alpha1.HumioClusterUpdateStrategyRollingUpdate {
 		return true
 	}


### PR DESCRIPTION
This is the default update strategy, but without this it means even if ReplaceAllOnUpdate is explicitly configured and there's only pending config changes for rollout, then we likely still do rolling update, which is not the desired behavior.