### PR TITLE
helm: Update Deployment to use appVersion from Chart.yaml by default

### DIFF
--- a/charts/humio-operator/templates/operator-deployment.yaml
+++ b/charts/humio-operator/templates/operator-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     productID: "none"
     productName: "humio-operator"
-    productVersion: {{ .Values.operator.image.tag | quote }}
+    productVersion: "{{ .Values.operator.image.tag | default .Chart.AppVersion }}"
   labels:
     {{- include "humio.labels" . | nindent 4 }}
 spec:
@@ -23,7 +23,7 @@ spec:
       annotations:
         productID: "none"
         productName: "humio-operator"
-        productVersion: {{ .Values.operator.image.tag | quote }}
+        productVersion: "{{ .Values.operator.image.tag | default .Chart.AppVersion }}"
 {{- if .Values.operator.podAnnotations }}
         {{- toYaml .Values.operator.podAnnotations | nindent 8 }}
 {{- end }}
@@ -49,7 +49,7 @@ spec:
       serviceAccountName: {{ .Release.Name }}
       containers:
       - name: humio-operator
-        image: {{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag }}
+        image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
         command:
         - /manager

--- a/charts/humio-operator/values.yaml
+++ b/charts/humio-operator/values.yaml
@@ -1,7 +1,8 @@
 operator:
   image:
     repository: humio/humio-operator
-    tag: 0.27.1
+    # default for tag is the appVersion set in Chart.yaml
+    tag:
     pullPolicy: IfNotPresent
     pullSecrets: []
   prometheus:


### PR DESCRIPTION
With this change, we don't need to remember to update the values.yaml file when we publish new builds.