### PR TITLE
fix: honor ctx cancellation while waiting for bootstrap pod (closes #1055)

### DIFF
--- a/internal/controller/humiobootstraptoken_controller.go
+++ b/internal/controller/humiobootstraptoken_controller.go
@@ -34,6 +34,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -346,24 +347,29 @@ func (r *HumioBootstrapTokenReconciler) ensureBootstrapTokenHashedToken(ctx cont
 		return err
 	}
 
-	var podRunning bool
+	// Wait for the one-shot bootstrap pod to enter Running. We poll once
+	// per second up to waitForPodTimeoutSeconds and honor ctx cancellation
+	// so that operator drain / leader-election handoff / pod eviction
+	// don't get held hostage by this loop. See issue #1055.
 	var foundPod corev1.Pod
-	for i := 0; i < waitForPodTimeoutSeconds; i++ {
-		err := r.Get(ctx, types.NamespacedName{
-			Namespace: pod.Namespace,
-			Name:      pod.Name,
-		}, &foundPod)
-		if err == nil {
-			if foundPod.Status.Phase == corev1.PodRunning {
-				podRunning = true
-				break
+	pollErr := wait.PollUntilContextTimeout(
+		ctx,
+		time.Second,
+		time.Duration(waitForPodTimeoutSeconds)*time.Second,
+		true, // immediate: do the first check before the first sleep
+		func(ctx context.Context) (bool, error) {
+			if err := r.Get(ctx, types.NamespacedName{
+				Namespace: pod.Namespace,
+				Name:      pod.Name,
+			}, &foundPod); err != nil {
+				r.Log.Info("waiting for bootstrap token pod to start")
+				return false, nil
 			}
-		}
-		r.Log.Info("waiting for bootstrap token pod to start")
-		time.Sleep(time.Second * 1)
-	}
-	if !podRunning {
-		return r.logErrorAndReturn(err, "failed to start bootstrap token pod")
+			return foundPod.Status.Phase == corev1.PodRunning, nil
+		},
+	)
+	if pollErr != nil {
+		return r.logErrorAndReturn(pollErr, "failed to start bootstrap token pod")
 	}
 
 	r.Log.Info("execing onetime pod")

--- a/internal/controller/humiobootstraptoken_controller.go
+++ b/internal/controller/humiobootstraptoken_controller.go
@@ -209,6 +209,38 @@ func (r *HumioBootstrapTokenReconciler) execCommand(ctx context.Context, pod *co
 	return stdout.String(), nil
 }
 
+// waitForBootstrapPodRunning polls once per second up to timeoutSeconds for
+// the given pod to reach PodRunning. It honors ctx cancellation so operator
+// drain / leader-election handoff / pod eviction don't get held hostage by
+// this loop. Transient Get errors are logged but don't fail the poll, so a
+// briefly-missing pod (e.g. between Create returning and the API caching it)
+// is tolerated. Persistent errors (e.g. RBAC) surface in the operator log
+// stream rather than getting masked behind the generic poll timeout.
+func (r *HumioBootstrapTokenReconciler) waitForBootstrapPodRunning(ctx context.Context, pod *corev1.Pod, timeoutSeconds int) (*corev1.Pod, error) {
+	foundPod := &corev1.Pod{}
+	pollErr := wait.PollUntilContextTimeout(
+		ctx,
+		time.Second,
+		time.Duration(timeoutSeconds)*time.Second,
+		true, // immediate: do the first check before the first sleep
+		func(ctx context.Context) (bool, error) {
+			r.Log.Info("waiting for bootstrap token pod to start")
+			if err := r.Get(ctx, types.NamespacedName{
+				Namespace: pod.Namespace,
+				Name:      pod.Name,
+			}, foundPod); err != nil {
+				r.Log.Info("transient error fetching bootstrap token pod", "error", err.Error())
+				return false, nil
+			}
+			return foundPod.Status.Phase == corev1.PodRunning, nil
+		},
+	)
+	if pollErr != nil {
+		return nil, pollErr
+	}
+	return foundPod, nil
+}
+
 func (r *HumioBootstrapTokenReconciler) createPod(ctx context.Context, hbt *humiov1alpha1.HumioBootstrapToken) (*corev1.Pod, error) {
 	existingPod := &corev1.Pod{}
 	humioCluster := &humiov1alpha1.HumioCluster{}
@@ -347,33 +379,14 @@ func (r *HumioBootstrapTokenReconciler) ensureBootstrapTokenHashedToken(ctx cont
 		return err
 	}
 
-	// Wait for the one-shot bootstrap pod to enter Running. We poll once
-	// per second up to waitForPodTimeoutSeconds and honor ctx cancellation
-	// so that operator drain / leader-election handoff / pod eviction
-	// don't get held hostage by this loop. See issue #1055.
-	var foundPod corev1.Pod
-	pollErr := wait.PollUntilContextTimeout(
-		ctx,
-		time.Second,
-		time.Duration(waitForPodTimeoutSeconds)*time.Second,
-		true, // immediate: do the first check before the first sleep
-		func(ctx context.Context) (bool, error) {
-			if err := r.Get(ctx, types.NamespacedName{
-				Namespace: pod.Namespace,
-				Name:      pod.Name,
-			}, &foundPod); err != nil {
-				r.Log.Info("waiting for bootstrap token pod to start")
-				return false, nil
-			}
-			return foundPod.Status.Phase == corev1.PodRunning, nil
-		},
-	)
+	// Wait for the one-shot bootstrap pod to enter Running. See issue #1055.
+	foundPod, pollErr := r.waitForBootstrapPodRunning(ctx, pod, waitForPodTimeoutSeconds)
 	if pollErr != nil {
 		return r.logErrorAndReturn(pollErr, "failed to start bootstrap token pod")
 	}
 
 	r.Log.Info("execing onetime pod")
-	output, err := r.execCommand(ctx, &foundPod, commandArgs)
+	output, err := r.execCommand(ctx, foundPod, commandArgs)
 	if err != nil {
 		return r.logErrorAndReturn(err, "failed to exec pod")
 	}

--- a/internal/controller/humiobootstraptoken_controller_test.go
+++ b/internal/controller/humiobootstraptoken_controller_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2020 Humio https://humio.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// Tests for waitForBootstrapPodRunning — the loop replaced in issue #1055.
+// The original loop was a fixed-iteration time.Sleep that ignored ctx, so
+// these tests cover the new contract: (1) returns the pod when it reaches
+// Running, (2) respects ctx cancellation promptly, (3) returns a timeout
+// error rather than hanging forever when the pod never starts.
+
+func newBootstrapPodReconciler(initial ...*corev1.Pod) *HumioBootstrapTokenReconciler {
+	builder := fake.NewClientBuilder()
+	for _, p := range initial {
+		builder = builder.WithObjects(p)
+	}
+	return &HumioBootstrapTokenReconciler{
+		Client: builder.Build(),
+		Log:    logr.Discard(),
+	}
+}
+
+func bootstrapPod(phase corev1.PodPhase) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "humio-bootstrap-pod",
+			Namespace: "default",
+		},
+		Status: corev1.PodStatus{Phase: phase},
+	}
+}
+
+func TestWaitForBootstrapPodRunning_ReturnsPodWhenAlreadyRunning(t *testing.T) {
+	pod := bootstrapPod(corev1.PodRunning)
+	r := newBootstrapPodReconciler(pod)
+
+	start := time.Now()
+	got, err := r.waitForBootstrapPodRunning(context.Background(), pod, 5)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got == nil || got.Name != pod.Name {
+		t.Fatalf("expected pod %q, got %+v", pod.Name, got)
+	}
+	// With `immediate: true`, the first check fires before the first sleep,
+	// so a pod already in Running should return well under one full poll
+	// interval (1s).
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("expected immediate return, took %v", elapsed)
+	}
+}
+
+func TestWaitForBootstrapPodRunning_RespectsContextCancellation(t *testing.T) {
+	// Pod exists but is stuck in Pending — without ctx-honoring poll,
+	// this would block the full timeout (5s).
+	pod := bootstrapPod(corev1.PodPending)
+	r := newBootstrapPodReconciler(pod)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel partway through, well before the timeout would fire.
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	got, err := r.waitForBootstrapPodRunning(ctx, pod, 30)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected context error, got nil")
+	}
+	if got != nil {
+		t.Fatalf("expected nil pod on cancellation, got %+v", got)
+	}
+	// Should return promptly after cancel — generous bound for CI noise,
+	// but well under the 30s timeout the pre-#1055 code would have waited.
+	if elapsed > 3*time.Second {
+		t.Fatalf("ctx cancellation should return promptly, took %v", elapsed)
+	}
+}
+
+func TestWaitForBootstrapPodRunning_TimesOutWhenPodMissing(t *testing.T) {
+	// No pod created in the fake client — every Get returns NotFound.
+	// The poll should tolerate the Get error (the comment in production
+	// says transient Get errors don't fail the poll) and time out cleanly.
+	r := newBootstrapPodReconciler()
+	missing := bootstrapPod(corev1.PodPending)
+
+	start := time.Now()
+	got, err := r.waitForBootstrapPodRunning(context.Background(), missing, 2)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if got != nil {
+		t.Fatalf("expected nil pod on timeout, got %+v", got)
+	}
+	// 2s timeout + a bit of jitter — should not blow past 5s.
+	if elapsed > 5*time.Second {
+		t.Fatalf("timeout should fire near the configured bound, took %v", elapsed)
+	}
+}


