### PR TITLE
Cancel in progress "e2e" and "e2e-dummy" workflow executions when PR'…

### DIFF
--- a/.github/workflows/e2e-dummy.yaml
+++ b/.github/workflows/e2e-dummy.yaml
@@ -1,5 +1,12 @@
 on: pull_request
 name: e2e-dummy
+
+# Automatically cancel workflow executions in the same concurrency group.
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs#example-using-concurrency-and-the-default-behavior
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e-dummy:
     name: ${{ matrix.kind-k8s-version }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,5 +1,12 @@
 on: pull_request
 name: e2e
+
+# Automatically cancel workflow executions in the same concurrency group.
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs#example-using-concurrency-and-the-default-behavior
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     name: ${{ matrix.kind-k8s-version }}


### PR DESCRIPTION
…s are updated.

This is to prevent building up a queue as we only need the results of the last execution.