### PR TITLE
Pod DisruptionBudget template creation

### DIFF
--- a/charts/humio-operator/templates/poddisruptionbudget.yaml
+++ b/charts/humio-operator/templates/poddisruptionbudget.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "humio.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}


### PR DESCRIPTION
Description:
This PR adds a PodDisruptionBudget (PDB) template to our Helm charts to ensure high availability during cluster operations.

Changes:
- Added new template file `templates/poddisruptionbudget.yaml`
- Implemented configurable PDB settings in `values.yaml`
- PDB supports both integer and percentage values for minAvailable