### PR TITLE
Revert "fix: use ClusterIP rather than headless service operator client"

### DIFF
--- a/pkg/helpers/clusterinterface.go
+++ b/pkg/helpers/clusterinterface.go
@@ -94,7 +94,7 @@ func (c Cluster) Url(ctx context.Context, k8sClient client.Client) (*url.URL, er
 		if !TLSEnabled(&humioManagedCluster) {
 			protocol = "http"
 		}
-		baseURL, _ := url.Parse(fmt.Sprintf("%s://%s.%s:%d/", protocol, c.managedClusterName, c.namespace, 8080))
+		baseURL, _ := url.Parse(fmt.Sprintf("%s://%s-headless.%s:%d/", protocol, c.managedClusterName, c.namespace, 8080))
 		return baseURL, nil
 	}
 

--- a/pkg/helpers/clusterinterface_test.go
+++ b/pkg/helpers/clusterinterface_test.go
@@ -189,7 +189,7 @@ func TestCluster_HumioConfig_managedHumioCluster(t *testing.T) {
 			if !TLSEnabled(&tt.managedHumioCluster) {
 				protocol = "http"
 			}
-			expectedURL := fmt.Sprintf("%s://%s.%s:8080/", protocol, tt.managedHumioCluster.Name, tt.managedHumioCluster.Namespace)
+			expectedURL := fmt.Sprintf("%s://%s-headless.%s:8080/", protocol, tt.managedHumioCluster.Name, tt.managedHumioCluster.Namespace)
 			if cluster.Config().Address.String() != expectedURL {
 				t.Errorf("url not correct, expected: %s, got: %s", expectedURL, cluster.Config().Address)
 			}

--- a/pkg/humio/client.go
+++ b/pkg/humio/client.go
@@ -217,7 +217,7 @@ func (h *ClientConfig) GetBaseURL(config *humioapi.Config, req reconcile.Request
 	if !helpers.TLSEnabled(hc) {
 		protocol = "http"
 	}
-	baseURL, _ := url.Parse(fmt.Sprintf("%s://%s.%s:%d/", protocol, hc.Name, hc.Namespace, 8080))
+	baseURL, _ := url.Parse(fmt.Sprintf("%s://%s-headless.%s:%d/", protocol, hc.Name, hc.Namespace, 8080))
 	return baseURL
 
 }

--- a/pkg/humio/client_mock.go
+++ b/pkg/humio/client_mock.go
@@ -79,7 +79,7 @@ func (h *MockClientConfig) GetClusters(config *humioapi.Config, req reconcile.Re
 }
 
 func (h *MockClientConfig) GetBaseURL(config *humioapi.Config, req reconcile.Request, hc *humiov1alpha1.HumioCluster) *url.URL {
-	baseURL, _ := url.Parse(fmt.Sprintf("http://%s.%s:%d/", hc.Name, hc.Namespace, 8080))
+	baseURL, _ := url.Parse(fmt.Sprintf("http://%s-headless.%s:%d/", hc.Name, hc.Namespace, 8080))
 	return baseURL
 }
 


### PR DESCRIPTION
This reverts commit 0c96b65c6482442210e0eda91fd79c914362b62b.