### PR TITLE
Allow creating/updating View connections with multiple filters per repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-logr/zapr v1.2.4
 	github.com/google/go-cmp v0.5.9
 	github.com/google/martian v2.1.0+incompatible
-	github.com/humio/cli v0.32.3
+	github.com/humio/cli v0.32.4-0.20231025112913-b4dceeab38b6
 	github.com/onsi/ginkgo/v2 v2.12.0
 	github.com/onsi/gomega v1.27.11-0.20230807134635-babe25fc5472
 	github.com/prometheus/client_golang v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJY
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
 github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/humio/cli v0.32.3 h1:iBodQTpwGuadyg9zwCc5zXWNvFELxNxH6M08MO1Y+Ho=
-github.com/humio/cli v0.32.3/go.mod h1:I4yilQO5wI6uc7NMLmKSGFATY3AZddCbehIvjESK8WQ=
+github.com/humio/cli v0.32.4-0.20231025112913-b4dceeab38b6 h1:fEb+4t483D2QPA4CtcGxCV3SJ4IpGEN3OaU0i7rBMr0=
+github.com/humio/cli v0.32.4-0.20231025112913-b4dceeab38b6/go.mod h1:I4yilQO5wI6uc7NMLmKSGFATY3AZddCbehIvjESK8WQ=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=

--- a/pkg/humio/client.go
+++ b/pkg/humio/client.go
@@ -26,6 +26,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	graphql "github.com/cli/shurcooL-graphql"
 	"github.com/go-logr/logr"
 
 	humioapi "github.com/humio/cli/api"
@@ -533,10 +534,13 @@ func (h *ClientConfig) DeleteAction(config *humioapi.Config, req reconcile.Reque
 	return h.GetHumioClient(config, req).Actions().Delete(ha.Spec.ViewName, ha.Spec.Name)
 }
 
-func getConnectionMap(viewConnections []humioapi.ViewConnection) map[string][]string {
-	connectionMap := make(map[string][]string)
+func getConnectionMap(viewConnections []humioapi.ViewConnection) []humioapi.ViewConnectionInput {
+	connectionMap := make([]humioapi.ViewConnectionInput, 0)
 	for _, connection := range viewConnections {
-		connectionMap[connection.RepoName] = append(connectionMap[connection.RepoName], connection.Filter)
+		connectionMap = append(connectionMap, humioapi.ViewConnectionInput{
+			RepositoryName: graphql.String(connection.RepoName),
+			Filter:         graphql.String(connection.Filter),
+		})
 	}
 	return connectionMap
 }

--- a/pkg/humio/client.go
+++ b/pkg/humio/client.go
@@ -428,9 +428,8 @@ func (h *ClientConfig) AddView(config *humioapi.Config, req reconcile.Request, h
 	}
 
 	description := ""
-	connectionMap := getConnectionMap(viewConnections)
 
-	err := h.GetHumioClient(config, req).Views().Create(hv.Spec.Name, description, connectionMap)
+	err := h.GetHumioClient(config, req).Views().Create(hv.Spec.Name, description, getConnectionMap(viewConnections))
 	return &view, err
 }
 
@@ -534,10 +533,10 @@ func (h *ClientConfig) DeleteAction(config *humioapi.Config, req reconcile.Reque
 	return h.GetHumioClient(config, req).Actions().Delete(ha.Spec.ViewName, ha.Spec.Name)
 }
 
-func getConnectionMap(viewConnections []humioapi.ViewConnection) map[string]string {
-	connectionMap := make(map[string]string)
+func getConnectionMap(viewConnections []humioapi.ViewConnection) map[string][]string {
+	connectionMap := make(map[string][]string)
 	for _, connection := range viewConnections {
-		connectionMap[connection.RepoName] = connection.Filter
+		connectionMap[connection.RepoName] = append(connectionMap[connection.RepoName], connection.Filter)
 	}
 	return connectionMap
 }


### PR DESCRIPTION
View connections need to have a different data type to allow multiple filters for a single repository.

This change requires humio/cli#138 to be merged and a new version of the module created. Fixes #745.