### PR TITLE
Allow unlimited sizes in HumioRepository

### DIFF
--- a/api/v1alpha1/humiorepository_types.go
+++ b/api/v1alpha1/humiorepository_types.go
@@ -35,10 +35,10 @@ const (
 type HumioRetention struct {
 	// perhaps we should migrate to resource.Quantity? the Humio API needs float64, but that is not supported here, see more here:
 	// https://github.com/kubernetes-sigs/controller-tools/issues/245
-	//+kubebuilder:validation:Minimum=1
+	//+kubebuilder:validation:Minimum=0
 	//+optional
 	IngestSizeInGB *int32 `json:"ingestSizeInGB,omitempty"`
-	//+kubebuilder:validation:Minimum=1
+	//+kubebuilder:validation:Minimum=0
 	//+optional
 	StorageSizeInGB *int32 `json:"storageSizeInGB,omitempty"`
 	//+kubebuilder:validation:Minimum=1

--- a/charts/humio-operator/crds/core.humio.com_humiorepositories.yaml
+++ b/charts/humio-operator/crds/core.humio.com_humiorepositories.yaml
@@ -87,11 +87,11 @@ spec:
                       perhaps we should migrate to resource.Quantity? the Humio API needs float64, but that is not supported here, see more here:
                       https://github.com/kubernetes-sigs/controller-tools/issues/245
                     format: int32
-                    minimum: 1
+                    minimum: 0
                     type: integer
                   storageSizeInGB:
                     format: int32
-                    minimum: 1
+                    minimum: 0
                     type: integer
                   timeInDays:
                     format: int32

--- a/config/crd/bases/core.humio.com_humiorepositories.yaml
+++ b/config/crd/bases/core.humio.com_humiorepositories.yaml
@@ -87,11 +87,11 @@ spec:
                       perhaps we should migrate to resource.Quantity? the Humio API needs float64, but that is not supported here, see more here:
                       https://github.com/kubernetes-sigs/controller-tools/issues/245
                     format: int32
-                    minimum: 1
+                    minimum: 0
                     type: integer
                   storageSizeInGB:
                     format: int32
-                    minimum: 1
+                    minimum: 0
                     type: integer
                   timeInDays:
                     format: int32

--- a/docs/api.md
+++ b/docs/api.md
@@ -35758,7 +35758,7 @@ Retention defines the retention settings for the repository
 https://github.com/kubernetes-sigs/controller-tools/issues/245<br/>
           <br/>
             <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 1<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -35768,7 +35768,7 @@ https://github.com/kubernetes-sigs/controller-tools/issues/245<br/>
           <br/>
           <br/>
             <i>Format</i>: int32<br/>
-            <i>Minimum</i>: 1<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>


### PR DESCRIPTION
Fixes #925 

ingestSizeInGB and storageSizeInGB are currently defined with a minimum of 1. However the value of 0 is required to leave these as unlimited and to only use the timeInDays limits.

Changing this to 0 fixes this issue.