### PR TITLE
Add GitHub Action workflow to run golangci-lint.

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,26 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,9 +19,9 @@ issues:
 linters:
   disable-all: true
   enable:
+    - copyloopvar
     - dupl
     - errcheck
-    - exportloopref
     - ginkgolinter
     - goconst
     - gocyclo

--- a/api/v1alpha1/humioaction_types.go
+++ b/api/v1alpha1/humioaction_types.go
@@ -40,7 +40,7 @@ type HumioActionWebhookProperties struct {
 	Headers map[string]string `json:"headers,omitempty"`
 	// SecretHeaders specifies what HTTP headers to use and where to fetch the values from.
 	// If both Headers and SecretHeaders are specified, they will be merged together.
-	//+kubebuilder:default={}
+	// +kubebuilder:default={}
 	SecretHeaders []HeadersSource `json:"secretHeaders,omitempty"`
 	Method        string          `json:"method,omitempty"`
 	// Url specifies what URL to use
@@ -56,8 +56,8 @@ type HumioActionWebhookProperties struct {
 // HeadersSource defines a header and corresponding source for the value of it.
 type HeadersSource struct {
 	// Name is the name of the header.
-	//+kubebuilder:validation:MinLength=1
-	//+required
+	// +kubebuilder:validation:MinLength=1
+	// +required
 	Name string `json:"name"`
 	// ValueFrom defines where to fetch the value of the header from.
 	ValueFrom VarSource `json:"valueFrom,omitempty"`
@@ -67,8 +67,8 @@ type HeadersSource struct {
 type HumioActionEmailProperties struct {
 	BodyTemplate    string `json:"bodyTemplate,omitempty"`
 	SubjectTemplate string `json:"subjectTemplate,omitempty"`
-	//+kubebuilder:validation:MinItems=1
-	//+required
+	// +kubebuilder:validation:MinItems=1
+	// +required
 	Recipients []string `json:"recipients,omitempty"`
 	UseProxy   bool     `json:"useProxy,omitempty"`
 }
@@ -128,9 +128,9 @@ type HumioActionSlackPostMessageProperties struct {
 	// If both ApiToken and ApiTokenSource are specified, ApiToken will be used.
 	ApiTokenSource VarSource `json:"apiTokenSource,omitempty"`
 	Channels       []string  `json:"channels,omitempty"`
-	//+kubebuilder:default={}
+	// +kubebuilder:default={}
 	Fields map[string]string `json:"fields,omitempty"`
-	//+kubebuilder:default=false
+	// +kubebuilder:default=false
 	UseProxy bool `json:"useProxy,omitempty"`
 }
 
@@ -162,12 +162,12 @@ type HumioActionSpec struct {
 	// This conflicts with ManagedClusterName.
 	ExternalClusterName string `json:"externalClusterName,omitempty"`
 	// Name is the name of the Action
-	//+kubebuilder:validation:MinLength=1
-	//+required
+	// +kubebuilder:validation:MinLength=1
+	// +required
 	Name string `json:"name"`
 	// ViewName is the name of the Humio View under which the Action will be managed. This can also be a Repository
-	//+kubebuilder:validation:MinLength=1
-	//+required
+	// +kubebuilder:validation:MinLength=1
+	// +required
 	ViewName string `json:"viewName"`
 	// EmailProperties indicates this is an Email Action, and contains the corresponding properties
 	EmailProperties *HumioActionEmailProperties `json:"emailProperties,omitempty"`

--- a/api/v1alpha1/humioaggregatealert_types.go
+++ b/api/v1alpha1/humioaggregatealert_types.go
@@ -41,19 +41,19 @@ type HumioAggregateAlertSpec struct {
 	// This conflicts with ManagedClusterName.
 	ExternalClusterName string `json:"externalClusterName,omitempty"`
 	// Name is the name of the aggregate alert inside Humio
-	//+kubebuilder:validation:MinLength=1
-	//+required
+	// +kubebuilder:validation:MinLength=1
+	// +required
 	Name string `json:"name"`
 	// ViewName is the name of the Humio View under which the aggregate alert will be managed. This can also be a Repository
-	//+kubebuilder:validation:MinLength=1
-	//+required
+	// +kubebuilder:validation:MinLength=1
+	// +required
 	ViewName string `json:"viewName"`
 	// QueryString defines the desired Humio query string
 	QueryString string `json:"queryString"`
 	// QueryTimestampType defines the timestamp type to use for a query
 	QueryTimestampType string `json:"queryTimestampType,omitempty"`
 	// Description is the description of the Aggregate alert
-	//+optional
+	// +optional
 	Description string `json:"description,omitempty"`
 	// Search Interval time in seconds
 	SearchIntervalSeconds int `json:"searchIntervalSeconds,omitempty"`
@@ -64,7 +64,7 @@ type HumioAggregateAlertSpec struct {
 	// Aggregate Alert trigger mode
 	TriggerMode string `json:"triggerMode,omitempty"`
 	// Enabled will set the AggregateAlert to enabled when set to true
-	//+kubebuilder:default=false
+	// +kubebuilder:default=false
 	Enabled bool `json:"enabled,omitempty"`
 	// Actions is the list of Humio Actions by name that will be triggered by this Aggregate alert
 	Actions []string `json:"actions"`

--- a/api/v1alpha1/humioalert_types.go
+++ b/api/v1alpha1/humioalert_types.go
@@ -55,18 +55,18 @@ type HumioAlertSpec struct {
 	// This conflicts with ManagedClusterName.
 	ExternalClusterName string `json:"externalClusterName,omitempty"`
 	// Name is the name of the alert inside Humio
-	//+kubebuilder:validation:MinLength=1
-	//+required
+	// +kubebuilder:validation:MinLength=1
+	// +required
 	Name string `json:"name"`
 	// ViewName is the name of the Humio View under which the Alert will be managed. This can also be a Repository
-	//+kubebuilder:validation:MinLength=1
-	//+required
+	// +kubebuilder:validation:MinLength=1
+	// +required
 	ViewName string `json:"viewName"`
 	// Query defines the desired state of the Humio query
-	//+required
+	// +required
 	Query HumioQuery `json:"query"`
 	// Description is the description of the Alert
-	//+optional
+	// +optional
 	Description string `json:"description,omitempty"`
 	// ThrottleTimeMillis is the throttle time in milliseconds. An Alert is triggered at most once per the throttle time
 	ThrottleTimeMillis int `json:"throttleTimeMillis,omitempty"`

--- a/api/v1alpha1/humiocluster_types.go
+++ b/api/v1alpha1/humiocluster_types.go
@@ -68,7 +68,7 @@ type HumioClusterSpec struct {
 	// DigestPartitionsCount is the desired number of digest partitions
 	DigestPartitionsCount int `json:"digestPartitionsCount,omitempty"`
 	// License is the kubernetes secret reference which contains the Humio license
-	//+required
+	// +required
 	License HumioClusterLicenseSpec `json:"license,omitempty"`
 	// IdpCertificateSecretName is the name of the secret that contains the IDP Certificate when using SAML authentication
 	IdpCertificateSecretName string `json:"idpCertificateSecretName,omitempty"`
@@ -117,11 +117,11 @@ type HumioNodeSpec struct {
 
 	// ImageSource is the reference to an external source identifying the image.
 	// The value from ImageSource takes precedence over Image.
-	//+optional
+	// +optional
 	ImageSource *HumioImageSource `json:"imageSource,omitempty"`
 
 	// NodeCount is the desired number of humio cluster nodes
-	//+kubebuilder:default=0
+	// +kubebuilder:default=0
 	NodeCount int `json:"nodeCount,omitempty"`
 
 	// DataVolumePersistentVolumeClaimSpecTemplate is the PersistentVolumeClaimSpec that will be used with for the humio data volume. This conflicts with DataVolumeSource.
@@ -138,7 +138,7 @@ type HumioNodeSpec struct {
 
 	// DisableInitContainer is used to disable the init container completely which collects the availability zone from the Kubernetes worker node.
 	// This is not recommended, unless you are using auto rebalancing partitions and are running in a single availability zone.
-	//+kubebuilder:default=false
+	// +kubebuilder:default=false
 	DisableInitContainer bool `json:"disableInitContainer,omitempty"`
 
 	// EnvironmentVariablesSource is the reference to an external source of environment variables that will be merged with environmentVariables
@@ -267,7 +267,7 @@ type HumioNodeSpec struct {
 	UpdateStrategy *HumioUpdateStrategy `json:"updateStrategy,omitempty"`
 
 	// PriorityClassName is the name of the priority class that will be used by the Humio pods
-	//+kubebuilder:default=""
+	// +kubebuilder:default=""
 	PriorityClassName string `json:"priorityClassName,omitempty"`
 
 	// HumioNodePoolFeatures defines the features that are allowed by the node pool
@@ -282,7 +282,7 @@ type HumioFeatureFlags struct {
 	// EnableDownscalingFeature (PREVIEW) is a feature flag for enabling the downscaling functionality of the humio operator for this humio cluster.
 	// Default: false
 	// Preview: this feature is in a preview state
-	//+kubebuilder:default=false
+	// +kubebuilder:default=false
 	EnableDownscalingFeature bool `json:"enableDownscalingFeature,omitempty"`
 }
 
@@ -296,7 +296,7 @@ type HumioUpdateStrategy struct {
 	// Type controls how Humio pods are updated  when changes are made to the HumioCluster resource that results
 	// in a change to the Humio pods. The available values are: OnDelete, RollingUpdate, ReplaceAllOnUpdate, and
 	// RollingUpdateBestEffort.
-	///
+	//
 	// When set to OnDelete, no Humio pods will be terminated but new pods will be created with the new spec. Replacing
 	// existing pods will require each pod to be deleted by the user.
 	//
@@ -322,12 +322,12 @@ type HumioUpdateStrategy struct {
 
 	// MaxUnavailable is the maximum number of pods that can be unavailable during a rolling update.
 	// This can be configured to an absolute number or a percentage, e.g. "maxUnavailable: 5" or "maxUnavailable: 25%".
-	//+kubebuilder:default=1
+	// +kubebuilder:default=1
 	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty"`
 }
 type HumioNodePoolSpec struct {
-	//+kubebuilder:validation:MinLength:=1
-	//+required
+	// +kubebuilder:validation:MinLength:=1
+	// +required
 	Name string `json:"name"`
 
 	HumioNodeSpec `json:"spec,omitempty"`
@@ -376,7 +376,7 @@ type HumioESHostnameSource struct {
 type HumioClusterIngressSpec struct {
 	// Enabled enables the logic for the Humio operator to create ingress-related objects. Requires one of the following
 	// to be set: spec.hostname, spec.hostnameSource, spec.esHostname or spec.esHostnameSource
-	//+kubebuilder:default=false
+	// +kubebuilder:default=false
 	Enabled bool `json:"enabled,omitempty"`
 	// Controller is used to specify the controller used for ingress in the Kubernetes cluster. For now, only nginx is supported.
 	Controller string `json:"controller,omitempty"`
@@ -444,8 +444,8 @@ type HumioNodePoolStatusList []HumioNodePoolStatus
 // HumioNodePoolStatus shows the status of each node pool
 type HumioNodePoolStatus struct {
 	// Name is the name of the node pool
-	//+kubebuilder:validation:MinLength=1
-	//+required
+	// +kubebuilder:validation:MinLength=1
+	// +required
 	Name string `json:"name"`
 	// State will be empty before the cluster is bootstrapped. From there it can be "Running", "Upgrading", "Restarting" or "Pending"
 	State string `json:"state,omitempty"`

--- a/api/v1alpha1/humioexternalcluster_types.go
+++ b/api/v1alpha1/humioexternalcluster_types.go
@@ -30,8 +30,8 @@ const (
 // HumioExternalClusterSpec defines the desired state of HumioExternalCluster.
 type HumioExternalClusterSpec struct {
 	// Url is used to connect to the Humio cluster we want to use.
-	//+kubebuilder:validation:MinLength=1
-	//+required
+	// +kubebuilder:validation:MinLength=1
+	// +required
 	Url string `json:"url"`
 	// APITokenSecretName is used to obtain the API token we need to use when communicating with the external Humio cluster.
 	// It refers to a Kubernetes secret that must be located in the same namespace as the HumioExternalCluster.

--- a/api/v1alpha1/humiofilteralert_types.go
+++ b/api/v1alpha1/humiofilteralert_types.go
@@ -41,28 +41,28 @@ type HumioFilterAlertSpec struct {
 	// This conflicts with ManagedClusterName.
 	ExternalClusterName string `json:"externalClusterName,omitempty"`
 	// Name is the name of the filter alert inside Humio
-	//+kubebuilder:validation:MinLength=1
-	//+required
+	// +kubebuilder:validation:MinLength=1
+	// +required
 	Name string `json:"name"`
 	// ViewName is the name of the Humio View under which the filter alert will be managed. This can also be a Repository
-	//+kubebuilder:validation:MinLength=1
-	//+required
+	// +kubebuilder:validation:MinLength=1
+	// +required
 	ViewName string `json:"viewName"`
 	// QueryString defines the desired Humio query string
 	QueryString string `json:"queryString"`
 	// Description is the description of the filter alert
-	//+optional
+	// +optional
 	Description string `json:"description,omitempty"`
 	// ThrottleTimeSeconds is the throttle time in seconds. A filter alert is triggered at most once per the throttle time
-	//+kubebuilder:validation:Minimum=60
-	//+required
+	// +kubebuilder:validation:Minimum=60
+	// +required
 	ThrottleTimeSeconds int `json:"throttleTimeSeconds,omitempty"`
 	// ThrottleField is the field on which to throttle
-	//+kubebuilder:validation:MinLength=1
-	//+required
+	// +kubebuilder:validation:MinLength=1
+	// +required
 	ThrottleField *string `json:"throttleField,omitempty"`
 	// Enabled will set the FilterAlert to enabled when set to true
-	//+kubebuilder:default=false
+	// +kubebuilder:default=false
 	Enabled bool `json:"enabled,omitempty"`
 	// Actions is the list of Humio Actions by name that will be triggered by this filter alert
 	Actions []string `json:"actions"`

--- a/api/v1alpha1/humioingesttoken_types.go
+++ b/api/v1alpha1/humioingesttoken_types.go
@@ -41,16 +41,16 @@ type HumioIngestTokenSpec struct {
 	// This conflicts with ManagedClusterName.
 	ExternalClusterName string `json:"externalClusterName,omitempty"`
 	// Name is the name of the ingest token inside Humio
-	//+kubebuilder:validation:MinLength=1
-	//+required
+	// +kubebuilder:validation:MinLength=1
+	// +required
 	Name string `json:"name"`
 	// ParserName is the name of the parser which will be assigned to the ingest token.
-	//+kubebuilder:validation:MinLength=1
-	//+required
+	// +kubebuilder:validation:MinLength=1
+	// +required
 	ParserName *string `json:"parserName,omitempty"`
 	// RepositoryName is the name of the Humio repository under which the ingest token will be created
-	//+kubebuilder:validation:MinLength=1
-	//+required
+	// +kubebuilder:validation:MinLength=1
+	// +required
 	RepositoryName string `json:"repositoryName,omitempty"`
 	// TokenSecretName specifies the name of the Kubernetes secret that will be created
 	// and contain the ingest token. The key in the secret storing the ingest token is "token".

--- a/api/v1alpha1/humioparser_types.go
+++ b/api/v1alpha1/humioparser_types.go
@@ -41,14 +41,14 @@ type HumioParserSpec struct {
 	// This conflicts with ManagedClusterName.
 	ExternalClusterName string `json:"externalClusterName,omitempty"`
 	// Name is the name of the parser inside Humio
-	//+kubebuilder:validation:MinLength=1
-	//+required
+	// +kubebuilder:validation:MinLength=1
+	// +required
 	Name string `json:"name"`
 	// ParserScript contains the code for the Humio parser
 	ParserScript string `json:"parserScript,omitempty"`
 	// RepositoryName defines what repository this parser should be managed in
-	//+kubebuilder:validation:MinLength=1
-	//+required
+	// +kubebuilder:validation:MinLength=1
+	// +required
 	RepositoryName string `json:"repositoryName,omitempty"`
 	// TagFields is used to define what fields will be used to define how data will be tagged when being parsed by
 	// this parser

--- a/api/v1alpha1/humiorepository_types.go
+++ b/api/v1alpha1/humiorepository_types.go
@@ -35,14 +35,14 @@ const (
 type HumioRetention struct {
 	// perhaps we should migrate to resource.Quantity? the Humio API needs float64, but that is not supported here, see more here:
 	// https://github.com/kubernetes-sigs/controller-tools/issues/245
-	//+kubebuilder:validation:Minimum=0
-	//+optional
+	// +kubebuilder:validation:Minimum=0
+	// +optional
 	IngestSizeInGB *int32 `json:"ingestSizeInGB,omitempty"`
-	//+kubebuilder:validation:Minimum=0
-	//+optional
+	// +kubebuilder:validation:Minimum=0
+	// +optional
 	StorageSizeInGB *int32 `json:"storageSizeInGB,omitempty"`
-	//+kubebuilder:validation:Minimum=1
-	//+optional
+	// +kubebuilder:validation:Minimum=1
+	// +optional
 	TimeInDays *int32 `json:"timeInDays,omitempty"`
 }
 
@@ -56,11 +56,11 @@ type HumioRepositorySpec struct {
 	// This conflicts with ManagedClusterName.
 	ExternalClusterName string `json:"externalClusterName,omitempty"`
 	// Name is the name of the repository inside Humio
-	//+kubebuilder:validation:MinLength=1
-	//+required
+	// +kubebuilder:validation:MinLength=1
+	// +required
 	Name string `json:"name"`
 	// Description contains the description that will be set on the repository
-	//+optional
+	// +optional
 	Description string `json:"description,omitempty"`
 	// Retention defines the retention settings for the repository
 	Retention HumioRetention `json:"retention,omitempty"`

--- a/api/v1alpha1/humioscheduledsearch_types.go
+++ b/api/v1alpha1/humioscheduledsearch_types.go
@@ -41,17 +41,17 @@ type HumioScheduledSearchSpec struct {
 	// This conflicts with ManagedClusterName.
 	ExternalClusterName string `json:"externalClusterName,omitempty"`
 	// Name is the name of the scheduled search inside Humio
-	//+kubebuilder:validation:MinLength=1
-	//+required
+	// +kubebuilder:validation:MinLength=1
+	// +required
 	Name string `json:"name"`
 	// ViewName is the name of the Humio View under which the scheduled search will be managed. This can also be a Repository
-	//+kubebuilder:validation:MinLength=1
-	//+required
+	// +kubebuilder:validation:MinLength=1
+	// +required
 	ViewName string `json:"viewName"`
 	// QueryString defines the desired Humio query string
 	QueryString string `json:"queryString"`
 	// Description is the description of the scheduled search
-	//+optional
+	// +optional
 	Description string `json:"description,omitempty"`
 	// QueryStart is the start of the relative time interval for the query.
 	QueryStart string `json:"queryStart"`
@@ -64,7 +64,7 @@ type HumioScheduledSearchSpec struct {
 	// BackfillLimit is the user-defined limit, which caps the number of missed searches to backfill, e.g. in the event of a shutdown.
 	BackfillLimit int `json:"backfillLimit"`
 	// Enabled will set the ScheduledSearch to enabled when set to true
-	//+kubebuilder:default=false
+	// +kubebuilder:default=false
 	Enabled bool `json:"enabled,omitempty"`
 	// Actions is the list of Humio Actions by name that will be triggered by this scheduled search
 	Actions []string `json:"actions"`

--- a/api/v1alpha1/humioview_types.go
+++ b/api/v1alpha1/humioview_types.go
@@ -34,8 +34,8 @@ const (
 
 type HumioViewConnection struct {
 	// RepositoryName contains the name of the target repository
-	//+kubebuilder:validation:MinLength=1
-	//+required
+	// +kubebuilder:validation:MinLength=1
+	// +required
 	RepositoryName string `json:"repositoryName,omitempty"`
 	// Filter contains the prefix filter that will be applied for the given RepositoryName
 	Filter string `json:"filter,omitempty"`
@@ -51,11 +51,11 @@ type HumioViewSpec struct {
 	// This conflicts with ManagedClusterName.
 	ExternalClusterName string `json:"externalClusterName,omitempty"`
 	// Name is the name of the view inside Humio
-	//+kubebuilder:validation:MinLength=1
-	//+required
+	// +kubebuilder:validation:MinLength=1
+	// +required
 	Name string `json:"name"`
 	// Description contains the description that will be set on the view
-	//+optional
+	// +optional
 	Description string `json:"description,omitempty"`
 	// Connections contains the connections to the Humio repositories which is accessible in this view
 	Connections []HumioViewConnection `json:"connections,omitempty"`

--- a/charts/humio-operator/crds/core.humio.com_humioclusters.yaml
+++ b/charts/humio-operator/crds/core.humio.com_humioclusters.yaml
@@ -13946,7 +13946,7 @@ spec:
                                 Type controls how Humio pods are updated  when changes are made to the HumioCluster resource that results
                                 in a change to the Humio pods. The available values are: OnDelete, RollingUpdate, ReplaceAllOnUpdate, and
                                 RollingUpdateBestEffort.
-                                /
+
                                 When set to OnDelete, no Humio pods will be terminated but new pods will be created with the new spec. Replacing
                                 existing pods will require each pod to be deleted by the user.
 
@@ -16047,7 +16047,7 @@ spec:
                       Type controls how Humio pods are updated  when changes are made to the HumioCluster resource that results
                       in a change to the Humio pods. The available values are: OnDelete, RollingUpdate, ReplaceAllOnUpdate, and
                       RollingUpdateBestEffort.
-                      /
+
                       When set to OnDelete, no Humio pods will be terminated but new pods will be created with the new spec. Replacing
                       existing pods will require each pod to be deleted by the user.
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -66,7 +66,6 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
-// nolint:gocyclo
 func main() {
 	var metricsAddr string
 	var metricsCertPath, metricsCertName, metricsCertKey string

--- a/config/crd/bases/core.humio.com_humioclusters.yaml
+++ b/config/crd/bases/core.humio.com_humioclusters.yaml
@@ -13946,7 +13946,7 @@ spec:
                                 Type controls how Humio pods are updated  when changes are made to the HumioCluster resource that results
                                 in a change to the Humio pods. The available values are: OnDelete, RollingUpdate, ReplaceAllOnUpdate, and
                                 RollingUpdateBestEffort.
-                                /
+
                                 When set to OnDelete, no Humio pods will be terminated but new pods will be created with the new spec. Replacing
                                 existing pods will require each pod to be deleted by the user.
 
@@ -16047,7 +16047,7 @@ spec:
                       Type controls how Humio pods are updated  when changes are made to the HumioCluster resource that results
                       in a change to the Humio pods. The available values are: OnDelete, RollingUpdate, ReplaceAllOnUpdate, and
                       RollingUpdateBestEffort.
-                      /
+
                       When set to OnDelete, no Humio pods will be terminated but new pods will be created with the new spec. Replacing
                       existing pods will require each pod to be deleted by the user.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -32163,7 +32163,7 @@ This can be configured to an absolute number or a percentage, e.g. "maxUnavailab
           Type controls how Humio pods are updated  when changes are made to the HumioCluster resource that results
 in a change to the Humio pods. The available values are: OnDelete, RollingUpdate, ReplaceAllOnUpdate, and
 RollingUpdateBestEffort.
-/
+
 When set to OnDelete, no Humio pods will be terminated but new pods will be created with the new spec. Replacing
 existing pods will require each pod to be deleted by the user.
 
@@ -36051,7 +36051,7 @@ This can be configured to an absolute number or a percentage, e.g. "maxUnavailab
           Type controls how Humio pods are updated  when changes are made to the HumioCluster resource that results
 in a change to the Humio pods. The available values are: OnDelete, RollingUpdate, ReplaceAllOnUpdate, and
 RollingUpdateBestEffort.
-/
+
 When set to OnDelete, no Humio pods will be terminated but new pods will be created with the new spec. Replacing
 existing pods will require each pod to be deleted by the user.
 

--- a/images/logscale-dummy/main.go
+++ b/images/logscale-dummy/main.go
@@ -8,7 +8,8 @@ import (
 
 func main() {
 	http.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
-		fmt.Fprintf(w, "\n")
+		_, err := fmt.Fprintf(w, "\n")
+		fmt.Printf("got err=%v", err)
 	})
 
 	humioPort := os.Getenv("HUMIO_PORT")
@@ -30,7 +31,10 @@ func main() {
 
 func runHTTPS(humioPort, esPort string) {
 	if esPort != "" {
-		go http.ListenAndServeTLS(fmt.Sprintf(":%s", esPort), "cert.pem", "key.pem", nil)
+		go func() {
+			err := http.ListenAndServeTLS(fmt.Sprintf(":%s", esPort), "cert.pem", "key.pem", nil)
+			fmt.Printf("got err=%v", err)
+		}()
 	}
 	err := http.ListenAndServeTLS(fmt.Sprintf(":%s", humioPort), "cert.pem", "key.pem", nil)
 	if err != nil {
@@ -40,7 +44,10 @@ func runHTTPS(humioPort, esPort string) {
 
 func runHTTP(humioPort, esPort string) {
 	if esPort != "" {
-		go http.ListenAndServe(fmt.Sprintf(":%s", esPort), nil)
+		go func() {
+			err := http.ListenAndServe(fmt.Sprintf(":%s", esPort), nil)
+			fmt.Printf("got err=%v", err)
+		}()
 
 	}
 	err := http.ListenAndServe(fmt.Sprintf(":%s", humioPort), nil)
@@ -48,10 +55,3 @@ func runHTTP(humioPort, esPort string) {
 		fmt.Printf("got err=%v", err)
 	}
 }
-
-/*
- TODO: Consider loading in the "real" certificate from the keystore instead of baking in a cert.pem and key.pem during build.
-
- TODO: Consider adding functionality that writes a file so "wait for global file in test cases" will pass.
-								"ls /mnt/global*.json",
-*/

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -124,7 +124,9 @@ func (c *Client) MakeRequest(ctx context.Context, req *graphql.Request, resp *gr
 	if httpResp == nil {
 		return fmt.Errorf("could not execute http request")
 	}
-	defer httpResp.Body.Close()
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(httpResp.Body)
 
 	if httpResp.StatusCode != http.StatusOK {
 		var respBody []byte
@@ -156,11 +158,11 @@ func (c *Client) MakeRequest(ctx context.Context, req *graphql.Request, resp *gr
 	}
 
 	// This prints all extensions. To use this properly, use a logger
-	//if len(actualResponse.Extensions) > 0 {
-	//	for _, extension := range resp.Extensions {
-	//		fmt.Printf("%v\n", extension)
-	//	}
-	//}
+	// if len(actualResponse.Extensions) > 0 {
+	//	 for _, extension := range resp.Extensions {
+	//     fmt.Printf("%v\n", extension)
+	//   }
+	// }
 	if len(actualResponse.Errors) > 0 {
 		return actualResponse.Errors
 	}

--- a/internal/controller/humioaggregatealert_controller.go
+++ b/internal/controller/humioaggregatealert_controller.go
@@ -85,7 +85,7 @@ func (r *HumioAggregateAlertReconciler) Reconcile(ctx context.Context, req ctrl.
 	}
 	humioHttpClient := r.HumioClient.GetHumioHttpClient(cluster.Config(), req)
 
-	defer func(ctx context.Context, HumioClient humio.Client, haa *humiov1alpha1.HumioAggregateAlert) {
+	defer func(ctx context.Context, haa *humiov1alpha1.HumioAggregateAlert) {
 		curAggregateAlert, err := r.HumioClient.GetAggregateAlert(ctx, humioHttpClient, req, haa)
 		if errors.As(err, &humioapi.EntityNotFound{}) {
 			_ = r.setState(ctx, humiov1alpha1.HumioAggregateAlertStateNotFound, haa)
@@ -96,7 +96,7 @@ func (r *HumioAggregateAlertReconciler) Reconcile(ctx context.Context, req ctrl.
 			return
 		}
 		_ = r.setState(ctx, humiov1alpha1.HumioAggregateAlertStateExists, haa)
-	}(ctx, r.HumioClient, haa)
+	}(ctx, haa)
 
 	return r.reconcileHumioAggregateAlert(ctx, humioHttpClient, haa, req)
 }

--- a/internal/controller/humioalert_controller.go
+++ b/internal/controller/humioalert_controller.go
@@ -85,7 +85,7 @@ func (r *HumioAlertReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 	humioHttpClient := r.HumioClient.GetHumioHttpClient(cluster.Config(), req)
 
-	defer func(ctx context.Context, humioClient humio.Client, ha *humiov1alpha1.HumioAlert) {
+	defer func(ctx context.Context, ha *humiov1alpha1.HumioAlert) {
 		_, err := r.HumioClient.GetAlert(ctx, humioHttpClient, req, ha)
 		if errors.As(err, &humioapi.EntityNotFound{}) {
 			_ = r.setState(ctx, humiov1alpha1.HumioAlertStateNotFound, ha)
@@ -96,7 +96,7 @@ func (r *HumioAlertReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return
 		}
 		_ = r.setState(ctx, humiov1alpha1.HumioAlertStateExists, ha)
-	}(ctx, r.HumioClient, ha)
+	}(ctx, ha)
 
 	return r.reconcileHumioAlert(ctx, humioHttpClient, ha, req)
 }

--- a/internal/controller/humiocluster_defaults.go
+++ b/internal/controller/humiocluster_defaults.go
@@ -33,8 +33,10 @@ import (
 const (
 	targetReplicationFactor      = 2
 	digestPartitionsCount        = 24
+	HumioPortName                = "http"
 	HumioPort                    = 8080
-	elasticPort                  = 9200
+	ElasticPortName              = "es"
+	ElasticPort                  = 9200
 	idpCertificateFilename       = "idp-certificate.pem"
 	ExtraKafkaPropertiesFilename = "extra-kafka-properties.properties"
 	ViewGroupPermissionsFilename = "view-group-permissions.json"
@@ -415,7 +417,7 @@ func (hnp *HumioNodePool) GetEnvironmentVariables() []corev1.EnvVar {
 		},
 
 		{Name: "HUMIO_PORT", Value: strconv.Itoa(HumioPort)},
-		{Name: "ELASTIC_PORT", Value: strconv.Itoa(elasticPort)},
+		{Name: "ELASTIC_PORT", Value: strconv.Itoa(ElasticPort)},
 		{Name: "DEFAULT_DIGEST_REPLICATION_FACTOR", Value: strconv.Itoa(hnp.GetTargetReplicationFactor())},
 		{Name: "DEFAULT_SEGMENT_REPLICATION_FACTOR", Value: strconv.Itoa(hnp.GetTargetReplicationFactor())},
 		{Name: "INGEST_QUEUE_INITIAL_PARTITIONS", Value: strconv.Itoa(hnp.GetDigestPartitionsCount())},
@@ -815,7 +817,7 @@ func (hnp *HumioNodePool) GetHumioESServicePort() int32 {
 	if hnp.humioNodeSpec.HumioESServicePort != 0 {
 		return hnp.humioNodeSpec.HumioESServicePort
 	}
-	return elasticPort
+	return ElasticPort
 }
 
 func (hnp *HumioNodePool) GetServiceType() corev1.ServiceType {

--- a/internal/controller/humiocluster_persistent_volumes.go
+++ b/internal/controller/humiocluster_persistent_volumes.go
@@ -45,7 +45,7 @@ func constructPersistentVolumeClaim(hnp *HumioNodePool) *corev1.PersistentVolume
 func FindPvcForPod(pvcList []corev1.PersistentVolumeClaim, pod corev1.Pod) (corev1.PersistentVolumeClaim, error) {
 	for _, pvc := range pvcList {
 		for _, volume := range pod.Spec.Volumes {
-			if volume.Name == "humio-data" {
+			if volume.Name == HumioDataVolumeName {
 				if volume.VolumeSource.PersistentVolumeClaim == nil {
 					continue
 				}
@@ -63,10 +63,10 @@ func FindNextAvailablePvc(pvcList []corev1.PersistentVolumeClaim, podList []core
 	if pvcClaimNamesInUse == nil {
 		return "", fmt.Errorf("pvcClaimNamesInUse must not be nil")
 	}
-	// run through all pods and record PVC claim name for "humio-data" volume
+	// run through all pods and record PVC claim name for HumioDataVolumeName volume
 	for _, pod := range podList {
 		for _, volume := range pod.Spec.Volumes {
-			if volume.Name == "humio-data" {
+			if volume.Name == HumioDataVolumeName {
 				if volume.PersistentVolumeClaim == nil {
 					continue
 				}

--- a/internal/controller/humiocluster_services.go
+++ b/internal/controller/humiocluster_services.go
@@ -52,14 +52,14 @@ func ConstructService(hnp *HumioNodePool) *corev1.Service {
 			Selector: hnp.GetNodePoolLabels(),
 			Ports: []corev1.ServicePort{
 				{
-					Name:       "http",
+					Name:       HumioPortName,
 					Port:       hnp.GetHumioServicePort(),
 					TargetPort: intstr.IntOrString{IntVal: HumioPort},
 				},
 				{
-					Name:       "es",
+					Name:       ElasticPortName,
 					Port:       hnp.GetHumioESServicePort(),
-					TargetPort: intstr.IntOrString{IntVal: elasticPort},
+					TargetPort: intstr.IntOrString{IntVal: ElasticPort},
 				},
 			},
 		},
@@ -81,12 +81,12 @@ func constructHeadlessService(hc *humiov1alpha1.HumioCluster) *corev1.Service {
 			PublishNotReadyAddresses: true,
 			Ports: []corev1.ServicePort{
 				{
-					Name: "http",
+					Name: HumioPortName,
 					Port: HumioPort,
 				},
 				{
-					Name: "es",
-					Port: elasticPort,
+					Name: ElasticPortName,
+					Port: ElasticPort,
 				},
 			},
 		},
@@ -107,12 +107,12 @@ func constructInternalService(hc *humiov1alpha1.HumioCluster) *corev1.Service {
 			}),
 			Ports: []corev1.ServicePort{
 				{
-					Name: "http",
+					Name: HumioPortName,
 					Port: HumioPort,
 				},
 				{
-					Name: "es",
-					Port: elasticPort,
+					Name: ElasticPortName,
+					Port: ElasticPort,
 				},
 			},
 		},

--- a/internal/controller/humiocluster_status.go
+++ b/internal/controller/humiocluster_status.go
@@ -117,16 +117,18 @@ func (o *optionBuilder) withNodePoolState(state string, nodePoolName string, pod
 }
 
 func (o *optionBuilder) withNodePoolStatusList(humioNodePoolStatusList humiov1alpha1.HumioNodePoolStatusList) *optionBuilder {
-	var statesList []stateOption
+	statesList := make([]stateOption, len(humioNodePoolStatusList))
+	idx := 0
 	for _, poolStatus := range humioNodePoolStatusList {
-		statesList = append(statesList, stateOption{
+		statesList[idx] = stateOption{
 			nodePoolName:              poolStatus.Name,
 			state:                     poolStatus.State,
 			zoneUnderMaintenance:      poolStatus.ZoneUnderMaintenance,
 			desiredPodRevision:        poolStatus.DesiredPodRevision,
 			desiredPodHash:            poolStatus.DesiredPodHash,
 			desiredBootstrapTokenHash: poolStatus.DesiredBootstrapTokenHash,
-		})
+		}
+		idx++
 	}
 	o.options = append(o.options, stateOptionList{
 		statesList: statesList,

--- a/internal/controller/humiofilteralert_controller.go
+++ b/internal/controller/humiofilteralert_controller.go
@@ -85,7 +85,7 @@ func (r *HumioFilterAlertReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 	humioHttpClient := r.HumioClient.GetHumioHttpClient(cluster.Config(), req)
 
-	defer func(ctx context.Context, humioClient humio.Client, hfa *humiov1alpha1.HumioFilterAlert) {
+	defer func(ctx context.Context, hfa *humiov1alpha1.HumioFilterAlert) {
 		_, err := r.HumioClient.GetFilterAlert(ctx, humioHttpClient, req, hfa)
 		if errors.As(err, &humioapi.EntityNotFound{}) {
 			_ = r.setState(ctx, humiov1alpha1.HumioFilterAlertStateNotFound, hfa)
@@ -96,7 +96,7 @@ func (r *HumioFilterAlertReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			return
 		}
 		_ = r.setState(ctx, humiov1alpha1.HumioFilterAlertStateExists, hfa)
-	}(ctx, r.HumioClient, hfa)
+	}(ctx, hfa)
 
 	return r.reconcileHumioFilterAlert(ctx, humioHttpClient, hfa, req)
 }

--- a/internal/controller/humioscheduledsearch_controller.go
+++ b/internal/controller/humioscheduledsearch_controller.go
@@ -85,7 +85,7 @@ func (r *HumioScheduledSearchReconciler) Reconcile(ctx context.Context, req ctrl
 	}
 	humioHttpClient := r.HumioClient.GetHumioHttpClient(cluster.Config(), req)
 
-	defer func(ctx context.Context, humioClient humio.Client, hss *humiov1alpha1.HumioScheduledSearch) {
+	defer func(ctx context.Context, hss *humiov1alpha1.HumioScheduledSearch) {
 		_, err := r.HumioClient.GetScheduledSearch(ctx, humioHttpClient, req, hss)
 		if errors.As(err, &humioapi.EntityNotFound{}) {
 			_ = r.setState(ctx, humiov1alpha1.HumioScheduledSearchStateNotFound, hss)
@@ -96,7 +96,7 @@ func (r *HumioScheduledSearchReconciler) Reconcile(ctx context.Context, req ctrl
 			return
 		}
 		_ = r.setState(ctx, humiov1alpha1.HumioScheduledSearchStateExists, hss)
-	}(ctx, r.HumioClient, hss)
+	}(ctx, hss)
 
 	return r.reconcileHumioScheduledSearch(ctx, humioHttpClient, hss, req)
 }

--- a/internal/controller/humioview_controller.go
+++ b/internal/controller/humioview_controller.go
@@ -125,7 +125,7 @@ func (r *HumioViewReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 		return reconcile.Result{Requeue: true}, nil
 	}
-	defer func(ctx context.Context, humioClient humio.Client, hv *humiov1alpha1.HumioView) {
+	defer func(ctx context.Context, hv *humiov1alpha1.HumioView) {
 		_, err := r.HumioClient.GetView(ctx, humioHttpClient, req, hv)
 		if errors.As(err, &humioapi.EntityNotFound{}) {
 			_ = r.setState(ctx, humiov1alpha1.HumioViewStateNotFound, hv)
@@ -136,7 +136,7 @@ func (r *HumioViewReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return
 		}
 		_ = r.setState(ctx, humiov1alpha1.HumioViewStateExists, hv)
-	}(ctx, r.HumioClient, hv)
+	}(ctx, hv)
 
 	r.Log.Info("get current view")
 	curView, err := r.HumioClient.GetView(ctx, humioHttpClient, req, hv)

--- a/internal/controller/suite/resources/humioresources_controller_test.go
+++ b/internal/controller/suite/resources/humioresources_controller_test.go
@@ -38,7 +38,10 @@ import (
 	"github.com/humio/humio-operator/internal/controller/suite"
 )
 
-const EmailActionExample string = "example@example.com"
+const (
+	emailActionExample         string = "example@example.com"
+	expectedSecretValueExample string = "secret-token"
+)
 
 var _ = Describe("Humio Resources Controllers", func() {
 	BeforeEach(func() {
@@ -83,7 +86,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedIngestToken := &humiov1alpha1.HumioIngestToken{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedIngestToken)
+				_ = k8sClient.Get(ctx, key, fetchedIngestToken)
 				return fetchedIngestToken.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioIngestTokenStateExists))
 
@@ -188,13 +191,13 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedIngestToken := &humiov1alpha1.HumioIngestToken{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedIngestToken)
+				_ = k8sClient.Get(ctx, key, fetchedIngestToken)
 				return fetchedIngestToken.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioIngestTokenStateExists))
 
 			suite.UsingClusterBy(clusterKey.Name, "HumioIngestToken: Checking we do not create a token secret")
 			var allSecrets corev1.SecretList
-			k8sClient.List(ctx, &allSecrets, client.InNamespace(fetchedIngestToken.Namespace))
+			_ = k8sClient.List(ctx, &allSecrets, client.InNamespace(fetchedIngestToken.Namespace))
 			for _, secret := range allSecrets.Items {
 				for _, owner := range secret.OwnerReferences {
 					Expect(owner.Name).ShouldNot(BeIdenticalTo(fetchedIngestToken.Name))
@@ -258,7 +261,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 			suite.UsingClusterBy(clusterKey.Name, fmt.Sprintf("HumioIngestToken: Validates resource enters state %s", humiov1alpha1.HumioIngestTokenStateConfigError))
 			fetchedIngestToken := &humiov1alpha1.HumioIngestToken{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, keyErr, fetchedIngestToken)
+				_ = k8sClient.Get(ctx, keyErr, fetchedIngestToken)
 				return fetchedIngestToken.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioIngestTokenStateConfigError))
 
@@ -292,7 +295,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 			suite.UsingClusterBy(clusterKey.Name, fmt.Sprintf("HumioIngestToken: Validates resource enters state %s", humiov1alpha1.HumioIngestTokenStateConfigError))
 			fetchedIngestToken = &humiov1alpha1.HumioIngestToken{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, keyErr, fetchedIngestToken)
+				_ = k8sClient.Get(ctx, keyErr, fetchedIngestToken)
 				return fetchedIngestToken.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioIngestTokenStateConfigError))
 
@@ -337,7 +340,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedRepository := &humiov1alpha1.HumioRepository{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedRepository)
+				_ = k8sClient.Get(ctx, key, fetchedRepository)
 				return fetchedRepository.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioRepositoryStateExists))
 
@@ -491,7 +494,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedRepo := &humiov1alpha1.HumioRepository{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, viewKey, fetchedRepo)
+				_ = k8sClient.Get(ctx, viewKey, fetchedRepo)
 				return fetchedRepo.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioRepositoryStateExists))
 
@@ -500,7 +503,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedView := &humiov1alpha1.HumioView{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, viewKey, fetchedView)
+				_ = k8sClient.Get(ctx, viewKey, fetchedView)
 				return fetchedView.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioViewStateExists))
 
@@ -627,7 +630,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedParser := &humiov1alpha1.HumioParser{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedParser)
+				_ = k8sClient.Get(ctx, key, fetchedParser)
 				return fetchedParser.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioParserStateExists))
 
@@ -740,7 +743,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 			suite.UsingClusterBy(clusterKey.Name, "HumioExternalCluster: Confirming external cluster gets marked as ready")
 			fetchedExternalCluster := &humiov1alpha1.HumioExternalCluster{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedExternalCluster)
+				_ = k8sClient.Get(ctx, key, fetchedExternalCluster)
 				return fetchedExternalCluster.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioExternalClusterStateReady))
 
@@ -777,7 +780,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 			suite.UsingClusterBy(clusterKey.Name, fmt.Sprintf("HumioParser: Validates resource enters state %s", humiov1alpha1.HumioParserStateConfigError))
 			fetchedParser := &humiov1alpha1.HumioParser{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, keyErr, fetchedParser)
+				_ = k8sClient.Get(ctx, keyErr, fetchedParser)
 				return fetchedParser.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioParserStateConfigError))
 
@@ -812,7 +815,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 			suite.UsingClusterBy(clusterKey.Name, fmt.Sprintf("HumioParser: Validates resource enters state %s", humiov1alpha1.HumioParserStateConfigError))
 			fetchedParser := &humiov1alpha1.HumioParser{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, keyErr, fetchedParser)
+				_ = k8sClient.Get(ctx, keyErr, fetchedParser)
 				return fetchedParser.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioParserStateConfigError))
 
@@ -846,7 +849,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 			suite.UsingClusterBy(clusterKey.Name, fmt.Sprintf("HumioRepository: Validates resource enters state %s", humiov1alpha1.HumioRepositoryStateConfigError))
 			fetchedRepository := &humiov1alpha1.HumioRepository{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, keyErr, fetchedRepository)
+				_ = k8sClient.Get(ctx, keyErr, fetchedRepository)
 				return fetchedRepository.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioRepositoryStateConfigError))
 
@@ -880,7 +883,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 			suite.UsingClusterBy(clusterKey.Name, fmt.Sprintf("HumioRepository: Validates resource enters state %s", humiov1alpha1.HumioRepositoryStateConfigError))
 			fetchedRepository := &humiov1alpha1.HumioRepository{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, keyErr, fetchedRepository)
+				_ = k8sClient.Get(ctx, keyErr, fetchedRepository)
 				return fetchedRepository.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioRepositoryStateConfigError))
 
@@ -919,7 +922,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 			suite.UsingClusterBy(clusterKey.Name, fmt.Sprintf("HumioView: Validates resource enters state %s", humiov1alpha1.HumioViewStateConfigError))
 			fetchedView := &humiov1alpha1.HumioView{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, keyErr, fetchedView)
+				_ = k8sClient.Get(ctx, keyErr, fetchedView)
 				return fetchedView.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioViewStateConfigError))
 
@@ -958,7 +961,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 			suite.UsingClusterBy(clusterKey.Name, fmt.Sprintf("HumioView: Validates resource enters state %s", humiov1alpha1.HumioViewStateConfigError))
 			fetchedView := &humiov1alpha1.HumioView{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, keyErr, fetchedView)
+				_ = k8sClient.Get(ctx, keyErr, fetchedView)
 				return fetchedView.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioViewStateConfigError))
 
@@ -980,7 +983,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 				Name:               "example-action",
 				ViewName:           testRepo.Spec.Name,
 				EmailProperties: &humiov1alpha1.HumioActionEmailProperties{
-					Recipients: []string{EmailActionExample},
+					Recipients: []string{emailActionExample},
 				},
 			}
 
@@ -1002,7 +1005,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -1035,7 +1038,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 				expectedUpdatedAction, err = humioClient.GetAction(ctx, humioHttpClient, reconcile.Request{NamespacedName: clusterKey}, fetchedAction)
 				return err
 			}, testTimeout, suite.TestInterval).Should(Succeed())
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(expectedUpdatedAction).ToNot(BeNil())
 
 			suite.UsingClusterBy(clusterKey.Name, "HumioAction: Verifying the action matches the expected")
@@ -1097,7 +1100,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -1120,7 +1123,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			suite.UsingClusterBy(clusterKey.Name, "HumioAction: Waiting for the humio repo action to be updated")
 			Eventually(func() error {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				fetchedAction.Spec.HumioRepositoryProperties = updatedAction.Spec.HumioRepositoryProperties
 				return k8sClient.Update(ctx, fetchedAction)
 			}, testTimeout, suite.TestInterval).Should(Succeed())
@@ -1186,7 +1189,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -1210,7 +1213,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			suite.UsingClusterBy(clusterKey.Name, "HumioAction: Waiting for the ops genie action to be updated")
 			Eventually(func() error {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				fetchedAction.Spec.OpsGenieProperties = updatedAction.Spec.OpsGenieProperties
 				return k8sClient.Update(ctx, fetchedAction)
 			}, testTimeout, suite.TestInterval).Should(Succeed())
@@ -1280,7 +1283,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -1303,7 +1306,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			suite.UsingClusterBy(clusterKey.Name, "HumioAction: Waiting for the pagerduty action to be updated")
 			Eventually(func() error {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				fetchedAction.Spec.PagerDutyProperties = updatedAction.Spec.PagerDutyProperties
 				return k8sClient.Update(ctx, fetchedAction)
 			}, testTimeout, suite.TestInterval).Should(Succeed())
@@ -1375,7 +1378,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -1404,7 +1407,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			suite.UsingClusterBy(clusterKey.Name, "HumioAction: Waiting for the slack post message action to be updated")
 			Eventually(func() error {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				fetchedAction.Spec.SlackPostMessageProperties = updatedAction.Spec.SlackPostMessageProperties
 				return k8sClient.Update(ctx, fetchedAction)
 			}, testTimeout, suite.TestInterval).Should(Succeed())
@@ -1479,7 +1482,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -1507,7 +1510,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			suite.UsingClusterBy(clusterKey.Name, "HumioAction: Waiting for the slack action to be updated")
 			Eventually(func() error {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				fetchedAction.Spec.SlackProperties = updatedAction.Spec.SlackProperties
 				return k8sClient.Update(ctx, fetchedAction)
 			}, testTimeout, suite.TestInterval).Should(Succeed())
@@ -1579,7 +1582,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -1603,7 +1606,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			suite.UsingClusterBy(clusterKey.Name, "HumioAction: Waiting for the victor ops action to be updated")
 			Eventually(func() error {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				fetchedAction.Spec.VictorOpsProperties = updatedAction.Spec.VictorOpsProperties
 				return k8sClient.Update(ctx, fetchedAction)
 			}, testTimeout, suite.TestInterval).Should(Succeed())
@@ -1674,7 +1677,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -1698,7 +1701,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			suite.UsingClusterBy(clusterKey.Name, "HumioAction: Waiting for the web hook action to be updated")
 			Eventually(func() error {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				fetchedAction.Spec.WebhookProperties = updatedWebhookActionProperties
 				return k8sClient.Update(ctx, fetchedAction)
 			}, testTimeout, suite.TestInterval).Should(Succeed())
@@ -1766,7 +1769,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateConfigError))
 
@@ -1816,7 +1819,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateConfigError))
 
@@ -1865,7 +1868,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 				},
 			}
 
-			expectedSecretValue := "secret-token"
+			expectedSecretValue := expectedSecretValueExample
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "action-humio-repository-secret",
@@ -1881,7 +1884,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -1936,7 +1939,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 				},
 			}
 
-			expectedSecretValue := "secret-token"
+			expectedSecretValue := expectedSecretValueExample
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "action-genie-secret",
@@ -1952,7 +1955,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -2005,7 +2008,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -2076,7 +2079,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -2129,7 +2132,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -2187,7 +2190,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 				},
 			}
 
-			expectedSecretValue := "secret-token"
+			expectedSecretValue := expectedSecretValueExample
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "action-slack-post-secret",
@@ -2203,7 +2206,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -2258,7 +2261,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -2331,7 +2334,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -2386,7 +2389,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -2457,7 +2460,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -2510,7 +2513,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -2564,7 +2567,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -2636,7 +2639,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -2695,7 +2698,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -2793,7 +2796,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -2891,7 +2894,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAction)
+				_ = k8sClient.Get(ctx, key, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -2940,7 +2943,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 				Name:               "example-email-action",
 				ViewName:           testRepo.Spec.Name,
 				EmailProperties: &humiov1alpha1.HumioActionEmailProperties{
-					Recipients: []string{EmailActionExample},
+					Recipients: []string{emailActionExample},
 				},
 			}
 
@@ -2962,7 +2965,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, actionKey, fetchedAction)
+				_ = k8sClient.Get(ctx, actionKey, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -3000,7 +3003,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAlert := &humiov1alpha1.HumioAlert{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAlert)
+				_ = k8sClient.Get(ctx, key, fetchedAlert)
 				return fetchedAlert.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioAlertStateExists))
 
@@ -3148,7 +3151,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 				Name:               "example-email-action4",
 				ViewName:           testRepo.Spec.Name,
 				EmailProperties: &humiov1alpha1.HumioActionEmailProperties{
-					Recipients: []string{EmailActionExample},
+					Recipients: []string{emailActionExample},
 				},
 			}
 
@@ -3170,7 +3173,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, actionKey, fetchedAction)
+				_ = k8sClient.Get(ctx, actionKey, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -3205,7 +3208,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedFilterAlert := &humiov1alpha1.HumioFilterAlert{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedFilterAlert)
+				_ = k8sClient.Get(ctx, key, fetchedFilterAlert)
 				return fetchedFilterAlert.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioFilterAlertStateExists))
 
@@ -3376,7 +3379,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 				Name:               "example-email-action3",
 				ViewName:           testRepo.Spec.Name,
 				EmailProperties: &humiov1alpha1.HumioActionEmailProperties{
-					Recipients: []string{EmailActionExample},
+					Recipients: []string{emailActionExample},
 				},
 			}
 
@@ -3398,7 +3401,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, actionKey, fetchedAction)
+				_ = k8sClient.Get(ctx, actionKey, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -3436,7 +3439,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAggregateAlert := &humiov1alpha1.HumioAggregateAlert{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedAggregateAlert)
+				_ = k8sClient.Get(ctx, key, fetchedAggregateAlert)
 				return fetchedAggregateAlert.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioAggregateAlertStateExists))
 
@@ -3493,7 +3496,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 				Actions:               humioapi.GetActionNames(aggregateAlert.GetActions()),
 				Labels:                aggregateAlert.Labels,
 			}
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(createdAggregateAlert.Spec).To(Equal(toCreateAggregateAlert.Spec))
 
 			suite.UsingClusterBy(clusterKey.Name, "HumioAggregateAlert: Updating the aggregate alert successfully")
@@ -3612,7 +3615,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 				Name:               "example-email-action2",
 				ViewName:           testRepo.Spec.Name,
 				EmailProperties: &humiov1alpha1.HumioActionEmailProperties{
-					Recipients: []string{EmailActionExample},
+					Recipients: []string{emailActionExample},
 				},
 			}
 
@@ -3634,7 +3637,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedAction := &humiov1alpha1.HumioAction{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, actionKey, fetchedAction)
+				_ = k8sClient.Get(ctx, actionKey, fetchedAction)
 				return fetchedAction.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioActionStateExists))
 
@@ -3672,7 +3675,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			fetchedScheduledSearch := &humiov1alpha1.HumioScheduledSearch{}
 			Eventually(func() string {
-				k8sClient.Get(ctx, key, fetchedScheduledSearch)
+				_ = k8sClient.Get(ctx, key, fetchedScheduledSearch)
 				return fetchedScheduledSearch.Status.State
 			}, testTimeout, suite.TestInterval).Should(Equal(humiov1alpha1.HumioScheduledSearchStateExists))
 
@@ -3734,7 +3737,7 @@ var _ = Describe("Humio Resources Controllers", func() {
 
 			suite.UsingClusterBy(clusterKey.Name, "HumioScheduledSearch: Waiting for the scheduled search to be updated")
 			Eventually(func() error {
-				k8sClient.Get(ctx, key, fetchedScheduledSearch)
+				_ = k8sClient.Get(ctx, key, fetchedScheduledSearch)
 				fetchedScheduledSearch.Spec.QueryString = updatedScheduledSearch.Spec.QueryString
 				fetchedScheduledSearch.Spec.QueryStart = updatedScheduledSearch.Spec.QueryStart
 				fetchedScheduledSearch.Spec.QueryEnd = updatedScheduledSearch.Spec.QueryEnd

--- a/internal/controller/suite/resources/suite_test.go
+++ b/internal/controller/suite/resources/suite_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/humio/humio-operator/internal/helpers"
 	"github.com/humio/humio-operator/internal/humio"
 	"github.com/humio/humio-operator/internal/kubernetes"
+	uberzap "go.uber.org/zap"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/rest"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -51,7 +52,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	corev1alpha1 "github.com/humio/humio-operator/api/v1alpha1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -83,7 +84,9 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	var log logr.Logger
 	zapLog, _ := helpers.NewLogger()
-	defer zapLog.Sync()
+	defer func(zapLog *uberzap.Logger) {
+		_ = zapLog.Sync()
+	}(zapLog)
 	log = zapr.NewLogger(zapLog)
 	logf.SetLogger(log)
 
@@ -135,7 +138,7 @@ var _ = BeforeSuite(func() {
 	err = corev1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sManager, err = ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:  scheme.Scheme,
@@ -264,7 +267,7 @@ var _ = BeforeSuite(func() {
 	suite.CreateAndBootstrapCluster(context.TODO(), k8sClient, humioClient, cluster, true, corev1alpha1.HumioClusterStateRunning, testTimeout)
 
 	sharedCluster, err = helpers.NewCluster(context.TODO(), k8sClient, clusterKey.Name, "", clusterKey.Namespace, helpers.UseCertManager(), true, false)
-	Expect(err).To(BeNil())
+	Expect(err).ToNot(HaveOccurred())
 	Expect(sharedCluster).ToNot(BeNil())
 	Expect(sharedCluster.Config()).ToNot(BeNil())
 
@@ -416,8 +419,8 @@ var _ = ReportAfterSuite("HumioCluster Controller Suite", func(suiteReport ginkg
 		// 1. regular container stdout
 		// 2. ReportAfterEach
 		// 3. ReportAfterSuite
-		//suite.PrintLinesWithRunID(testRunID, strings.Split(r.CapturedGinkgoWriterOutput, "\n"), r.State)
-		//suite.PrintLinesWithRunID(testRunID, strings.Split(r.CapturedStdOutErr, "\n"), r.State)
+		// suite.PrintLinesWithRunID(testRunID, strings.Split(r.CapturedGinkgoWriterOutput, "\n"), r.State)
+		// suite.PrintLinesWithRunID(testRunID, strings.Split(r.CapturedStdOutErr, "\n"), r.State)
 
 		r.CapturedGinkgoWriterOutput = testRunID
 		r.CapturedStdOutErr = testRunID
@@ -439,8 +442,8 @@ var _ = ReportAfterEach(func(specReport ginkgotypes.SpecReport) {
 	// 1. regular container stdout
 	// 2. ReportAfterEach
 	// 3. ReportAfterSuite
-	//suite.PrintLinesWithRunID(testRunID, strings.Split(specReport.CapturedGinkgoWriterOutput, "\n"), specReport.State)
-	//suite.PrintLinesWithRunID(testRunID, strings.Split(specReport.CapturedStdOutErr, "\n"), specReport.State)
+	// suite.PrintLinesWithRunID(testRunID, strings.Split(specReport.CapturedGinkgoWriterOutput, "\n"), specReport.State)
+	// suite.PrintLinesWithRunID(testRunID, strings.Split(specReport.CapturedStdOutErr, "\n"), specReport.State)
 
 	specReport.CapturedGinkgoWriterOutput = testRunID
 	specReport.CapturedStdOutErr = testRunID

--- a/internal/helpers/clusterinterface.go
+++ b/internal/helpers/clusterinterface.go
@@ -90,10 +90,7 @@ func (c Cluster) Url(ctx context.Context, k8sClient client.Client) (*url.URL, er
 		}
 
 		protocol := "https"
-		if !c.certManagerEnabled {
-			protocol = "http"
-		}
-		if !TLSEnabled(&humioManagedCluster) {
+		if !c.certManagerEnabled || !TLSEnabled(&humioManagedCluster) {
 			protocol = "http"
 		}
 		baseURL, _ := url.Parse(fmt.Sprintf("%s://%s-internal.%s:%d/", protocol, c.managedClusterName, c.namespace, 8080))

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -30,6 +30,10 @@ import (
 	humiov1alpha1 "github.com/humio/humio-operator/api/v1alpha1"
 )
 
+const (
+	TrueStr string = "true"
+)
+
 // GetTypeName returns the name of the type of object which is obtained by using reflection
 func GetTypeName(myvar interface{}) string {
 	t := reflect.TypeOf(myvar)
@@ -117,9 +121,11 @@ func MapToSortedString(m map[string]string) string {
 	if len(m) == 0 {
 		return `"":""`
 	}
-	var a []string
+	a := make([]string, len(m))
+	idx := 0
 	for k, v := range m {
-		a = append(a, fmt.Sprintf("%s=%s", k, v))
+		a[idx] = fmt.Sprintf("%s=%s", k, v)
+		idx++
 	}
 	sort.SliceStable(a, func(i, j int) bool {
 		return a[i] > a[j]
@@ -138,7 +144,7 @@ func NewLogger() (*uberzap.Logger, error) {
 
 // UseCertManager returns whether the operator will use cert-manager
 func UseCertManager() bool {
-	return !UseEnvtest() && os.Getenv("USE_CERTMANAGER") == "true"
+	return !UseEnvtest() && os.Getenv("USE_CERTMANAGER") == TrueStr
 }
 
 // GetDefaultHumioCoreImageFromEnvVar returns the user-defined default image for humio-core containers
@@ -153,12 +159,12 @@ func GetDefaultHumioHelperImageFromEnvVar() string {
 
 // UseEnvtest returns whether the Kubernetes API is provided by envtest
 func UseEnvtest() bool {
-	return os.Getenv("TEST_USING_ENVTEST") == "true"
+	return os.Getenv("TEST_USING_ENVTEST") == TrueStr
 }
 
 // UseDummyImage returns whether we are using a dummy image replacement instead of real container images
 func UseDummyImage() bool {
-	return os.Getenv("DUMMY_LOGSCALE_IMAGE") == "true"
+	return os.Getenv("DUMMY_LOGSCALE_IMAGE") == TrueStr
 }
 
 // GetE2ELicenseFromEnvVar returns the E2E license set as an environment variable
@@ -169,5 +175,5 @@ func GetE2ELicenseFromEnvVar() string {
 // PreserveKindCluster returns true if the intention is to not delete kind cluster after test execution.
 // This is to allow reruns of tests to be performed where resources can be reused.
 func PreserveKindCluster() bool {
-	return os.Getenv("PRESERVE_KIND_CLUSTER") == "true"
+	return os.Getenv("PRESERVE_KIND_CLUSTER") == TrueStr
 }


### PR DESCRIPTION
This also fixes most issues flagged by the default list of linters that are enabled.

For now, I decided to ignore the handful of places where the gocyclo rule flags issues, so that we can keep the linter enabled to prevent us from introducing more code that would be called out by gocyclo. If we end up fixing those handful of places, we can always remove the nolint marker.