### PR TITLE
Add Karpenter integration via temporary PDBs

### DIFF
--- a/api/v1alpha1/humiocluster_types.go
+++ b/api/v1alpha1/humiocluster_types.go
@@ -289,6 +289,13 @@ type HumioOperatorFeatureFlags struct {
 	// Preview: this feature is in a preview state
 	// +kubebuilder:default=false
 	EnableDownscalingFeature bool `json:"enableDownscalingFeature,omitempty"`
+	// EnableKarpenterIntegration enables dynamic management of temporary PodDisruptionBudgets to prevent
+	// Karpenter from disrupting Humio pods during upgrades and restarts. When enabled, the operator creates
+	// a restrictive PDB (maxUnavailable: 0) for each node pool whenever the cluster is not fully stable,
+	// and deletes it when all node pools are confirmed Running with no pending changes.
+	// Default: false
+	// +kubebuilder:default=false
+	EnableKarpenterIntegration bool `json:"enableKarpenterIntegration,omitempty"`
 }
 
 // HumioNodePoolFeatures is used to toggle certain features that are specific instance of HumioNodeSpec. This means

--- a/charts/humio-operator/crds/core.humio.com_humioclusters.yaml
+++ b/charts/humio-operator/crds/core.humio.com_humioclusters.yaml
@@ -5834,6 +5834,15 @@ spec:
                       Default: false
                       Preview: this feature is in a preview state
                     type: boolean
+                  enableKarpenterIntegration:
+                    default: false
+                    description: |-
+                      EnableKarpenterIntegration enables dynamic management of temporary PodDisruptionBudgets to prevent
+                      Karpenter from disrupting Humio pods during upgrades and restarts. When enabled, the operator creates
+                      a restrictive PDB (maxUnavailable: 0) for each node pool whenever the cluster is not fully stable,
+                      and deletes it when all node pools are confirmed Running with no pending changes.
+                      Default: false
+                    type: boolean
                 type: object
               helperImage:
                 description: HelperImage is the desired helper container image, including

--- a/charts/humio-operator/crds/core.humio.com_humiopackageregistries.yaml
+++ b/charts/humio-operator/crds/core.humio.com_humiopackageregistries.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: 'humio-operator'
     app.kubernetes.io/instance: 'humio-operator'
     app.kubernetes.io/managed-by: 'Helm'
-    helm.sh/chart: 'humio-operator-0.33.0'
+    helm.sh/chart: 'humio-operator-0.0.1'
 spec:
   group: core.humio.com
   names:

--- a/charts/humio-operator/crds/core.humio.com_humiopackages.yaml
+++ b/charts/humio-operator/crds/core.humio.com_humiopackages.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: 'humio-operator'
     app.kubernetes.io/instance: 'humio-operator'
     app.kubernetes.io/managed-by: 'Helm'
-    helm.sh/chart: 'humio-operator-0.33.0'
+    helm.sh/chart: 'humio-operator-0.0.1'
 spec:
   group: core.humio.com
   names:

--- a/config/crd/bases/core.humio.com_humioclusters.yaml
+++ b/config/crd/bases/core.humio.com_humioclusters.yaml
@@ -5834,6 +5834,15 @@ spec:
                       Default: false
                       Preview: this feature is in a preview state
                     type: boolean
+                  enableKarpenterIntegration:
+                    default: false
+                    description: |-
+                      EnableKarpenterIntegration enables dynamic management of temporary PodDisruptionBudgets to prevent
+                      Karpenter from disrupting Humio pods during upgrades and restarts. When enabled, the operator creates
+                      a restrictive PDB (maxUnavailable: 0) for each node pool whenever the cluster is not fully stable,
+                      and deletes it when all node pools are confirmed Running with no pending changes.
+                      Default: false
+                    type: boolean
                 type: object
               helperImage:
                 description: HelperImage is the desired helper container image, including

--- a/config/crd/bases/core.humio.com_humiopackageregistries.yaml
+++ b/config/crd/bases/core.humio.com_humiopackageregistries.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: 'humio-operator'
     app.kubernetes.io/instance: 'humio-operator'
     app.kubernetes.io/managed-by: 'Helm'
-    helm.sh/chart: 'humio-operator-0.33.0'
+    helm.sh/chart: 'humio-operator-0.0.1'
 spec:
   group: core.humio.com
   names:

--- a/config/crd/bases/core.humio.com_humiopackages.yaml
+++ b/config/crd/bases/core.humio.com_humiopackages.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: 'humio-operator'
     app.kubernetes.io/instance: 'humio-operator'
     app.kubernetes.io/managed-by: 'Helm'
-    helm.sh/chart: 'humio-operator-0.33.0'
+    helm.sh/chart: 'humio-operator-0.0.1'
 spec:
   group: core.humio.com
   names:

