### PR TITLE
1. Adjust Makefile to handle `humioclusters.core.humio.com" is invali…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,16 +144,17 @@ endif
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) apply -f -
+	$(KUSTOMIZE) build config/crd | $(KUBECTL) create -f -
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+deploy: manifests kustomize  ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+	$(MAKE) uninstall ignore-not-found=true
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
+	$(KUSTOMIZE) build config/default | $(KUBECTL) create -f -
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/charts/humio-operator/templates/rbac/roles.yaml
+++ b/charts/humio-operator/templates/rbac/roles.yaml
@@ -112,9 +112,9 @@ rules:
       - humioviewpermissionroles
       - humioviewpermissionroles/finalizers
       - humioviewpermissionroles/status
-      - humiomulticlustersearchview
-      - humiomulticlustersearchview/finalizers
-      - humiomulticlustersearchview/status
+      - humiomulticlustersearchviews
+      - humiomulticlustersearchviews/finalizers
+      - humiomulticlustersearchviews/status
     verbs:
       - create
       - delete


### PR DESCRIPTION
…d: metadata.annotations: Too long: may not be more than 262144 bytes`

2. Update chart rbac resources due to error reported: `User "system:serviceaccount:logging:humio-operator" cannot list resource "humiomulticlustersearchviews" in API group "core.humio.com" at the cluster scope`