### PR TITLE
Small fixes to prep for migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23-alpine AS builder
+FROM golang:1.23.6-alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build -t ${IMG} .
+	docker build -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.

--- a/hack/functions.sh
+++ b/hack/functions.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 declare -r kindest_node_image_multiplatform_amd64_arm64=${E2E_KIND_K8S_VERSION:-kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f}
-declare -r kind_version=0.29.0
+declare -r kind_version=0.30.0
 declare -r go_version=1.23.6
 declare -r helm_version=3.14.4
-declare -r kubectl_version=1.23.3
+declare -r kubectl_version=1.34.0
 declare -r jq_version=1.7.1
 declare -r yq_version=4.45.2
 declare -r default_cert_manager_version=1.12.12
@@ -239,7 +239,7 @@ EOF
 helm_install_cert_manager() {
   $helm get metadata cert-manager && return
 
-  k8s_server_version=$($kubectl version --short=true | grep "Server Version:" | awk '{print $NF}' | sed 's/v//' | cut -d. -f1-2)
+  k8s_server_version=$($kubectl version | grep "Server Version:" | awk '{print $NF}' | sed 's/v//' | cut -d. -f1-2)
   cert_manager_version=v${default_cert_manager_version}
   if [[ ${k8s_server_version} < 1.27 ]] ; then cert_manager_version=v1.11.5 ; fi
   $helm repo add jetstack https://charts.jetstack.io

--- a/hack/run-e2e-using-kind-dummy.sh
+++ b/hack/run-e2e-using-kind-dummy.sh
@@ -26,7 +26,10 @@ if [ ! -x "${docker}" ] ; then
   echo "'docker' is not installed. Install it and rerun the script."
   exit 1
 fi
-$docker login
+
+if [ "${docker_username}" != "none" ] && [ "${docker_password}" != "none" ]; then
+  echo "${docker_password}" | ${docker} login --username "${docker_username}" --password-stdin
+fi
 
 mkdir -p $bin_dir
 

--- a/hack/run-e2e-using-kind.sh
+++ b/hack/run-e2e-using-kind.sh
@@ -28,7 +28,10 @@ if [ ! -x "${docker}" ] ; then
   echo "'docker' is not installed. Install it and rerun the script."
   exit 1
 fi
-$docker login
+
+if [ "${docker_username}" != "none" ] && [ "${docker_password}" != "none" ]; then
+  echo "${docker_password}" | ${docker} login --username "${docker_username}" --password-stdin
+fi
 
 mkdir -p $bin_dir
 

--- a/hack/start-kind.sh
+++ b/hack/start-kind.sh
@@ -26,7 +26,10 @@ if [ ! -x "${docker}" ] ; then
   echo "'docker' is not installed. Install it and rerun the script."
   exit 1
 fi
-$docker login
+
+if [ "${docker_username}" != "none" ] && [ "${docker_password}" != "none" ]; then
+  echo "${docker_password}" | ${docker} login --username "${docker_username}" --password-stdin
+fi
 
 mkdir -p $bin_dir
 

--- a/hack/stop-kind.sh
+++ b/hack/stop-kind.sh
@@ -28,7 +28,10 @@ if [ ! -x "${docker}" ] ; then
   echo "'docker' is not installed. Install it and rerun the script."
   exit 1
 fi
-$docker login
+
+if [ "${docker_username}" != "none" ] && [ "${docker_password}" != "none" ]; then
+  echo "${docker_password}" | ${docker} login --username "${docker_username}" --password-stdin
+fi
 
 mkdir -p $bin_dir
 

--- a/images/helper/Dockerfile
+++ b/images/helper/Dockerfile
@@ -22,4 +22,6 @@ COPY LICENSE /licenses/LICENSE
 COPY --from=builder /app /
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
+USER 1001
+
 ENTRYPOINT ["/app"]

--- a/images/logscale-dummy/Dockerfile
+++ b/images/logscale-dummy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine AS builder
+FROM golang:1.23.6-alpine AS builder
 
 RUN apk add bash
 


### PR DESCRIPTION
- ensure Makefile `docker build` commands have the same format
- update kind / kubectl versions
- run docker login only if dependencies are in place
- ensure same FROM golang:1.23.6-alpine used across