### PR TITLE
fix: Add missing PodDisruptionBudget to the Role/ClusterRole

### DIFF
--- a/charts/humio-operator/templates/operator-rbac.yaml
+++ b/charts/humio-operator/templates/operator-rbac.yaml
@@ -136,6 +136,18 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 {{- if $.Values.certmanager }}
 - apiGroups:
   - cert-manager.io
@@ -296,6 +308,18 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
   verbs:
   - create
   - delete


### PR DESCRIPTION
Without this change, the operator is unable to access those resources and spits out errors like so:
```
W0212 08:06:36.849355       1 reflector.go:539] pkg/mod/k8s.io/client-go@v0.29.7/tools/cache/reflector.go:229: failed to list *v1.PodDisruptionBudget: poddisruptionbudgets.policy is forbidden: User "system:serviceaccount:default:foo" cannot list resource "poddisruptionbudgets" in API group "policy" at the cluster scope
E0212 08:06:36.849440       1 reflector.go:147] pkg/mod/k8s.io/client-go@v0.29.7/tools/cache/reflector.go:229: Failed to watch *v1.PodDisruptionBudget: failed to list *v1.PodDisruptionBudget: poddisruptionbudgets.policy is forbidden: User "system:serviceaccount:default:foo" cannot list resource "poddisruptionbudgets" in API group "policy" at the cluster scope
```