### PR TITLE
fix(controller): consolidate three deferred status updates into one terminal write (incremental: #1056)

### DIFF
--- a/internal/controller/humiocluster_controller.go
+++ b/internal/controller/humiocluster_controller.go
@@ -141,6 +141,17 @@ func (r *HumioClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// See issue #1056 for the broader refactor — this PR is the deferred-
 	// path piece; inline early-return updates inside the reconcile body
 	// are left untouched to keep the diff reviewable.
+	//
+	// TODO(#1056): the inline r.updateStatus(...) calls scattered through
+	// this function still each issue their own Status().Update(). Those
+	// are the next chunk of the refactor — fold them into finalStatus too
+	// (or replace early returns with state transitions on finalStatus) so
+	// that a single reconcile pass emits exactly one status write.
+	//
+	// The closure-mutation pattern below relies on Go's defer execution
+	// being sequential (not goroutined), and on statusOptions/.withX
+	// returning the same builder pointer so the reassignments are
+	// effectively no-ops. Don't extract these defers into goroutines.
 	finalStatus := statusOptions()
 	defer func(ctx context.Context, hc *humiov1alpha1.HumioCluster) {
 		_, _ = r.updateStatus(ctx, r.Status(), hc, finalStatus.

--- a/internal/controller/humiocluster_controller.go
+++ b/internal/controller/humiocluster_controller.go
@@ -132,14 +132,18 @@ func (r *HumioClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	humioNodePools := getHumioNodePoolManagers(hc)
 	emptyResult := reconcile.Result{}
 
-	// update status with observed generation
-	// TODO: Look into refactoring of the use of "defer func's" to update HumioCluster.Status.
-	//       Right now we use StatusWriter to update the status multiple times, and rely on RetryOnConflict to retry
-	//       on conflicts which they'll be on many of the status updates.
-	//       We should be able to bundle all the options together and do a single update using StatusWriter.
-	//       Bundling options in a single StatusWriter.Update() should help reduce the number of conflicts.
+	// Bundle the terminal Status update into a single Status().Update() call
+	// at the end of Reconcile, so we make one apiserver write rather than
+	// three racing updates each guarded by RetryOnConflict. The downstream
+	// defers (pods/nodeCount, version) mutate this shared builder instead
+	// of calling updateStatus directly; this defer is set up FIRST so it
+	// runs LAST in the LIFO defer chain and sees all the accumulated opts.
+	// See issue #1056 for the broader refactor — this PR is the deferred-
+	// path piece; inline early-return updates inside the reconcile body
+	// are left untouched to keep the diff reviewable.
+	finalStatus := statusOptions()
 	defer func(ctx context.Context, hc *humiov1alpha1.HumioCluster) {
-		_, _ = r.updateStatus(ctx, r.Status(), hc, statusOptions().
+		_, _ = r.updateStatus(ctx, r.Status(), hc, finalStatus.
 			withObservedGeneration(hc.GetGeneration()))
 	}(ctx, hc)
 
@@ -175,16 +179,14 @@ func (r *HumioClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return result, err
 	}
 
-	// update status with pods and nodeCount based on podStatusList
+	// Mutate the shared finalStatus builder with pods/nodeCount; the
+	// terminal defer above will emit the single Status().Update().
 	defer func(ctx context.Context, hc *humiov1alpha1.HumioCluster) {
-		opts := statusOptions()
 		podStatusList, err := r.getPodStatusList(ctx, hc, humioNodePools.Filter(NodePoolFilterHasNode))
 		if err != nil {
 			r.Log.Error(err, "unable to get pod status list")
 		}
-		_, _ = r.updateStatus(ctx, r.Status(), hc, opts.
-			withPods(podStatusList).
-			withNodeCount(len(podStatusList)))
+		finalStatus = finalStatus.withPods(podStatusList).withNodeCount(len(podStatusList))
 	}(ctx, hc)
 
 	// remove unused node pool status entries
@@ -332,17 +334,18 @@ func (r *HumioClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 	humioHttpClient := r.HumioClient.GetHumioHttpClient(cluster.Config(), req)
 
-	// update status with version
+	// Mutate the shared finalStatus builder with version when Running; the
+	// terminal defer above will emit the single Status().Update().
 	defer func(ctx context.Context, humioClient humio.Client, hc *humiov1alpha1.HumioCluster) {
-		opts := statusOptions()
-		if hc.Status.State == humiov1alpha1.HumioClusterStateRunning {
-			status, err := humioClient.Status(ctx, humioHttpClient)
-			if err != nil {
-				r.Log.Error(err, "unable to get cluster status")
-				return
-			}
-			_, _ = r.updateStatus(ctx, r.Status(), hc, opts.withVersion(status.Version))
+		if hc.Status.State != humiov1alpha1.HumioClusterStateRunning {
+			return
 		}
+		status, err := humioClient.Status(ctx, humioHttpClient)
+		if err != nil {
+			r.Log.Error(err, "unable to get cluster status")
+			return
+		}
+		finalStatus = finalStatus.withVersion(status.Version)
 	}(ctx, r.HumioClient, hc)
 
 	// downscale cluster if needed

--- a/internal/controller/humiocluster_status_test.go
+++ b/internal/controller/humiocluster_status_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2020 Humio https://humio.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	humiov1alpha1 "github.com/humio/humio-operator/api/v1alpha1"
+)
+
+// Tests for the shared-builder mutation pattern introduced for issue #1056.
+// Reconcile sets up a single `finalStatus := statusOptions()` and then three
+// defers either mutate it via withX() or read it for the terminal Update.
+// These tests pin the two invariants the pattern relies on:
+//
+//   1. withX() must return the same builder pointer (so the closure
+//      reassignment `finalStatus = finalStatus.withX(...)` is effectively
+//      a no-op and doesn't desync the outer variable from the in-place
+//      mutation).
+//   2. Sequential withX() calls on one builder accumulate all options,
+//      so a single terminal Update() emits the union of every mutation.
+
+func TestStatusOptionsBuilder_WithReturnsSameBuilder(t *testing.T) {
+	// PR #1059's defers do `finalStatus = finalStatus.withX(...)`. That
+	// reassignment is safe only if withX returns the same pointer. If a
+	// future refactor switched to value receivers or returned a copy, the
+	// in-place mutation from one defer wouldn't be visible to the next.
+	b := statusOptions()
+	if got := b.withVersion("v1"); got != b {
+		t.Errorf("withVersion: expected same pointer, got different (%p vs %p)", got, b)
+	}
+	if got := b.withNodeCount(3); got != b {
+		t.Errorf("withNodeCount: expected same pointer, got different (%p vs %p)", got, b)
+	}
+	if got := b.withObservedGeneration(7); got != b {
+		t.Errorf("withObservedGeneration: expected same pointer, got different (%p vs %p)", got, b)
+	}
+	if got := b.withPods(humiov1alpha1.HumioPodStatusList{}); got != b {
+		t.Errorf("withPods: expected same pointer, got different (%p vs %p)", got, b)
+	}
+}
+
+func TestStatusOptionsBuilder_AccumulatesAcrossMutations(t *testing.T) {
+	// Simulate the PR #1059 deferred chain: three independent closures
+	// each call withX on the same shared builder. The terminal "update"
+	// reads the accumulated options exactly once. Before the refactor
+	// each defer constructed its own builder and emitted its own
+	// Status().Update() — three writes. After, the shared builder must
+	// contain all the options from all three defers.
+	shared := statusOptions()
+
+	// Defer 1 (registered first, runs last in LIFO order) — terminal,
+	// adds observedGeneration:
+	deferTerminal := func() {
+		shared = shared.withObservedGeneration(42)
+	}
+	// Defer 2 — pods/nodeCount:
+	deferPods := func() {
+		shared = shared.withPods(humiov1alpha1.HumioPodStatusList{}).withNodeCount(5)
+	}
+	// Defer 3 — version (only when Running, but for the unit test we
+	// always run it):
+	deferVersion := func() {
+		shared = shared.withVersion("1.2.3")
+	}
+
+	// LIFO execution order — last registered runs first.
+	deferVersion()
+	deferPods()
+	deferTerminal()
+
+	got := shared.Get()
+	// 4 options: version + pods + nodeCount + observedGeneration.
+	if len(got) != 4 {
+		t.Fatalf("expected 4 accumulated options, got %d", len(got))
+	}
+
+	// Spot-check the option types are present. Order doesn't matter for
+	// the Apply phase — each Option just mutates a distinct field on the
+	// HumioCluster status.
+	sawVersion, sawPods, sawNodeCount, sawObservedGen := false, false, false, false
+	for _, opt := range got {
+		switch opt.(type) {
+		case versionOption:
+			sawVersion = true
+		case podsOption:
+			sawPods = true
+		case nodeCountOption:
+			sawNodeCount = true
+		case observedGenerationOption:
+			sawObservedGen = true
+		}
+	}
+	if !sawVersion {
+		t.Error("missing versionOption — defer chain didn't accumulate version")
+	}
+	if !sawPods {
+		t.Error("missing podsOption — defer chain didn't accumulate pods")
+	}
+	if !sawNodeCount {
+		t.Error("missing nodeCountOption — defer chain didn't accumulate nodeCount")
+	}
+	if !sawObservedGen {
+		t.Error("missing observedGenerationOption — defer chain didn't accumulate observed generation")
+	}
+}
+
+// Belt-and-suspenders: the terminal defer applies every accumulated option
+// to the cluster status in a single Apply pass. This test confirms that
+// after accumulating across the simulated deferred chain, every field
+// lands on hc.Status — which is what the single terminal Status().Update()
+// will ultimately write.
+func TestStatusOptionsBuilder_AppliesAllFieldsInOnePass(t *testing.T) {
+	hc := &humiov1alpha1.HumioCluster{}
+
+	shared := statusOptions().
+		withVersion("9.9.9").
+		withNodeCount(11).
+		withObservedGeneration(99)
+
+	for _, opt := range shared.Get() {
+		opt.Apply(hc)
+	}
+
+	if hc.Status.Version != "9.9.9" {
+		t.Errorf("Version: want 9.9.9, got %q", hc.Status.Version)
+	}
+	if hc.Status.NodeCount != 11 {
+		t.Errorf("NodeCount: want 11, got %d", hc.Status.NodeCount)
+	}
+	if hc.Status.ObservedGeneration != "99" {
+		// ObservedGeneration is rendered as a string in HumioClusterStatus.
+		// If this changes upstream, update the assertion.
+		t.Errorf("ObservedGeneration: want %q, got %q", "99", hc.Status.ObservedGeneration)
+	}
+}


### PR DESCRIPTION
Closes #1056 (incremental — see "What's not in this PR" below).

The maintainer's TODO at the top of `Reconcile` documented the problem (three deferred `StatusWriter.Update()` calls per reconcile, racing each other through `RetryOnConflict`) and proposed the bundled-options fix. This PR ships the deferred-path piece. Inline early-return updates are left for follow-up so the diff stays reviewable.

## Change

`internal/controller/humiocluster_controller.go`:

- Introduce `finalStatus := statusOptions()` near the top of `Reconcile`.
- The existing observedGeneration `defer` becomes the **terminal** defer — it adds observedGeneration to `finalStatus` and emits one `r.updateStatus(...)`. It's set up first, so it runs last in the LIFO defer chain after the other two defers have populated `finalStatus`.
- The pods/nodeCount `defer` and the version `defer` no longer call `updateStatus` — they mutate `finalStatus` via `.withPods`/`.withNodeCount`/`.withVersion`.

**Net write count from the deferred chain: 3 → 1.**

## Why this is safe to land standalone

| Concern | Why it's fine here |
|---|---|
| Builder chaining returns same pointer | Verified: `withVersion`, `withPods`, `withNodeCount`, `withObservedGeneration` all `return o` (pointer-receiver methods on `*optionBuilder`). `finalStatus = finalStatus.withX(...)` is equivalent to in-place mutation. |
| LIFO defer order | The terminal defer is set up before the other two, so version and pods/nodeCount defers run first (mutating `finalStatus`), then the terminal defer runs and emits the single write. |
| Test expectations | No existing unit test asserts the *count* of `Status().Update()` calls — they assert the resulting CR Status content, which is unchanged. |
| User-visible behavior | Identical final Status (same observedGeneration, pods, nodeCount, version). |

## What's NOT in this PR

The ~20 inline `r.updateStatus(...)` calls inside the reconcile body — early-return branches and intermediate-state writes — are untouched. Each needs individual review of merge semantics against the surrounding code path, which is a larger conversation worth having in #1056 with maintainer eyes on each one. This PR is the cleanest first step that doesn't require reasoning about every reconcile branch in one go.

## Test plan

- [x] `go build ./internal/controller/...` clean
- [x] `go vet ./internal/controller/...` clean
- [ ] Existing e2e suite passes (no behavior change on the happy path)
- [ ] Sample reconcile under controller-runtime trace logs shows 1 Status PUT instead of 3 for the terminal-update sequence

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/
