### PR TITLE
feat: Add ARM64 build for operator image

### DIFF
--- a/.github/workflows/release-container-image.yaml
+++ b/.github/workflows/release-container-image.yaml
@@ -5,10 +5,12 @@ on:
     paths:
     - VERSION
 name: Publish Container Image Release
-jobs:
+jobs:  
   build-and-publish:
     name: Test, Build and Publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v3
     - name: Set version information
@@ -16,13 +18,31 @@ jobs:
         echo "RELEASE_VERSION=$(cat VERSION)" >> $GITHUB_ENV
         echo "RELEASE_COMMIT=$(git rev-parse --verify HEAD)" >> $GITHUB_ENV
         echo "RELEASE_DATE=$(date --iso-8601=seconds)" >> $GITHUB_ENV
-    - name: Login to DockerHub
-      uses: docker/login-action@v2
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-    - name: docker build
-      run: make docker-build-operator IMG=humio/humio-operator:${{ env.RELEASE_VERSION }} IMG_BUILD_ARGS="--label version=${{ env.RELEASE_VERSION }} --label release=${{ github.run_id }} --build-arg RELEASE_VERSION=${{ env.RELEASE_VERSION }} --build-arg RELEASE_COMMIT=${{ env.RELEASE_COMMIT }} --build-arg RELEASE_DATE=${{ env.RELEASE_DATE }}"
+    - name: Build but don't push
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        # Because we use a container scanner pre-push we don't specify platform here so only the runner platform builds
+        # platforms: linux/amd64,linux/arm64
+        load: true
+        tags: ${{ github.repository_owner }}/humio-operator:${{ env.RELEASE_VERSION }}    
+        labels: |
+          version=${{ env.RELEASE_VERSION }}
+          release=${{ github.run_id }}
+        build-args: |
+            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+            RELEASE_COMMIT=${{ env.RELEASE_COMMIT }}
+            RELEASE_DATE=${{ env.RELEASE_DATE }}        
+        cache-to: type=local,type=registry,type=gha
     - name: Set up Python
       uses: actions/setup-python@v4
     - name: Install dependencies
@@ -32,15 +52,30 @@ jobs:
         python -m pip install --upgrade retry
         pip install retry
     - name: CrowdStrike Container Image Scan Operator
+      if: github.repository_owner == 'humio'
       uses: crowdstrike/container-image-scan-action@v1
       with:
         falcon_client_id: 1cd30708cb31442f85a6eec83279fe7b
-        container_repository: humio/humio-operator
+        container_repository: ${{ github.repository_owner }}/humio-operator
         container_tag: ${{ env.RELEASE_VERSION }}
       env:
         FALCON_CLIENT_SECRET: "${{ secrets.FALCON_CLIENT_SECRET }}"
-    - name: docker push
-      run:  make docker-push IMG=humio/humio-operator:${{ env.RELEASE_VERSION }}
+    - name: Build and push
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ github.repository_owner }}/humio-operator:${{ env.RELEASE_VERSION }}    
+        labels: |
+          version=${{ env.RELEASE_VERSION }}
+          release=${{ github.run_id }}
+        build-args: |
+          RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+          RELEASE_COMMIT=${{ env.RELEASE_COMMIT }}
+          RELEASE_DATE=${{ env.RELEASE_DATE }}        
+        cache-from: type=gha, mode=max
+        cache-to: type=gha
 # Disable olm push until we have a new bundle
 #    - name: operator-courier push
 #      env:
@@ -53,6 +88,8 @@ jobs:
   gh-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - name: Get release version
@@ -64,6 +101,6 @@ jobs:
           tag_name: operator-${{ env.RELEASE_VERSION }}
           release_name: Operator Release ${{ env.RELEASE_VERSION }}
           body: |
-            **Image:** `humio/humio-operator:${{ env.RELEASE_VERSION }}`
+            **Image:** `${{ github.repository_owner }}/humio-operator:${{ env.RELEASE_VERSION }}`
             **Upgrade notes:** https://library.humio.com/falcon-logscale-self-hosted/installation-kubernetes-operator-upgrade.html#installation-containers-kubernetes-operator-upgrade-notes
           prerelease: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -ldflags="-s -w -X 'main.version=$RELEASE_VERSION' -X 'main.commit=$RELEASE_COMMIT' -X 'main.date=$RELEASE_DATE'" -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="-s -w -X 'main.version=$RELEASE_VERSION' -X 'main.commit=$RELEASE_COMMIT' -X 'main.date=$RELEASE_DATE'" -a -o manager main.go
 
 # Use ubi8 as base image to package the manager binary to comply with Red Hat image certification requirements
 FROM scratch


### PR DESCRIPTION
This change provides for arm64 builds and makes minor changes to the workflow to allow correct builds on forks for the image. Buildable forks and cross platform for helper images is not a goal