--- a/internal/controller/humiocluster_controller.go
+++ b/internal/controller/humiocluster_controller.go
@@ -201,6 +201,12 @@ func (r *HumioClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 	}
 
+	// Phase 1: create restrictive PDBs to prevent Karpenter disruptions when cluster is not stable
+	if err := r.reconcileKarpenterPDBsAddOnly(ctx, hc, humioNodePools); err != nil {
+		return r.updateStatus(ctx, r.Status(), hc, statusOptions().
+			withMessage(err.Error()))
+	}
+
 	// ensure pods that does not run the desired version or config gets deleted and update state accordingly
 	for _, pool := range humioNodePools.Items {
 		if r.nodePoolAllowsMaintenanceOperations(hc, pool, humioNodePools.Items) {
@@ -209,6 +215,12 @@ func (r *HumioClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				return result, err
 			}
 		}
+	}
+
+	// Phase 2: delete restrictive PDBs when cluster is stable and all pools confirmed clean
+	if err := r.reconcileKarpenterPDBsRemoveIfStable(ctx, hc, humioNodePools); err != nil {
+		return r.updateStatus(ctx, r.Status(), hc, statusOptions().
+			withMessage(err.Error()))
 	}
 
 	// create various k8s objects, e.g. Issuer, Certificate, ConfigMap, Ingress, Service, ServiceAccount, ClusterRole, ClusterRoleBinding

