### PR TITLE
Add requeue-period flag to humio-operator binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,7 @@ update-schema:
 	go run github.com/suessflorian/gqlfetch/gqlfetch@607d6757018016bba0ba7fd1cb9fed6aefa853b5 --endpoint ${SCHEMA_CLUSTER}/graphql --header "Authorization=Bearer ${SCHEMA_CLUSTER_API_TOKEN}" > internal/api/humiographql/schema/_schema.graphql
 	printf "# Fetched from version %s" $$(curl --silent --location '${SCHEMA_CLUSTER}/api/v1/status' | jq -r ".version") >> internal/api/humiographql/schema/_schema.graphql
 
-.PHONY: test-envtest
+.PHONY: test
 test: manifests generate fmt vet setup-envtest ginkgo ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
 	TEST_USING_ENVTEST=true \

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/go-logr/logr"
@@ -75,6 +76,8 @@ func main() {
 	var secureMetrics bool
 	var enableHTTP2 bool
 	var tlsOpts []func(*tls.Config)
+	var requeuePeriod time.Duration
+
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -92,6 +95,7 @@ func main() {
 	flag.StringVar(&metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	flag.DurationVar(&requeuePeriod, "requeue-period", 15*time.Second, "The default reconciliation requeue period for all Humio* resources.")
 	flag.Parse()
 
 	var log logr.Logger
@@ -226,7 +230,10 @@ func main() {
 	userAgent := fmt.Sprintf("humio-operator/%s (%s on %s)", version, commit, date)
 
 	if err = (&controller.HumioActionReconciler{
-		Client:      mgr.GetClient(),
+		Client: mgr.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		HumioClient: humio.NewClient(log, userAgent),
 		BaseLogger:  log,
 	}).SetupWithManager(mgr); err != nil {
@@ -234,7 +241,10 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controller.HumioAggregateAlertReconciler{
-		Client:      mgr.GetClient(),
+		Client: mgr.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		HumioClient: humio.NewClient(log, userAgent),
 		BaseLogger:  log,
 	}).SetupWithManager(mgr); err != nil {
@@ -242,7 +252,10 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controller.HumioAlertReconciler{
-		Client:      mgr.GetClient(),
+		Client: mgr.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		HumioClient: humio.NewClient(log, userAgent),
 		BaseLogger:  log,
 	}).SetupWithManager(mgr); err != nil {
@@ -250,14 +263,20 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controller.HumioBootstrapTokenReconciler{
-		Client:     mgr.GetClient(),
+		Client: mgr.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		BaseLogger: log,
 	}).SetupWithManager(mgr); err != nil {
 		ctrl.Log.Error(err, "unable to create controller", "controller", "HumioBootstrapToken")
 		os.Exit(1)
 	}
 	if err = (&controller.HumioClusterReconciler{
-		Client:      mgr.GetClient(),
+		Client: mgr.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		HumioClient: humio.NewClient(log, userAgent),
 		BaseLogger:  log,
 	}).SetupWithManager(mgr); err != nil {
@@ -265,7 +284,10 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controller.HumioExternalClusterReconciler{
-		Client:      mgr.GetClient(),
+		Client: mgr.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		HumioClient: humio.NewClient(log, userAgent),
 		BaseLogger:  log,
 	}).SetupWithManager(mgr); err != nil {
@@ -273,14 +295,20 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controller.HumioFilterAlertReconciler{
-		Client:      mgr.GetClient(),
+		Client: mgr.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		HumioClient: humio.NewClient(log, userAgent),
 		BaseLogger:  log,
 	}).SetupWithManager(mgr); err != nil {
 		ctrl.Log.Error(err, "unable to create controller", "controller", "HumioFilterAlert")
 	}
 	if err = (&controller.HumioIngestTokenReconciler{
-		Client:      mgr.GetClient(),
+		Client: mgr.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		HumioClient: humio.NewClient(log, userAgent),
 		BaseLogger:  log,
 	}).SetupWithManager(mgr); err != nil {
@@ -288,7 +316,10 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controller.HumioParserReconciler{
-		Client:      mgr.GetClient(),
+		Client: mgr.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		HumioClient: humio.NewClient(log, userAgent),
 		BaseLogger:  log,
 	}).SetupWithManager(mgr); err != nil {
@@ -296,7 +327,10 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controller.HumioRepositoryReconciler{
-		Client:      mgr.GetClient(),
+		Client: mgr.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		HumioClient: humio.NewClient(log, userAgent),
 		BaseLogger:  log,
 	}).SetupWithManager(mgr); err != nil {
@@ -304,7 +338,10 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controller.HumioScheduledSearchReconciler{
-		Client:      mgr.GetClient(),
+		Client: mgr.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		HumioClient: humio.NewClient(log, userAgent),
 		BaseLogger:  log,
 	}).SetupWithManager(mgr); err != nil {
@@ -312,7 +349,10 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controller.HumioViewReconciler{
-		Client:      mgr.GetClient(),
+		Client: mgr.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		HumioClient: humio.NewClient(log, userAgent),
 		BaseLogger:  log,
 	}).SetupWithManager(mgr); err != nil {

--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -1,0 +1,8 @@
+package controller
+
+import "time"
+
+// CommonConfig has common configuration parameters for all controllers.
+type CommonConfig struct {
+	RequeuePeriod time.Duration // How frequently to requeue a resource for reconcile.
+}

--- a/internal/controller/humioaction_controller.go
+++ b/internal/controller/humioaction_controller.go
@@ -40,6 +40,7 @@ import (
 // HumioActionReconciler reconciles a HumioAction object
 type HumioActionReconciler struct {
 	client.Client
+	CommonConfig
 	BaseLogger  logr.Logger
 	Log         logr.Logger
 	HumioClient humio.Client
@@ -193,8 +194,8 @@ func (r *HumioActionReconciler) reconcileHumioAction(ctx context.Context, client
 		)
 	}
 
-	r.Log.Info("done reconciling, will requeue after 15 seconds")
-	return reconcile.Result{RequeueAfter: time.Second * 15}, nil
+	r.Log.Info("done reconciling, will requeue", "requeuePeriod", r.CommonConfig.RequeuePeriod.String())
+	return reconcile.Result{RequeueAfter: r.CommonConfig.RequeuePeriod}, nil
 }
 
 func (r *HumioActionReconciler) resolveSecrets(ctx context.Context, ha *humiov1alpha1.HumioAction) error {

--- a/internal/controller/humioaggregatealert_controller.go
+++ b/internal/controller/humioaggregatealert_controller.go
@@ -40,6 +40,7 @@ import (
 // HumioAggregateAlertReconciler reconciles a HumioAggregateAlert object
 type HumioAggregateAlertReconciler struct {
 	client.Client
+	CommonConfig
 	BaseLogger  logr.Logger
 	Log         logr.Logger
 	HumioClient humio.Client
@@ -189,9 +190,8 @@ func (r *HumioAggregateAlertReconciler) reconcileHumioAggregateAlert(ctx context
 		)
 	}
 
-	r.Log.Info("done reconciling, will requeue in 15 seconds")
-	return reconcile.Result{RequeueAfter: time.Second * 15}, nil
-
+	r.Log.Info("done reconciling, will requeue", "requeuePeriod", r.CommonConfig.RequeuePeriod.String())
+	return reconcile.Result{RequeueAfter: r.CommonConfig.RequeuePeriod}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/humioalert_controller.go
+++ b/internal/controller/humioalert_controller.go
@@ -40,6 +40,7 @@ import (
 // HumioAlertReconciler reconciles a HumioAlert object
 type HumioAlertReconciler struct {
 	client.Client
+	CommonConfig
 	BaseLogger  logr.Logger
 	Log         logr.Logger
 	HumioClient humio.Client
@@ -175,8 +176,8 @@ func (r *HumioAlertReconciler) reconcileHumioAlert(ctx context.Context, client *
 		)
 	}
 
-	r.Log.Info("done reconciling, will requeue after 15 seconds")
-	return reconcile.Result{RequeueAfter: time.Second * 15}, nil
+	r.Log.Info("done reconciling, will requeue", "requeuePeriod", r.CommonConfig.RequeuePeriod.String())
+	return reconcile.Result{RequeueAfter: r.CommonConfig.RequeuePeriod}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/humiobootstraptoken_controller.go
+++ b/internal/controller/humiobootstraptoken_controller.go
@@ -54,6 +54,7 @@ const (
 // HumioBootstrapTokenReconciler reconciles a HumioBootstrapToken object
 type HumioBootstrapTokenReconciler struct {
 	client.Client
+	CommonConfig
 	BaseLogger logr.Logger
 	Log        logr.Logger
 	Namespace  string
@@ -119,7 +120,8 @@ func (r *HumioBootstrapTokenReconciler) Reconcile(ctx context.Context, req ctrl.
 		return reconcile.Result{}, err
 	}
 
-	return reconcile.Result{RequeueAfter: time.Second * 60}, nil
+	r.Log.Info("done reconciling, will requeue", "requeuePeriod", r.CommonConfig.RequeuePeriod.String())
+	return reconcile.Result{RequeueAfter: r.CommonConfig.RequeuePeriod}, nil
 }
 
 func (r *HumioBootstrapTokenReconciler) updateStatus(ctx context.Context, hbt *humiov1alpha1.HumioBootstrapToken, state string) error {

--- a/internal/controller/humiocluster_controller.go
+++ b/internal/controller/humiocluster_controller.go
@@ -52,6 +52,7 @@ import (
 // HumioClusterReconciler reconciles a HumioCluster object
 type HumioClusterReconciler struct {
 	client.Client
+	CommonConfig
 	BaseLogger  logr.Logger
 	Log         logr.Logger
 	HumioClient humio.Client
@@ -330,7 +331,14 @@ func (r *HumioClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	r.Log.Info("done reconciling")
-	return r.updateStatus(ctx, r.Client.Status(), hc, statusOptions().withState(hc.Status.State).withMessage(""))
+	return r.updateStatus(
+		ctx,
+		r.Client.Status(),
+		hc,
+		statusOptions().
+			withState(hc.Status.State).
+			withRequeuePeriod(r.CommonConfig.RequeuePeriod).
+			withMessage(""))
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/humioexternalcluster_controller.go
+++ b/internal/controller/humioexternalcluster_controller.go
@@ -35,6 +35,7 @@ import (
 // HumioExternalClusterReconciler reconciles a HumioExternalCluster object
 type HumioExternalClusterReconciler struct {
 	client.Client
+	CommonConfig
 	BaseLogger  logr.Logger
 	Log         logr.Logger
 	HumioClient humio.Client
@@ -85,7 +86,7 @@ func (r *HumioExternalClusterReconciler) Reconcile(ctx context.Context, req ctrl
 
 	err = r.HumioClient.TestAPIToken(ctx, cluster.Config(), req)
 	if err != nil {
-		r.Log.Error(err, "unable to test if the API token is works")
+		r.Log.Error(err, "unable to test if the API token works")
 		err = r.Client.Get(ctx, req.NamespacedName, hec)
 		if err != nil {
 			return reconcile.Result{}, r.logErrorAndReturn(err, "unable to get cluster state")
@@ -108,8 +109,8 @@ func (r *HumioExternalClusterReconciler) Reconcile(ctx context.Context, req ctrl
 		}
 	}
 
-	r.Log.Info("done reconciling, will requeue after 15 seconds")
-	return reconcile.Result{RequeueAfter: time.Second * 15}, nil
+	r.Log.Info("done reconciling, will requeue", "requeuePeriod", r.CommonConfig.RequeuePeriod.String())
+	return reconcile.Result{RequeueAfter: r.CommonConfig.RequeuePeriod}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/humiofilteralert_controller.go
+++ b/internal/controller/humiofilteralert_controller.go
@@ -40,6 +40,7 @@ import (
 // HumioFilterAlertReconciler reconciles a HumioFilterAlert object
 type HumioFilterAlertReconciler struct {
 	client.Client
+	CommonConfig
 	BaseLogger  logr.Logger
 	Log         logr.Logger
 	HumioClient humio.Client
@@ -186,8 +187,8 @@ func (r *HumioFilterAlertReconciler) reconcileHumioFilterAlert(ctx context.Conte
 		)
 	}
 
-	r.Log.Info("done reconciling, will requeue after 15 seconds")
-	return reconcile.Result{RequeueAfter: time.Second * 15}, nil
+	r.Log.Info("done reconciling, will requeue", "requeuePeriod", r.CommonConfig.RequeuePeriod.String())
+	return reconcile.Result{RequeueAfter: r.CommonConfig.RequeuePeriod}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/humioingesttoken_controller.go
+++ b/internal/controller/humioingesttoken_controller.go
@@ -43,6 +43,7 @@ const humioFinalizer = "core.humio.com/finalizer" // TODO: Not only used for ing
 // HumioIngestTokenReconciler reconciles a HumioIngestToken object
 type HumioIngestTokenReconciler struct {
 	client.Client
+	CommonConfig
 	BaseLogger  logr.Logger
 	Log         logr.Logger
 	HumioClient humio.Client
@@ -176,8 +177,8 @@ func (r *HumioIngestTokenReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// A solution could be to add an annotation that includes the "old name" so we can see if it was changed.
 	// A workaround for now is to delete the ingest token CR and create it again.
 
-	r.Log.Info("done reconciling, will requeue after 15 seconds")
-	return reconcile.Result{RequeueAfter: time.Second * 15}, nil
+	r.Log.Info("done reconciling, will requeue", "requeuePeriod", r.CommonConfig.RequeuePeriod.String())
+	return reconcile.Result{RequeueAfter: r.CommonConfig.RequeuePeriod}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/humioparser_controller.go
+++ b/internal/controller/humioparser_controller.go
@@ -40,6 +40,7 @@ import (
 // HumioParserReconciler reconciles a HumioParser object
 type HumioParserReconciler struct {
 	client.Client
+	CommonConfig
 	BaseLogger  logr.Logger
 	Log         logr.Logger
 	HumioClient humio.Client
@@ -168,8 +169,8 @@ func (r *HumioParserReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// A solution could be to add an annotation that includes the "old name" so we can see if it was changed.
 	// A workaround for now is to delete the parser CR and create it again.
 
-	r.Log.Info("done reconciling, will requeue after 15 seconds")
-	return reconcile.Result{RequeueAfter: time.Second * 15}, nil
+	r.Log.Info("done reconciling, will requeue", "requeuePeriod", r.CommonConfig.RequeuePeriod.String())
+	return reconcile.Result{RequeueAfter: r.CommonConfig.RequeuePeriod}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/humiorepository_controller.go
+++ b/internal/controller/humiorepository_controller.go
@@ -39,6 +39,7 @@ import (
 // HumioRepositoryReconciler reconciles a HumioRepository object
 type HumioRepositoryReconciler struct {
 	client.Client
+	CommonConfig
 	BaseLogger  logr.Logger
 	Log         logr.Logger
 	HumioClient humio.Client
@@ -167,8 +168,8 @@ func (r *HumioRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// A solution could be to add an annotation that includes the "old name" so we can see if it was changed.
 	// A workaround for now is to delete the repository CR and create it again.
 
-	r.Log.Info("done reconciling, will requeue after 15 seconds")
-	return reconcile.Result{RequeueAfter: time.Second * 15}, nil
+	r.Log.Info("done reconciling, will requeue", "requeuePeriod", r.CommonConfig.RequeuePeriod.String())
+	return reconcile.Result{RequeueAfter: r.CommonConfig.RequeuePeriod}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/humioscheduledsearch_controller.go
+++ b/internal/controller/humioscheduledsearch_controller.go
@@ -40,6 +40,7 @@ import (
 // HumioScheduledSearchReconciler reconciles a HumioScheduledSearch object
 type HumioScheduledSearchReconciler struct {
 	client.Client
+	CommonConfig
 	BaseLogger  logr.Logger
 	Log         logr.Logger
 	HumioClient humio.Client
@@ -175,8 +176,8 @@ func (r *HumioScheduledSearchReconciler) reconcileHumioScheduledSearch(ctx conte
 		)
 	}
 
-	r.Log.Info("done reconciling, will requeue after 15 seconds")
-	return reconcile.Result{RequeueAfter: time.Second * 15}, nil
+	r.Log.Info("done reconciling, will requeue", "requeuePeriod", r.CommonConfig.RequeuePeriod.String())
+	return reconcile.Result{RequeueAfter: r.CommonConfig.RequeuePeriod}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/humioview_controller.go
+++ b/internal/controller/humioview_controller.go
@@ -40,6 +40,7 @@ import (
 // HumioViewReconciler reconciles a HumioView object
 type HumioViewReconciler struct {
 	client.Client
+	CommonConfig
 	BaseLogger  logr.Logger
 	Log         logr.Logger
 	HumioClient humio.Client
@@ -163,8 +164,8 @@ func (r *HumioViewReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}
 
-	r.Log.Info("done reconciling, will requeue after 15 seconds")
-	return reconcile.Result{RequeueAfter: time.Second * 15}, nil
+	r.Log.Info("done reconciling, will requeue", "requeuePeriod", r.CommonConfig.RequeuePeriod.String())
+	return reconcile.Result{RequeueAfter: r.CommonConfig.RequeuePeriod}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/suite/clusters/suite_test.go
+++ b/internal/controller/suite/clusters/suite_test.go
@@ -80,7 +80,7 @@ var _ = BeforeSuite(func() {
 	defer func(zapLog *uberzap.Logger) {
 		_ = zapLog.Sync()
 	}(zapLog)
-	log = zapr.NewLogger(zapLog)
+	log = zapr.NewLogger(zapLog).WithSink(GinkgoLogr.GetSink())
 	logf.SetLogger(log)
 
 	By("bootstrapping test environment")
@@ -142,8 +142,13 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
+	var requeuePeriod time.Duration
+
 	err = (&controller.HumioClusterReconciler{
-		Client:      k8sManager.GetClient(),
+		Client: k8sManager.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		HumioClient: testHumioClient,
 		BaseLogger:  log,
 		Namespace:   testProcessNamespace,
@@ -151,7 +156,10 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&controller.HumioExternalClusterReconciler{
-		Client:      k8sManager.GetClient(),
+		Client: k8sManager.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		HumioClient: testHumioClient,
 		BaseLogger:  log,
 		Namespace:   testProcessNamespace,

--- a/internal/controller/suite/resources/suite_test.go
+++ b/internal/controller/suite/resources/suite_test.go
@@ -87,7 +87,7 @@ var _ = BeforeSuite(func() {
 	defer func(zapLog *uberzap.Logger) {
 		_ = zapLog.Sync()
 	}(zapLog)
-	log = zapr.NewLogger(zapLog)
+	log = zapr.NewLogger(zapLog).WithSink(GinkgoLogr.GetSink())
 	logf.SetLogger(log)
 
 	By("bootstrapping test environment")
@@ -147,8 +147,13 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
+	requeuePeriod := time.Second * 15
+
 	err = (&controller.HumioActionReconciler{
-		Client:      k8sManager.GetClient(),
+		Client: k8sManager.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		HumioClient: humioClient,
 		BaseLogger:  log,
 		Namespace:   clusterKey.Namespace,
@@ -156,7 +161,10 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&controller.HumioAggregateAlertReconciler{
-		Client:      k8sManager.GetClient(),
+		Client: k8sManager.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		HumioClient: humioClient,
 		BaseLogger:  log,
 		Namespace:   clusterKey.Namespace,
@@ -164,7 +172,10 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&controller.HumioAlertReconciler{
-		Client:      k8sManager.GetClient(),
+		Client: k8sManager.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		HumioClient: humioClient,
 		BaseLogger:  log,
 		Namespace:   clusterKey.Namespace,
@@ -172,14 +183,20 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&controller.HumioBootstrapTokenReconciler{
-		Client:     k8sManager.GetClient(),
+		Client: k8sManager.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		BaseLogger: log,
 		Namespace:  clusterKey.Namespace,
 	}).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&controller.HumioClusterReconciler{
-		Client:      k8sManager.GetClient(),
+		Client: k8sManager.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		HumioClient: humioClient,
 		BaseLogger:  log,
 		Namespace:   clusterKey.Namespace,
@@ -187,7 +204,10 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&controller.HumioExternalClusterReconciler{
-		Client:      k8sManager.GetClient(),
+		Client: k8sManager.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		HumioClient: humioClient,
 		BaseLogger:  log,
 		Namespace:   clusterKey.Namespace,
@@ -195,7 +215,10 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&controller.HumioFilterAlertReconciler{
-		Client:      k8sManager.GetClient(),
+		Client: k8sManager.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		HumioClient: humioClient,
 		BaseLogger:  log,
 		Namespace:   clusterKey.Namespace,
@@ -203,7 +226,10 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&controller.HumioIngestTokenReconciler{
-		Client:      k8sManager.GetClient(),
+		Client: k8sManager.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		HumioClient: humioClient,
 		BaseLogger:  log,
 		Namespace:   clusterKey.Namespace,
@@ -211,7 +237,10 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&controller.HumioParserReconciler{
-		Client:      k8sManager.GetClient(),
+		Client: k8sManager.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		HumioClient: humioClient,
 		BaseLogger:  log,
 		Namespace:   clusterKey.Namespace,
@@ -219,7 +248,10 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&controller.HumioRepositoryReconciler{
-		Client:      k8sManager.GetClient(),
+		Client: k8sManager.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		HumioClient: humioClient,
 		BaseLogger:  log,
 		Namespace:   clusterKey.Namespace,
@@ -227,7 +259,10 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&controller.HumioScheduledSearchReconciler{
-		Client:      k8sManager.GetClient(),
+		Client: k8sManager.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		HumioClient: humioClient,
 		BaseLogger:  log,
 		Namespace:   clusterKey.Namespace,
@@ -235,7 +270,10 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&controller.HumioViewReconciler{
-		Client:      k8sManager.GetClient(),
+		Client: k8sManager.GetClient(),
+		CommonConfig: controller.CommonConfig{
+			RequeuePeriod: requeuePeriod,
+		},
 		HumioClient: humioClient,
 		BaseLogger:  log,
 		Namespace:   clusterKey.Namespace,


### PR DESCRIPTION
This flag allows Logscale cluster operators to configure the default requeue period of the Humio* CRs managed by the humio-operator. In deployments where there are sufficient role restrictions it should be possible to prevent competing changes to Logscale entities via the web interface or other GraphQL clients. Thus the requeue period does not need to be such a short period.

Resolves #956 