### PR TITLE
Deprecate certain fields in HumioCluster and remove use of unused env…

### DIFF
--- a/api/v1alpha1/humiocluster_types.go
+++ b/api/v1alpha1/humiocluster_types.go
@@ -52,9 +52,11 @@ type HumioClusterSpec struct {
 	// AutoRebalancePartitions will enable auto-rebalancing of both digest and storage partitions assigned to humio cluster nodes.
 	// If all Kubernetes worker nodes are located in the same availability zone, you must set DisableInitContainer to true to use auto rebalancing of partitions.
 	AutoRebalancePartitions bool `json:"autoRebalancePartitions,omitempty"`
-	// TargetReplicationFactor is the desired number of replicas of both storage and ingest partitions
+	// TargetReplicationFactor appends DIGEST_REPLICATION_FACTOR and STORAGE_REPLICATION_FACTOR to pod environment variables based on TargetReplicationFactor for LogScale versions prior to 1.89.0.
+	// Deprecated: No longer automatically appends DIGEST_REPLICATION_FACTOR and STORAGE_REPLICATION_FACTOR, but replaced by user requiring to append replication configurations to EnvironmentVariables in HumioNodeSpec.
 	TargetReplicationFactor int `json:"targetReplicationFactor,omitempty"`
 	// StoragePartitionsCount is the desired number of storage partitions
+	// Deprecated: No longer necessary since LogScale 1.89.0.
 	StoragePartitionsCount int `json:"storagePartitionsCount,omitempty"`
 	// DigestPartitionsCount is the desired number of digest partitions
 	DigestPartitionsCount int `json:"digestPartitionsCount,omitempty"`

--- a/charts/humio-operator/crds/core.humio.com_humioclusters.yaml
+++ b/charts/humio-operator/crds/core.humio.com_humioclusters.yaml
@@ -14182,12 +14182,16 @@ spec:
                   type: object
                 type: array
               storagePartitionsCount:
-                description: StoragePartitionsCount is the desired number of storage
-                  partitions
+                description: 'StoragePartitionsCount is the desired number of storage
+                  partitions Deprecated: No longer necessary since LogScale 1.89.0.'
                 type: integer
               targetReplicationFactor:
-                description: TargetReplicationFactor is the desired number of replicas
-                  of both storage and ingest partitions
+                description: 'TargetReplicationFactor appends DIGEST_REPLICATION_FACTOR
+                  and STORAGE_REPLICATION_FACTOR to pod environment variables based
+                  on TargetReplicationFactor for LogScale versions prior to 1.89.0.
+                  Deprecated: No longer automatically appends DIGEST_REPLICATION_FACTOR
+                  and STORAGE_REPLICATION_FACTOR, but replaced by user requiring to
+                  append replication configurations to EnvironmentVariables in HumioNodeSpec.'
                 type: integer
               terminationGracePeriodSeconds:
                 description: TerminationGracePeriodSeconds defines the amount of time

--- a/config/crd/bases/core.humio.com_humioclusters.yaml
+++ b/config/crd/bases/core.humio.com_humioclusters.yaml
@@ -14182,12 +14182,16 @@ spec:
                   type: object
                 type: array
               storagePartitionsCount:
-                description: StoragePartitionsCount is the desired number of storage
-                  partitions
+                description: 'StoragePartitionsCount is the desired number of storage
+                  partitions Deprecated: No longer necessary since LogScale 1.89.0.'
                 type: integer
               targetReplicationFactor:
-                description: TargetReplicationFactor is the desired number of replicas
-                  of both storage and ingest partitions
+                description: 'TargetReplicationFactor appends DIGEST_REPLICATION_FACTOR
+                  and STORAGE_REPLICATION_FACTOR to pod environment variables based
+                  on TargetReplicationFactor for LogScale versions prior to 1.89.0.
+                  Deprecated: No longer automatically appends DIGEST_REPLICATION_FACTOR
+                  and STORAGE_REPLICATION_FACTOR, but replaced by user requiring to
+                  append replication configurations to EnvironmentVariables in HumioNodeSpec.'
                 type: integer
               terminationGracePeriodSeconds:
                 description: TerminationGracePeriodSeconds defines the amount of time

--- a/controllers/humiocluster_defaults.go
+++ b/controllers/humiocluster_defaults.go
@@ -363,9 +363,6 @@ func (hnp HumioNodePool) GetEnvironmentVariables() []corev1.EnvVar {
 
 		{Name: "HUMIO_PORT", Value: strconv.Itoa(HumioPort)},
 		{Name: "ELASTIC_PORT", Value: strconv.Itoa(elasticPort)},
-		{Name: "DIGEST_REPLICATION_FACTOR", Value: strconv.Itoa(hnp.GetTargetReplicationFactor())},
-		{Name: "STORAGE_REPLICATION_FACTOR", Value: strconv.Itoa(hnp.GetTargetReplicationFactor())},
-		{Name: "DEFAULT_PARTITION_COUNT", Value: strconv.Itoa(hnp.GetStoragePartitionsCount())},
 		{Name: "INGEST_QUEUE_INITIAL_PARTITIONS", Value: strconv.Itoa(hnp.GetDigestPartitionsCount())},
 		{Name: "HUMIO_LOG4J_CONFIGURATION", Value: "log4j2-json-stdout.xml"},
 		{
@@ -391,6 +388,21 @@ func (hnp HumioNodePool) GetEnvironmentVariables() []corev1.EnvVar {
 				Value: "$(ZOOKEEPER_URL)",
 			})
 		}
+	}
+
+	if ok, _ := humioVersion.AtLeast(HumioVersionWithAutomaticPartitionManagement); !ok {
+		envVar = AppendEnvVarToEnvVarsIfNotAlreadyPresent(envVar, corev1.EnvVar{
+			Name:  "DIGEST_REPLICATION_FACTOR",
+			Value: strconv.Itoa(hnp.GetTargetReplicationFactor()),
+		})
+		envVar = AppendEnvVarToEnvVarsIfNotAlreadyPresent(envVar, corev1.EnvVar{
+			Name:  "STORAGE_REPLICATION_FACTOR",
+			Value: strconv.Itoa(hnp.GetTargetReplicationFactor()),
+		})
+		envVar = AppendEnvVarToEnvVarsIfNotAlreadyPresent(envVar, corev1.EnvVar{
+			Name:  "DEFAULT_PARTITION_COUNT",
+			Value: strconv.Itoa(hnp.GetStoragePartitionsCount()),
+		})
 	}
 
 	for _, defaultEnvVar := range envDefaults {

--- a/controllers/suite/clusters/humiocluster_controller_test.go
+++ b/controllers/suite/clusters/humiocluster_controller_test.go
@@ -3609,6 +3609,7 @@ var _ = Describe("HumioCluster Controller", func() {
 				Namespace: testProcessNamespace,
 			}
 			toCreate := suite.ConstructBasicSingleNodeHumioCluster(key, true)
+			toCreate.Spec.Image = controllers.HumioVersionMinimumSupported
 			toCreate.Spec.TargetReplicationFactor = 2
 			toCreate.Spec.HumioNodeSpec.NodeCount = 1
 


### PR DESCRIPTION
…ironment variables

Previously the operator would automatically append these to the environment variables for pods, but as of LogScale 1.89.0 they are no longer needed/used and we can use the default behavior. To override default behavior it is possible to do that by referring to the LogScale documentation and setting the relevant environment variables.

The environment variables no longer set for pods running LogScale 1.89.0 and newer:
- DIGEST_REPLICATION_FACTOR
- STORAGE_REPLICATION_FACTOR
- DEFAULT_PARTITION_COUNT

Since this changes the environment variables list for pods if running LogScale 1.89.0+ it means cluster pods will be replaced when upgrading to an operator version with these changes.