### PR TITLE
Make RollingUpdateBestEffort behave a bit more like RollingUpdate

### DIFF
--- a/controllers/humiocluster_pod_lifecycle.go
+++ b/controllers/humiocluster_pod_lifecycle.go
@@ -37,21 +37,23 @@ func (p *podLifecycleState) ShouldRollingRestart() bool {
 	}
 	if p.nodePool.GetUpdateStrategy().Type == humiov1alpha1.HumioClusterUpdateStrategyRollingUpdate ||
 		p.nodePool.GetUpdateStrategy().Type == humiov1alpha1.HumioClusterUpdateStrategyRollingUpdateBestEffort {
-		if p.WantsUpgrade() {
-			// if we're trying to go to or from a "latest" image, we can't do any version comparison
-			if p.versionDifference.from.IsLatest() || p.versionDifference.to.IsLatest() {
-				return false
-			}
-			if p.nodePool.GetUpdateStrategy().Type == humiov1alpha1.HumioClusterUpdateStrategyRollingUpdateBestEffort {
+
+		if p.nodePool.GetUpdateStrategy().Type == humiov1alpha1.HumioClusterUpdateStrategyRollingUpdateBestEffort {
+			if p.WantsUpgrade() {
+				// if we're trying to go to or from a "latest" image, we can't do any version comparison
+				if p.versionDifference.from.IsLatest() || p.versionDifference.to.IsLatest() {
+					return false
+				}
 				if p.versionDifference.from.SemVer().Major() == p.versionDifference.to.SemVer().Major() {
 					// allow rolling upgrades and downgrades for patch releases
 					if p.versionDifference.from.SemVer().Minor() == p.versionDifference.to.SemVer().Minor() {
 						return true
 					}
 				}
+				return false
 			}
-			return false
 		}
+		return true
 	}
 	if p.configurationDifference != nil {
 		return !p.configurationDifference.requiresSimultaneousRestart

--- a/controllers/humiocluster_pod_lifecycle.go
+++ b/controllers/humiocluster_pod_lifecycle.go
@@ -35,23 +35,23 @@ func (p *podLifecycleState) ShouldRollingRestart() bool {
 	if p.nodePool.GetUpdateStrategy().Type == humiov1alpha1.HumioClusterUpdateStrategyReplaceAllOnUpdate {
 		return false
 	}
-	if p.nodePool.GetUpdateStrategy().Type == humiov1alpha1.HumioClusterUpdateStrategyRollingUpdate {
-		return true
-	}
-	if p.WantsUpgrade() {
-		// if we're trying to go to or from a "latest" image, we can't do any version comparison
-		if p.versionDifference.from.IsLatest() || p.versionDifference.to.IsLatest() {
-			return false
-		}
-		if p.nodePool.GetUpdateStrategy().Type == humiov1alpha1.HumioClusterUpdateStrategyRollingUpdateBestEffort {
-			if p.versionDifference.from.SemVer().Major() == p.versionDifference.to.SemVer().Major() {
-				// allow rolling upgrades and downgrades for patch releases
-				if p.versionDifference.from.SemVer().Minor() == p.versionDifference.to.SemVer().Minor() {
-					return true
+	if p.nodePool.GetUpdateStrategy().Type == humiov1alpha1.HumioClusterUpdateStrategyRollingUpdate ||
+		p.nodePool.GetUpdateStrategy().Type == humiov1alpha1.HumioClusterUpdateStrategyRollingUpdateBestEffort {
+		if p.WantsUpgrade() {
+			// if we're trying to go to or from a "latest" image, we can't do any version comparison
+			if p.versionDifference.from.IsLatest() || p.versionDifference.to.IsLatest() {
+				return false
+			}
+			if p.nodePool.GetUpdateStrategy().Type == humiov1alpha1.HumioClusterUpdateStrategyRollingUpdateBestEffort {
+				if p.versionDifference.from.SemVer().Major() == p.versionDifference.to.SemVer().Major() {
+					// allow rolling upgrades and downgrades for patch releases
+					if p.versionDifference.from.SemVer().Minor() == p.versionDifference.to.SemVer().Minor() {
+						return true
+					}
 				}
 			}
+			return false
 		}
-		return false
 	}
 	if p.configurationDifference != nil {
 		return !p.configurationDifference.requiresSimultaneousRestart


### PR DESCRIPTION
It is somewhat surprising behavior, at least to me, that the "best effort" strategy is only considered in the case of a Logscale version update. I think it makes more sense to have it behave like `RollingUpdate` unless there is a version upgrade in which case the version comparison logic can take over. This will allow things like modifications to environment variables which need to restart pods to have a rolling update even if there is no version update at the same time.