### PR TITLE
fix(controller): apply maxUnavailable + unhealthyPodEvictionPolicy in constructPDB (#1050)

### DIFF
--- a/internal/controller/humiocluster_controller.go
+++ b/internal/controller/humiocluster_controller.go
@@ -3021,7 +3021,6 @@ func (r *HumioClusterReconciler) constructPDB(hc *humiov1alpha1.HumioCluster, hn
 		MatchLabels: kubernetes.MatchingLabelsForHumioNodePool(hc.Name, hnp.GetNodePoolName()),
 	}
 
-	minAvailable := pdbSpec.MinAvailable
 	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pdbName,
@@ -3038,14 +3037,25 @@ func (r *HumioClusterReconciler) constructPDB(hc *humiov1alpha1.HumioCluster, hn
 		return nil, fmt.Errorf("failed to set controller reference: %w", err)
 	}
 
-	if minAvailable != nil {
-		pdb.Spec.MinAvailable = minAvailable
-	} else {
+	// minAvailable and maxUnavailable are mutually exclusive (enforced by
+	// XValidation on HumioPodDisruptionBudgetSpec). Default to
+	// minAvailable=1 only when neither was specified.
+	switch {
+	case pdbSpec.MinAvailable != nil:
+		pdb.Spec.MinAvailable = pdbSpec.MinAvailable
+	case pdbSpec.MaxUnavailable != nil:
+		pdb.Spec.MaxUnavailable = pdbSpec.MaxUnavailable
+	default:
 		defaultMinAvailable := intstr.IntOrString{
 			Type:   intstr.Int,
 			IntVal: 1,
 		}
 		pdb.Spec.MinAvailable = &defaultMinAvailable
+	}
+
+	if pdbSpec.UnhealthyPodEvictionPolicy != nil {
+		policy := policyv1.UnhealthyPodEvictionPolicyType(*pdbSpec.UnhealthyPodEvictionPolicy)
+		pdb.Spec.UnhealthyPodEvictionPolicy = &policy
 	}
 
 	return pdb, nil


### PR DESCRIPTION
## Summary

Fixes #1050. The CRD spec ``HumioPodDisruptionBudgetSpec`` (``api/v1alpha1/humiocluster_types.go:352``) declares three configurable fields, ``MinAvailable``, ``MaxUnavailable``, ``UnhealthyPodEvictionPolicy``, but ``constructPDB`` only ever read ``MinAvailable``. Any user-set ``maxUnavailable`` or ``unhealthyPodEvictionPolicy`` was silently dropped from the generated ``PodDisruptionBudget``.

## Change

``internal/controller/humiocluster_controller.go:3017`` (``constructPDB``):

- ``MinAvailable`` and ``MaxUnavailable`` are mutually exclusive (already enforced by the ``XValidation`` rule on ``HumioPodDisruptionBudgetSpec``). Switch on which one is set; default to ``MinAvailable=1`` only when neither was specified.
- Map ``UnhealthyPodEvictionPolicy`` (string with ``Enum=IfHealthyBudget;AlwaysAllow``) into the typed ``policyv1.UnhealthyPodEvictionPolicyType`` field on the spec.

```go
switch {
case pdbSpec.MinAvailable != nil:
    pdb.Spec.MinAvailable = pdbSpec.MinAvailable
case pdbSpec.MaxUnavailable != nil:
    pdb.Spec.MaxUnavailable = pdbSpec.MaxUnavailable
default:
    /* default minAvailable=1 */
}

if pdbSpec.UnhealthyPodEvictionPolicy != nil {
    policy := policyv1.UnhealthyPodEvictionPolicyType(*pdbSpec.UnhealthyPodEvictionPolicy)
    pdb.Spec.UnhealthyPodEvictionPolicy = &policy
}
```

## Test plan

- [x] ``go build ./...``, clean
- [x] ``go vet ./...``, clean
- [x] Default behaviour preserved when neither ``MinAvailable`` nor ``MaxUnavailable`` is set (still ``MinAvailable=1``)
- Note: there's no existing unit test for ``constructPDB`` to extend; happy to add one if the maintainers prefer