### PR TITLE
Refactor diff field

### DIFF
--- a/controllers/humioaggregatealert_controller.go
+++ b/controllers/humioaggregatealert_controller.go
@@ -179,7 +179,7 @@ func (r *HumioAggregateAlertReconciler) reconcileHumioAggregateAlert(ctx context
 
 	if asExpected, diffKeysAndValues := aggregateAlertAlreadyAsExpected(haa, curAggregateAlert); !asExpected {
 		r.Log.Info("information differs, triggering update",
-			helpers.MapToAnySlice(diffKeysAndValues)...,
+			"diff", diffKeysAndValues,
 		)
 		updateErr := r.HumioClient.UpdateAggregateAlert(ctx, client, req, haa)
 		if updateErr != nil {

--- a/controllers/humioalert_controller.go
+++ b/controllers/humioalert_controller.go
@@ -166,7 +166,7 @@ func (r *HumioAlertReconciler) reconcileHumioAlert(ctx context.Context, client *
 
 	if asExpected, diffKeysAndValues := alertAlreadyAsExpected(ha, curAlert); !asExpected {
 		r.Log.Info("information differs, triggering update",
-			helpers.MapToAnySlice(diffKeysAndValues)...,
+			"diff", diffKeysAndValues,
 		)
 		err = r.HumioClient.UpdateAlert(ctx, client, req, ha)
 		if err != nil {

--- a/controllers/humiocluster_pods.go
+++ b/controllers/humiocluster_pods.go
@@ -720,23 +720,43 @@ func (r *HumioClusterReconciler) podsMatch(hnp *HumioNodePool, pod corev1.Pod, d
 	sanitizedDesiredPod := sanitizePod(hnp, desiredPodCopy)
 	podSpecDiff := cmp.Diff(sanitizedCurrentPod.Spec, sanitizedDesiredPod.Spec)
 	if !specMatches {
-		r.Log.Info(fmt.Sprintf("pod annotation %s does not match desired pod: got %+v, expected %+v", PodHashAnnotation, pod.Annotations[PodHashAnnotation], desiredPod.Annotations[PodHashAnnotation]), "podSpecDiff", podSpecDiff)
+		r.Log.Info(fmt.Sprintf("pod annotation %s does not match desired pod: got %+v, expected %+v",
+			PodHashAnnotation,
+			pod.Annotations[PodHashAnnotation], desiredPod.Annotations[PodHashAnnotation]),
+			"diff", podSpecDiff,
+		)
 		return false
 	}
 	if !revisionMatches {
-		r.Log.Info(fmt.Sprintf("pod annotation %s does not match desired pod: got %+v, expected %+v", PodRevisionAnnotation, pod.Annotations[PodRevisionAnnotation], desiredPod.Annotations[PodRevisionAnnotation]), "podSpecDiff", podSpecDiff)
+		r.Log.Info(fmt.Sprintf("pod annotation %s does not match desired pod: got %+v, expected %+v",
+			PodRevisionAnnotation,
+			pod.Annotations[PodRevisionAnnotation], desiredPod.Annotations[PodRevisionAnnotation]),
+			"diff", podSpecDiff,
+		)
 		return false
 	}
 	if !bootstrapTokenAnnotationMatches {
-		r.Log.Info(fmt.Sprintf("pod annotation %s does not match desired pod: got %+v, expected %+v", BootstrapTokenHashAnnotation, pod.Annotations[BootstrapTokenHashAnnotation], desiredPod.Annotations[BootstrapTokenHashAnnotation]), "podSpecDiff", podSpecDiff)
+		r.Log.Info(fmt.Sprintf("pod annotation %s does not match desired pod: got %+v, expected %+v",
+			BootstrapTokenHashAnnotation,
+			pod.Annotations[BootstrapTokenHashAnnotation], desiredPod.Annotations[BootstrapTokenHashAnnotation]),
+			"diff", podSpecDiff,
+		)
 		return false
 	}
 	if !envVarSourceMatches {
-		r.Log.Info(fmt.Sprintf("pod annotation %s does not match desired pod: got %+v, expected %+v", envVarSourceHashAnnotation, pod.Annotations[envVarSourceHashAnnotation], desiredPod.Annotations[envVarSourceHashAnnotation]), "podSpecDiff", podSpecDiff)
+		r.Log.Info(fmt.Sprintf("pod annotation %s does not match desired pod: got %+v, expected %+v",
+			envVarSourceHashAnnotation,
+			pod.Annotations[envVarSourceHashAnnotation], desiredPod.Annotations[envVarSourceHashAnnotation]),
+			"diff", podSpecDiff,
+		)
 		return false
 	}
 	if !certHashAnnotationMatches {
-		r.Log.Info(fmt.Sprintf("pod annotation %s does not match desired pod: got %+v, expected %+v", certHashAnnotation, pod.Annotations[certHashAnnotation], desiredPod.Annotations[certHashAnnotation]), "podSpecDiff", podSpecDiff)
+		r.Log.Info(fmt.Sprintf("pod annotation %s does not match desired pod: got %+v, expected %+v",
+			certHashAnnotation,
+			pod.Annotations[certHashAnnotation], desiredPod.Annotations[certHashAnnotation]),
+			"diff", podSpecDiff,
+		)
 		return false
 	}
 	return true

--- a/controllers/humiofilteralert_controller.go
+++ b/controllers/humiofilteralert_controller.go
@@ -177,7 +177,7 @@ func (r *HumioFilterAlertReconciler) reconcileHumioFilterAlert(ctx context.Conte
 
 	if asExpected, diffKeysAndValues := filterAlertAlreadyAsExpected(hfa, curFilterAlert); !asExpected {
 		r.Log.Info("information differs, triggering update",
-			helpers.MapToAnySlice(diffKeysAndValues)...,
+			"diff", diffKeysAndValues,
 		)
 		updateErr := r.HumioClient.UpdateFilterAlert(ctx, client, req, hfa)
 		if updateErr != nil {

--- a/controllers/humioingesttoken_controller.go
+++ b/controllers/humioingesttoken_controller.go
@@ -159,7 +159,7 @@ func (r *HumioIngestTokenReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	if asExpected, diffKeysAndValues := ingestTokenAlreadyAsExpected(hit, curToken); !asExpected {
 		r.Log.Info("information differs, triggering update",
-			helpers.MapToAnySlice(diffKeysAndValues)...,
+			"diff", diffKeysAndValues,
 		)
 		err = r.HumioClient.UpdateIngestToken(ctx, humioHttpClient, req, hit)
 		if err != nil {

--- a/controllers/humioparser_controller.go
+++ b/controllers/humioparser_controller.go
@@ -157,7 +157,7 @@ func (r *HumioParserReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	if asExpected, diffKeysAndValues := parserAlreadyAsExpected(hp, curParser); !asExpected {
 		r.Log.Info("information differs, triggering update",
-			helpers.MapToAnySlice(diffKeysAndValues)...,
+			"diff", diffKeysAndValues,
 		)
 		err = r.HumioClient.UpdateParser(ctx, humioHttpClient, req, hp)
 		if err != nil {

--- a/controllers/humiorepository_controller.go
+++ b/controllers/humiorepository_controller.go
@@ -156,7 +156,7 @@ func (r *HumioRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	if asExpected, diffKeysAndValues := repositoryAlreadyAsExpected(hr, curRepository); !asExpected {
 		r.Log.Info("information differs, triggering update",
-			helpers.MapToAnySlice(diffKeysAndValues)...,
+			"diff", diffKeysAndValues,
 		)
 		err = r.HumioClient.UpdateRepository(ctx, humioHttpClient, req, hr)
 		if err != nil {

--- a/controllers/humioscheduledsearch_controller.go
+++ b/controllers/humioscheduledsearch_controller.go
@@ -166,7 +166,7 @@ func (r *HumioScheduledSearchReconciler) reconcileHumioScheduledSearch(ctx conte
 
 	if asExpected, diffKeysAndValues := scheduledSearchAlreadyAsExpected(hss, curScheduledSearch); !asExpected {
 		r.Log.Info("information differs, triggering update",
-			helpers.MapToAnySlice(diffKeysAndValues)...,
+			"diff", diffKeysAndValues,
 		)
 		updateErr := r.HumioClient.UpdateScheduledSearch(ctx, client, req, hss)
 		if updateErr != nil {

--- a/controllers/humioview_controller.go
+++ b/controllers/humioview_controller.go
@@ -156,7 +156,7 @@ func (r *HumioViewReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	if asExpected, diffKeysAndValues := viewAlreadyAsExpected(hv, curView); !asExpected {
 		r.Log.Info("information differs, triggering update",
-			helpers.MapToAnySlice(diffKeysAndValues)...,
+			"diff", diffKeysAndValues,
 		)
 		updateErr := r.HumioClient.UpdateView(ctx, humioHttpClient, req, hv)
 		if updateErr != nil {

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -184,13 +184,3 @@ func GetE2ELicenseFromEnvVar() string {
 func PreserveKindCluster() bool {
 	return os.Getenv("PRESERVE_KIND_CLUSTER") == "true"
 }
-
-// MapToAnySlice converts a given map[string]string and converts it to []any.
-// This is useful when e.g. passing on key-value pairs to a logger.
-func MapToAnySlice(m map[string]string) []any {
-	result := make([]any, 0, len(m)*2)
-	for k, v := range m {
-		result = append(result, k, v)
-	}
-	return result
-}


### PR DESCRIPTION
With this change, the key-value diff pairs are nested into a `diff` field on the root logger. Previously, each key would be its own field on the root, making it not obvious which fields were related to diff.