### PR TITLE
fix(security): default RunAsGroup and FSGroup to non-root GID 65534 (closes #1054)

### DIFF
--- a/internal/controller/humiocluster_defaults.go
+++ b/internal/controller/humiocluster_defaults.go
@@ -724,13 +724,20 @@ func (hnp *HumioNodePool) GetContainerStartupProbe() *corev1.Probe {
 	return hnp.humioNodeSpec.ContainerStartupProbe
 }
 
+// nonRootGroupID is the GID used for default RunAsGroup and FSGroup. Matches
+// the `nogroup` GID on Debian/Alpine images and pairs with the existing
+// UID 65534 default. Replaces a previous default of 0 (root group), which
+// would group-own the pod's volumes and processes as root and was flagged
+// as a privilege seam (see issue #1054).
+const nonRootGroupID = int64(65534)
+
 func (hnp *HumioNodePool) GetPodSecurityContext() *corev1.PodSecurityContext {
 	if hnp.humioNodeSpec.PodSecurityContext == nil {
 		return &corev1.PodSecurityContext{
 			RunAsUser:    helpers.Int64Ptr(65534),
 			RunAsNonRoot: helpers.BoolPtr(true),
-			RunAsGroup:   helpers.Int64Ptr(0), // TODO: We probably want to move away from this.
-			FSGroup:      helpers.Int64Ptr(0), // TODO: We probably want to move away from this.
+			RunAsGroup:   helpers.Int64Ptr(nonRootGroupID),
+			FSGroup:      helpers.Int64Ptr(nonRootGroupID),
 		}
 	}
 	return hnp.humioNodeSpec.PodSecurityContext

--- a/internal/controller/humiocluster_defaults.go
+++ b/internal/controller/humiocluster_defaults.go
@@ -724,17 +724,24 @@ func (hnp *HumioNodePool) GetContainerStartupProbe() *corev1.Probe {
 	return hnp.humioNodeSpec.ContainerStartupProbe
 }
 
-// nonRootGroupID is the GID used for default RunAsGroup and FSGroup. Matches
-// the `nogroup` GID on Debian/Alpine images and pairs with the existing
-// UID 65534 default. Replaces a previous default of 0 (root group), which
-// would group-own the pod's volumes and processes as root and was flagged
-// as a privilege seam (see issue #1054).
-const nonRootGroupID = int64(65534)
+// nonRootUserID and nonRootGroupID are the UID/GID used for the default
+// PodSecurityContext (and existing ContainerSecurityContext) when the cluster
+// spec doesn't override them. 65534 is the conventional unprivileged
+// nobody/nogroup ID across most distros — it matches the UID 65534 default
+// already in GetContainerSecurityContext above (see line 519). Replaces a
+// previous GID default of 0 (root group), which would group-own the pod's
+// volumes and processes as root and was flagged as a privilege seam (see
+// issue #1054). Operators whose Humio image expects a different UID/GID
+// can still override via humioNodeSpec.PodSecurityContext.
+const (
+	nonRootUserID  = int64(65534)
+	nonRootGroupID = int64(65534)
+)
 
 func (hnp *HumioNodePool) GetPodSecurityContext() *corev1.PodSecurityContext {
 	if hnp.humioNodeSpec.PodSecurityContext == nil {
 		return &corev1.PodSecurityContext{
-			RunAsUser:    helpers.Int64Ptr(65534),
+			RunAsUser:    helpers.Int64Ptr(nonRootUserID),
 			RunAsNonRoot: helpers.BoolPtr(true),
 			RunAsGroup:   helpers.Int64Ptr(nonRootGroupID),
 			FSGroup:      helpers.Int64Ptr(nonRootGroupID),

--- a/internal/controller/humiocluster_defaults_test.go
+++ b/internal/controller/humiocluster_defaults_test.go
@@ -621,3 +621,61 @@ func Test_constructContainerArgs(t *testing.T) {
 		})
 	}
 }
+
+// Pins the default PodSecurityContext values introduced in issue #1054.
+// If a future refactor silently regresses RunAsGroup or FSGroup back to 0
+// (the root group), this test fails — without it the regression would only
+// surface in e2e.
+func Test_GetPodSecurityContext_DefaultsAreNonRoot(t *testing.T) {
+	hc := &humiov1alpha1.HumioCluster{}
+	hnp := NewHumioNodeManagerFromHumioCluster(hc)
+
+	got := hnp.GetPodSecurityContext()
+
+	if got == nil {
+		t.Fatal("expected non-nil default PodSecurityContext")
+	}
+	if got.RunAsNonRoot == nil || *got.RunAsNonRoot != true {
+		t.Errorf("RunAsNonRoot: want true, got %v", got.RunAsNonRoot)
+	}
+	if got.RunAsUser == nil || *got.RunAsUser != nonRootUserID {
+		t.Errorf("RunAsUser: want %d, got %v", nonRootUserID, got.RunAsUser)
+	}
+	if got.RunAsGroup == nil || *got.RunAsGroup != nonRootGroupID {
+		t.Errorf("RunAsGroup: want %d (non-root), got %v", nonRootGroupID, got.RunAsGroup)
+	}
+	if got.FSGroup == nil || *got.FSGroup != nonRootGroupID {
+		t.Errorf("FSGroup: want %d (non-root), got %v", nonRootGroupID, got.FSGroup)
+	}
+	// Guard against either default regressing to 0 (root).
+	if got.RunAsGroup != nil && *got.RunAsGroup == 0 {
+		t.Error("RunAsGroup defaulted to 0 (root group) — regression of issue #1054")
+	}
+	if got.FSGroup != nil && *got.FSGroup == 0 {
+		t.Error("FSGroup defaulted to 0 (root group) — regression of issue #1054")
+	}
+}
+
+// User-provided PodSecurityContext must pass through unmodified — the
+// non-root defaults only apply when the cluster spec leaves it nil.
+func Test_GetPodSecurityContext_RespectsUserOverride(t *testing.T) {
+	custom := &corev1.PodSecurityContext{
+		RunAsUser:  helpers.Int64Ptr(1000),
+		RunAsGroup: helpers.Int64Ptr(2000),
+		FSGroup:    helpers.Int64Ptr(3000),
+	}
+	hc := &humiov1alpha1.HumioCluster{
+		Spec: humiov1alpha1.HumioClusterSpec{
+			HumioNodeSpec: humiov1alpha1.HumioNodeSpec{
+				PodSecurityContext: custom,
+			},
+		},
+	}
+	hnp := NewHumioNodeManagerFromHumioCluster(hc)
+
+	got := hnp.GetPodSecurityContext()
+
+	if got != custom {
+		t.Fatalf("user override should pass through by reference; got different pointer")
+	}
+}


### PR DESCRIPTION
Closes #1054.

The HumioNodePool's default `PodSecurityContext` used GID `0` (root) for both `RunAsGroup` and `FSGroup` despite running as non-root UID `65534`. Both lines carried `// TODO: We probably want to move away from this.` This PR removes the TODOs and the privilege seam.

## Change

`internal/controller/humiocluster_defaults.go`:

```diff
+const nonRootGroupID = int64(65534)
+
 func (hnp *HumioNodePool) GetPodSecurityContext() *corev1.PodSecurityContext {
     if hnp.humioNodeSpec.PodSecurityContext == nil {
         return &corev1.PodSecurityContext{
             RunAsUser:    helpers.Int64Ptr(65534),
             RunAsNonRoot: helpers.BoolPtr(true),
-            RunAsGroup:   helpers.Int64Ptr(0), // TODO: We probably want to move away from this.
-            FSGroup:      helpers.Int64Ptr(0), // TODO: We probably want to move away from this.
+            RunAsGroup:   helpers.Int64Ptr(nonRootGroupID),
+            FSGroup:      helpers.Int64Ptr(nonRootGroupID),
         }
     }
     return hnp.humioNodeSpec.PodSecurityContext
 }
```

## Effect

| | Before | After |
|---|---|---|
| File ownership of writes by Humio pod | `65534:root` | `65534:65534` |
| Volume mount group ownership (kubelet FSGroup chown) | `root` (group 0) | `65534` |
| Sibling pod running as root group can read Humio's persistent data | yes | no |

## Backward compatibility

- **Default-only change.** Any CR that sets `spec.podSecurityContext` explicitly is untouched.
- **Existing clusters get a one-time recursive chown** on first rolling restart after this lands (standard `FSGroup` semantics). On large data volumes this takes time and should be in the release notes.
- **The Humio container image must have its data directories group-writable by GID 65534.** I have *not* verified the image side; if the upstream image expects the root group, the image's Dockerfile needs a `chgrp -R 65534 /data` (or equivalent path) to match. Deferring to maintainers on whether the image is already compatible or needs a parallel patch.

## Test plan

- [x] `go build ./internal/controller/...`  clean
- [x] `go vet ./internal/controller/...`  clean
- [x] Existing `internal/controller/suite/clusters/humiocluster_controller_test.go:2972` continues to pass — it compares `pod.Spec.SecurityContext` against `GetPodSecurityContext()` itself, so both sides of the equality update consistently.
- [ ] Deploy with default `PodSecurityContext` (unset in CR) on an existing cluster, confirm rolling restart succeeds and data is readable by the Humio process.
- [ ] Confirm `kubectl exec <pod> -- id` reports `gid=65534(nogroup)` rather than `gid=0(root)`.
- [ ] Confirm `kubectl exec <pod> -- ls -ld /data` (or wherever the persistent mount lives) shows GID 65534.

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/