--- a/internal/controller/humiocluster_karpenter.go
+++ b/internal/controller/humiocluster_karpenter.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2020 Humio https://humio.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	humiov1alpha1 "github.com/humio/humio-operator/api/v1alpha1"
+	"github.com/humio/humio-operator/internal/kubernetes"
+	policyv1 "k8s.io/api/policy/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	karpenterPDBSuffix = "-karpenter-pdb"
+)
+
+func karpenterPDBName(hnp *HumioNodePool) string {
+	return fmt.Sprintf("%s%s", hnp.GetNodePoolName(), karpenterPDBSuffix)
+}
+
+// isClusterStable returns true when the cluster is fully stable: the cluster state is Running
+// and all node pools with nodes are Running.
+func (r *HumioClusterReconciler) isClusterStable(hc *humiov1alpha1.HumioCluster, humioNodePools HumioNodePoolList) bool {
+	if hc.Status.State != humiov1alpha1.HumioClusterStateRunning {
+		return false
+	}
+
+	for _, pool := range humioNodePools.Filter(NodePoolFilterHasNode) {
+		if pool.GetState() != humiov1alpha1.HumioClusterStateRunning {
+			return false
+		}
+	}
+
+	return true
+}
+
+// ensureKarpenterPDBExists creates a restrictive PDB (maxUnavailable: 0) for the given node pool
+// if it does not already exist. This prevents Karpenter from evicting any pod in the pool.
+func (r *HumioClusterReconciler) ensureKarpenterPDBExists(ctx context.Context, hc *humiov1alpha1.HumioCluster, hnp *HumioNodePool) error {
+	pdbName := karpenterPDBName(hnp)
+
+	existingPDB := &policyv1.PodDisruptionBudget{}
+	err := r.Get(ctx, client.ObjectKey{Name: pdbName, Namespace: hc.Namespace}, existingPDB)
+	// if the PDB exists, do nothing
+	if err == nil {
+		return nil
+	}
+	if !k8serrors.IsNotFound(err) {
+		return fmt.Errorf("failed to get karpenter PDB %s/%s: %w", hc.Namespace, pdbName, err)
+	}
+
+	maxUnavailable := intstr.FromInt32(0)
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pdbName,
+			Namespace: hc.Namespace,
+			Labels:    hnp.GetNodePoolLabels(),
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			MaxUnavailable: &maxUnavailable,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: kubernetes.MatchingLabelsForHumioNodePool(hc.Name, hnp.GetNodePoolName()),
+			},
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(hc, pdb, r.Scheme()); err != nil {
+		return fmt.Errorf("failed to set controller reference on karpenter PDB %s: %w", pdbName, err)
+	}
+
+	if err := r.Create(ctx, pdb); err != nil {
+		return fmt.Errorf("failed to create karpenter PDB %s/%s: %w", hc.Namespace, pdbName, err)
+	}
+
+	r.Log.Info(fmt.Sprintf("created karpenter PDB %s to prevent disruptions", pdbName))
+	return nil
+}
+
+// deleteKarpenterPDB deletes the restrictive Karpenter PDB for the given node pool if it exists.
+func (r *HumioClusterReconciler) deleteKarpenterPDB(ctx context.Context, hc *humiov1alpha1.HumioCluster, hnp *HumioNodePool) error {
+	pdbName := karpenterPDBName(hnp)
+
+	existingPDB := &policyv1.PodDisruptionBudget{}
+	err := r.Get(ctx, client.ObjectKey{Name: pdbName, Namespace: hc.Namespace}, existingPDB)
+	if k8serrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get karpenter PDB %s/%s: %w", hc.Namespace, pdbName, err)
+	}
+
+	if err := r.Delete(ctx, existingPDB); err != nil {
+		return fmt.Errorf("failed to delete karpenter PDB %s/%s: %w", hc.Namespace, pdbName, err)
+	}
+
+	r.Log.Info(fmt.Sprintf("deleted karpenter PDB %s, allowing Karpenter consolidation", pdbName))
+	return nil
+}
+
+// reconcileKarpenterPDBsAddOnly is Phase 1: creates restrictive PDBs for all node pools
+// when the cluster is not stable. Never deletes PDBs.
+// If the feature is disabled, this is a no-op.
+func (r *HumioClusterReconciler) reconcileKarpenterPDBsAddOnly(ctx context.Context, hc *humiov1alpha1.HumioCluster, humioNodePools HumioNodePoolList) error {
+	if !hc.Spec.OperatorFeatureFlags.EnableKarpenterIntegration {
+		return nil
+	}
+
+	if r.isClusterStable(hc, humioNodePools) {
+		return nil
+	}
+
+	for _, pool := range humioNodePools.Filter(NodePoolFilterHasNode) {
+		if err := r.ensureKarpenterPDBExists(ctx, hc, pool); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// reconcileKarpenterPDBsRemoveIfStable is Phase 2: deletes restrictive PDBs for all node pools
+// when the cluster is stable. Also handles cleanup when the feature flag is disabled.
+func (r *HumioClusterReconciler) reconcileKarpenterPDBsRemoveIfStable(ctx context.Context, hc *humiov1alpha1.HumioCluster, humioNodePools HumioNodePoolList) error {
+	featureEnabled := hc.Spec.OperatorFeatureFlags.EnableKarpenterIntegration
+
+	if featureEnabled && !r.isClusterStable(hc, humioNodePools) {
+		return nil
+	}
+
+	for _, pool := range humioNodePools.Filter(NodePoolFilterHasNode) {
+		if err := r.deleteKarpenterPDB(ctx, hc, pool); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/controller/humiocluster_karpenter_test.go
+++ b/internal/controller/humiocluster_karpenter_test.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2020 Humio https://humio.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	humiov1alpha1 "github.com/humio/humio-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsClusterStable(t *testing.T) {
+	r := &HumioClusterReconciler{}
+
+	tests := []struct {
+		name           string
+		clusterState   string
+		nodePoolStates []struct {
+			name      string
+			state     string
+			nodeCount int
+		}
+		want bool
+	}{
+		{
+			name:         "all pools Running",
+			clusterState: humiov1alpha1.HumioClusterStateRunning,
+			nodePoolStates: []struct {
+				name      string
+				state     string
+				nodeCount int
+			}{
+				{name: "pool-a", state: humiov1alpha1.HumioClusterStateRunning, nodeCount: 3},
+				{name: "pool-b", state: humiov1alpha1.HumioClusterStateRunning, nodeCount: 3},
+			},
+			want: true,
+		},
+		{
+			name:         "cluster Upgrading",
+			clusterState: humiov1alpha1.HumioClusterStateUpgrading,
+			nodePoolStates: []struct {
+				name      string
+				state     string
+				nodeCount int
+			}{
+				{name: "pool-a", state: humiov1alpha1.HumioClusterStateUpgrading, nodeCount: 3},
+				{name: "pool-b", state: humiov1alpha1.HumioClusterStateRunning, nodeCount: 3},
+			},
+			want: false,
+		},
+		{
+			name:         "cluster Restarting",
+			clusterState: humiov1alpha1.HumioClusterStateRestarting,
+			nodePoolStates: []struct {
+				name      string
+				state     string
+				nodeCount int
+			}{
+				{name: "pool-a", state: humiov1alpha1.HumioClusterStateRestarting, nodeCount: 3},
+				{name: "pool-b", state: humiov1alpha1.HumioClusterStateRunning, nodeCount: 3},
+			},
+			want: false,
+		},
+		{
+			name:         "cluster Running but pool Upgrading",
+			clusterState: humiov1alpha1.HumioClusterStateRunning,
+			nodePoolStates: []struct {
+				name      string
+				state     string
+				nodeCount int
+			}{
+				{name: "pool-a", state: humiov1alpha1.HumioClusterStateRunning, nodeCount: 3},
+				{name: "pool-b", state: humiov1alpha1.HumioClusterStateUpgrading, nodeCount: 3},
+			},
+			want: false,
+		},
+		{
+			name:         "cluster Pending",
+			clusterState: humiov1alpha1.HumioClusterStatePending,
+			nodePoolStates: []struct {
+				name      string
+				state     string
+				nodeCount int
+			}{
+				{name: "pool-a", state: humiov1alpha1.HumioClusterStatePending, nodeCount: 3},
+			},
+			want: false,
+		},
+		{
+			name:         "cluster ConfigError",
+			clusterState: humiov1alpha1.HumioClusterStateConfigError,
+			nodePoolStates: []struct {
+				name      string
+				state     string
+				nodeCount int
+			}{
+				{name: "pool-a", state: humiov1alpha1.HumioClusterStateConfigError, nodeCount: 3},
+			},
+			want: false,
+		},
+		{
+			name:         "single pool Running",
+			clusterState: humiov1alpha1.HumioClusterStateRunning,
+			nodePoolStates: []struct {
+				name      string
+				state     string
+				nodeCount int
+			}{
+				{name: "pool-a", state: humiov1alpha1.HumioClusterStateRunning, nodeCount: 3},
+			},
+			want: true,
+		},
+		{
+			name:         "pool with zero nodes is ignored",
+			clusterState: humiov1alpha1.HumioClusterStateRunning,
+			nodePoolStates: []struct {
+				name      string
+				state     string
+				nodeCount int
+			}{
+				{name: "pool-a", state: humiov1alpha1.HumioClusterStateRunning, nodeCount: 3},
+				{name: "pool-b", state: humiov1alpha1.HumioClusterStateUpgrading, nodeCount: 0},
+			},
+			want: true,
+		},
+		{
+			name:         "empty state is not stable",
+			clusterState: "",
+			nodePoolStates: []struct {
+				name      string
+				state     string
+				nodeCount int
+			}{
+				{name: "pool-a", state: "", nodeCount: 3},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hc := &humiov1alpha1.HumioCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+				Status: humiov1alpha1.HumioClusterStatus{
+					State: tt.clusterState,
+				},
+			}
+
+			var nodePoolList HumioNodePoolList
+			for _, np := range tt.nodePoolStates {
+				pool := &HumioNodePool{
+					clusterName:  "test-cluster",
+					nodePoolName: np.name,
+					namespace:    "default",
+					state:        np.state,
+					humioNodeSpec: humiov1alpha1.HumioNodeSpec{
+						NodeCount: np.nodeCount,
+					},
+				}
+				nodePoolList.Add(pool)
+			}
+
+			got := r.isClusterStable(hc, nodePoolList)
+			if got != tt.want {
+				t.Errorf("isClusterStable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKarpenterPDBName(t *testing.T) {
+	pool := &HumioNodePool{
+		clusterName:  "mycluster",
+		nodePoolName: "ingest",
+		namespace:    "default",
+	}
+
+	got := karpenterPDBName(pool)
+	want := "mycluster-ingest-karpenter-pdb"
+	if got != want {
+		t.Errorf("karpenterPDBName() = %q, want %q", got, want)
+	}
+
+	userPDBName := pool.GetPodDisruptionBudgetName()
+	if got == userPDBName {
+		t.Errorf("karpenter PDB name %q must not collide with user PDB name %q", got, userPDBName)
+	}
+}
+
+func TestKarpenterPDBNameDefaultPool(t *testing.T) {
+	pool := &HumioNodePool{
+		clusterName: "mycluster",
+		namespace:   "default",
+	}
+
+	got := karpenterPDBName(pool)
+	want := "mycluster-karpenter-pdb"
+	if got != want {
+		t.Errorf("karpenterPDBName() for default pool = %q, want %q", got, want)
+	}
+
+	userPDBName := pool.GetPodDisruptionBudgetName()
+	if got == userPDBName {
+		t.Errorf("karpenter PDB name %q must not collide with user PDB name %q", got, userPDBName)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `enableKarpenterIntegration` feature flag to prevent Karpenter from disrupting Humio pods during upgrades and restarts
- When enabled, the operator creates a temporary PDB (maxUnavailable: 0) per node pool whenever the cluster is not fully stable, blocking all voluntary pod evictions
- PDBs are only removed after `ensureMismatchedPodsAreDeleted` confirms all pools have no diffs and the cluster is Running
- Feature is opt-in (default: false), existing users are unaffected

## Background
The operator updates node pools one at a time, blocking pod creation for non-updating pools via `nodePoolAllowsMaintenanceOperations`. If Karpenter terminates a node in a healthy pool during another pool's upgrade, the lost pods cannot be recreated until the upgrade completes. This change prevents that by freezing Karpenter consolidation during sensitive operations.