### PR TITLE
test: Skip looking for unschedulable pods when running with envtest.

### DIFF
--- a/controllers/suite/clusters/humiocluster_controller_test.go
+++ b/controllers/suite/clusters/humiocluster_controller_test.go
@@ -354,22 +354,24 @@ var _ = Describe("HumioCluster Controller", func() {
 
 			ensurePodsGoPending(ctx, controllers.NewHumioNodeManagerFromHumioCluster(&updatedHumioCluster), 2, 1)
 
-			Eventually(func() int {
-				var pendingPodsCount int
-				updatedClusterPods, _ = kubernetes.ListPods(ctx, k8sClient, updatedHumioCluster.Namespace, controllers.NewHumioNodeManagerFromHumioCluster(&updatedHumioCluster).GetPodLabels())
-				for _, pod := range updatedClusterPods {
-					if pod.Status.Phase == corev1.PodPending {
-						for _, condition := range pod.Status.Conditions {
-							if condition.Type == corev1.PodScheduled {
-								if condition.Status == corev1.ConditionFalse && condition.Reason == controllers.PodConditionReasonUnschedulable {
-									pendingPodsCount++
+			if !helpers.UseEnvtest() {
+				Eventually(func() int {
+					var pendingPodsCount int
+					updatedClusterPods, _ = kubernetes.ListPods(ctx, k8sClient, updatedHumioCluster.Namespace, controllers.NewHumioNodeManagerFromHumioCluster(&updatedHumioCluster).GetPodLabels())
+					for _, pod := range updatedClusterPods {
+						if pod.Status.Phase == corev1.PodPending {
+							for _, condition := range pod.Status.Conditions {
+								if condition.Type == corev1.PodScheduled {
+									if condition.Status == corev1.ConditionFalse && condition.Reason == controllers.PodConditionReasonUnschedulable {
+										pendingPodsCount++
+									}
 								}
 							}
 						}
 					}
-				}
-				return pendingPodsCount
-			}, testTimeout, 250*time.Millisecond).Should(Equal(1))
+					return pendingPodsCount
+				}, testTimeout, 250*time.Millisecond).Should(Equal(1))
+			}
 
 			suite.UsingClusterBy(key.Name, "Updating the cluster resources successfully with working affinity")
 			Eventually(func() error {


### PR DESCRIPTION
We have seen flakiness due to the pods being deleted so fast after manually marking them unschedulable, that the ListPods never gets to see the unschedulable pods.