### PR DESCRIPTION
Closes #1055.

`ensureBootstrapTokenHashedToken` polled pod status with a `time.Sleep(time.Second * 1)` inside a for-loop, which doesn't respect `ctx.Done()`. Operator drain, leader-election handoff, and pod eviction would all have to wait out the full `waitForPodTimeoutSeconds` (default 10s) per outstanding bootstrap, with the additional risk of orphaning the one-shot bootstrap pod if the operator was killed after the graceful timeout.

## Change

Replaced the manual for-loop with `wait.PollUntilContextTimeout` from `k8s.io/apimachinery/pkg/util/wait`. Same poll cadence (1 second), same total timeout (`waitForPodTimeoutSeconds`), and the function check returns `true` on `PodRunning` to break out. The new call wires `ctx`-cancel and timeout into a single primitive.

## Diff shape

- Imports: add `"k8s.io/apimachinery/pkg/util/wait"`
- Function body: ~16 lines of manual polling replaced with ~16 lines of `PollUntilContextTimeout` invocation. Net no real growth.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Pod becomes Running within 10s | returns nil, function continues | identical |
| Pod never becomes Running | sleeps full 10s, returns wrapped error | identical (returns `context deadline exceeded` wrapped) |
| ctx cancelled mid-poll | continues sleeping until next iteration check | returns immediately with ctx.Err() |
| ctx cancelled mid-Get | r.Get returns ctx error, but loop re-enters sleep | returns immediately |

## Test plan

- [x] `go vet ./internal/controller/...` clean
- [x] `go build ./internal/controller/...` clean
- [ ] Existing e2e suite still passes (bootstrap-token cluster-creation paths)
- [ ] Manual: ctrl+C the operator during a HumioCluster reconcile that's mid-bootstrap, confirm graceful shutdown is prompt

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/