### PR TITLE
fix: Parser update should not be triggered if no test cases have been…

### DIFF
--- a/controllers/humioparser_controller.go
+++ b/controllers/humioparser_controller.go
@@ -162,7 +162,13 @@ func (r *HumioParserReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	for i := range curParser.TestCases {
 		curParserTests[i] = curParser.TestCases[i].Event.RawString
 	}
+	if hp.Spec.TagFields == nil {
+		hp.Spec.TagFields = []string{}
+	}
 	_ = copy(expectedTests, hp.Spec.TestData)
+	if hp.Spec.TestData == nil {
+		hp.Spec.TestData = []string{}
+	}
 	sort.Strings(currentFieldsToTag)
 	sort.Strings(expectedTagFields)
 	sort.Strings(curParserTests)


### PR DESCRIPTION
… provided.

API returns an empty list, and so we have to ensure that is also what is passed on to the parser comparison that decides whether we need to issue a parser update.