### PR TITLE
Allow tls without the need for certmanager to be enabled

### DIFF
--- a/controllers/humiocluster_defaults.go
+++ b/controllers/humiocluster_defaults.go
@@ -804,7 +804,7 @@ func (hnp *HumioNodePool) TLSEnabled() bool {
 		return helpers.UseCertManager()
 	}
 
-	return helpers.UseCertManager() && *hnp.tls.Enabled
+	return helpers.UseCertManager() || *hnp.tls.Enabled
 }
 
 func (hnp *HumioNodePool) GetProbeScheme() corev1.URIScheme {


### PR DESCRIPTION
Right now if cert manager is set to false even with tls enabled for the humiocluster, the humio-auth container fails to connect to the humio container with the following error indicating it is trying to use http to a https port:
`Got err trying to obtain user ID of admin user: Post http://<pod ip>:8080/graphql: EOF`

This should return true if cert manager is disabled but tls is enabled, current logic requires both to be true to set HUMIO_NODE_URL to https://$(POD_NAME):8080/