### PR TITLE
Update helm to support metrics enablement and port change

### DIFF
--- a/charts/humio-operator/templates/operator-deployment.yaml
+++ b/charts/humio-operator/templates/operator-deployment.yaml
@@ -53,6 +53,10 @@ spec:
         imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
         command:
         - /manager
+{{- if .Values.operator.metrics.enabled }}
+        - --metrics-bind-address=:{{ .Values.operator.metrics.listen.port }}
+        - --metrics-secure={{ .Values.operator.metrics.secure }}
+{{- end }}
         env:
         - name: POD_NAME
           valueFrom:
@@ -68,12 +72,12 @@ spec:
           value: {{ .Values.defaultHumioHelperImage | quote }}
         livenessProbe:
           httpGet:
-            path: /metrics
-            port: 8080
+            path: /healthz
+            port: 8081
         readinessProbe:
           httpGet:
-            path: /metrics
-            port: 8080
+            path: /readyz
+            port: 8081
 {{- with .Values.operator.resources }}
         resources:
           {{- toYaml . | nindent 10 }}

--- a/charts/humio-operator/templates/operator-service.yaml
+++ b/charts/humio-operator/templates/operator-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.operator.metrics.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,10 +9,11 @@ metadata:
 spec:
   ports:
   - name: metrics
-    port: 8080
+    port: {{ .Values.operator.metrics.listen.port }}
     protocol: TCP
-    targetPort: 8080
+    targetPort: {{ .Values.operator.metrics.listen.port }}
   selector:
     app: '{{ .Chart.Name }}'
     app.kubernetes.io/name: '{{ .Chart.Name }}'
     app.kubernetes.io/instance: '{{ .Release.Name }}'
+{{- end }}

--- a/charts/humio-operator/values.yaml
+++ b/charts/humio-operator/values.yaml
@@ -5,6 +5,11 @@ operator:
     tag:
     pullPolicy: IfNotPresent
     pullSecrets: []
+  metrics:
+    enabled: true
+    listen:
+      port: 8080
+    secure: false
   prometheus:
     serviceMonitor:
       enabled: false


### PR DESCRIPTION
This resolves #951, where the operator doesn't become healthy to the API since kubebuilder v4. Added options to enable/disable metrics (enabled by default), and updated probes to use dedicated probe endpoints.