### PR TITLE
Allow retention change on initial repo creation

### DIFF
--- a/pkg/humio/client.go
+++ b/pkg/humio/client.go
@@ -353,6 +353,16 @@ func (h *ClientConfig) UpdateRepository(config *humioapi.Config, req reconcile.R
 		}
 	}
 
+	if curRepository.AutomaticSearch != helpers.BoolTrue(hr.Spec.AutomaticSearch) {
+		err = h.GetHumioClient(config, req).Repositories().UpdateAutomaticSearch(
+			hr.Spec.Name,
+			helpers.BoolTrue(hr.Spec.AutomaticSearch),
+		)
+		if err != nil {
+			return &humioapi.Repository{}, err
+		}
+	}
+
 	if curRepository.RetentionDays != float64(hr.Spec.Retention.TimeInDays) {
 		err = h.GetHumioClient(config, req).Repositories().UpdateTimeBasedRetention(
 			hr.Spec.Name,
@@ -380,16 +390,6 @@ func (h *ClientConfig) UpdateRepository(config *humioapi.Config, req reconcile.R
 			hr.Spec.Name,
 			float64(hr.Spec.Retention.IngestSizeInGB),
 			hr.Spec.AllowDataDeletion,
-		)
-		if err != nil {
-			return &humioapi.Repository{}, err
-		}
-	}
-
-	if curRepository.AutomaticSearch != helpers.BoolTrue(hr.Spec.AutomaticSearch) {
-		err = h.GetHumioClient(config, req).Repositories().UpdateAutomaticSearch(
-			hr.Spec.Name,
-			helpers.BoolTrue(hr.Spec.AutomaticSearch),
 		)
 		if err != nil {
 			return &humioapi.Repository{}, err


### PR DESCRIPTION
I noticed that recently newly created repositories do not have their retention settings set. This appears to be because retention settings are not set during creation, but during the first update cycle, which can't update if the `allowDataDeletion` flag isn't set true.

This change:

- Enable `allowDataDeletion` flag during creating of the repo, this will allow retention to be set.
- Move `AutomaticSearch` above retention, this allows automatic search to be set even if retention change is not permitted.