### PR TITLE
fix(controller): honor ctx in three remaining pod-wait loops (closes #1060)

### DIFF
--- a/internal/controller/humiocluster_controller.go
+++ b/internal/controller/humiocluster_controller.go
@@ -44,6 +44,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -2485,27 +2486,46 @@ func (r *HumioClusterReconciler) checkEvictionStatusForPodUsingClusterRefresh(ct
 }
 
 func (r *HumioClusterReconciler) checkEvictionStatusForPod(ctx context.Context, humioHttpClient *humioapi.Client, vhost int) (bool, error) {
-	for i := 0; i < waitForPodTimeoutSeconds; i++ {
-		nodesStatus, err := r.getClusterNodesStatus(ctx, humioHttpClient)
-		if err != nil {
-			return false, r.logErrorAndReturn(err, "could not get cluster nodes status.")
-		}
-		for _, node := range nodesStatus {
-			if node.GetId() == vhost {
-				reasonsNodeCannotBeSafelyUnregistered := node.GetReasonsNodeCannotBeSafelyUnregistered()
-				if !reasonsNodeCannotBeSafelyUnregistered.GetHasDataThatExistsOnlyOnThisNode() &&
-					!reasonsNodeCannotBeSafelyUnregistered.GetHasUnderReplicatedData() &&
-					!reasonsNodeCannotBeSafelyUnregistered.GetLeadsDigest() {
-					// if cheap check is ok, run a cache refresh check
-					if ok, _ := r.checkEvictionStatusForPodUsingClusterRefresh(ctx, humioHttpClient, vhost); ok {
-						return true, nil
+	// See issue #1060: poll honors ctx so operator drain / leader-election
+	// handoff / pod eviction don't get held hostage by this loop.
+	var safelyEvictable bool
+	pollErr := wait.PollUntilContextTimeout(
+		ctx,
+		time.Second,
+		time.Duration(waitForPodTimeoutSeconds)*time.Second,
+		true, // immediate: do the first check before the first sleep
+		func(ctx context.Context) (bool, error) {
+			nodesStatus, err := r.getClusterNodesStatus(ctx, humioHttpClient)
+			if err != nil {
+				return false, r.logErrorAndReturn(err, "could not get cluster nodes status.")
+			}
+			for _, node := range nodesStatus {
+				if node.GetId() == vhost {
+					reasonsNodeCannotBeSafelyUnregistered := node.GetReasonsNodeCannotBeSafelyUnregistered()
+					if !reasonsNodeCannotBeSafelyUnregistered.GetHasDataThatExistsOnlyOnThisNode() &&
+						!reasonsNodeCannotBeSafelyUnregistered.GetHasUnderReplicatedData() &&
+						!reasonsNodeCannotBeSafelyUnregistered.GetLeadsDigest() {
+						// if cheap check is ok, run a cache refresh check
+						if ok, _ := r.checkEvictionStatusForPodUsingClusterRefresh(ctx, humioHttpClient, vhost); ok {
+							safelyEvictable = true
+							return true, nil
+						}
 					}
 				}
 			}
+			return false, nil
+		},
+	)
+	if pollErr != nil {
+		// Timeout / ctx cancellation → not safely evictable yet, but
+		// don't surface the error to callers (matches the pre-#1060
+		// behavior of "return false, nil" on timeout).
+		if errors.Is(pollErr, context.Canceled) || errors.Is(pollErr, context.DeadlineExceeded) {
+			return false, nil
 		}
+		return false, pollErr
 	}
-
-	return false, nil
+	return safelyEvictable, nil
 }
 
 // Gracefully removes a LogScale pod from the nodepool using the following steps:
@@ -2572,21 +2592,31 @@ func (r *HumioClusterReconciler) markPodForEviction(ctx context.Context, hc *hum
 }
 
 func (r *HumioClusterReconciler) updateEvictionStatus(ctx context.Context, nodesStatus []humiographql.GetEvictionStatusClusterNodesClusterNode, pod corev1.Pod, vhost int) (bool, error) {
-	// wait for eviction status to be updated
+	// wait for eviction status to be updated.
+	//
+	// See issue #1060: poll honors ctx so operator drain / leader-election
+	// handoff / pod eviction don't get held hostage by this loop.
+	//
+	// NOTE: nodesStatus is a parameter and is NOT refreshed inside the
+	// loop, so this poll re-checks the same data each iteration. Existing
+	// behavior preserved — the refresh-data-inside-the-loop fix is a
+	// separate semantic question for a maintainer.
 	isBeingEvicted := false
-	for i := 0; i < waitForPodTimeoutSeconds; i++ {
-		for _, node := range nodesStatus {
-			if node.GetId() == vhost && *node.GetIsBeingEvicted() {
-				isBeingEvicted = true
-				break
+	_ = wait.PollUntilContextTimeout(
+		ctx,
+		time.Second,
+		time.Duration(waitForPodTimeoutSeconds)*time.Second,
+		true, // immediate: do the first check before the first sleep
+		func(ctx context.Context) (bool, error) {
+			for _, node := range nodesStatus {
+				if node.GetId() == vhost && *node.GetIsBeingEvicted() {
+					isBeingEvicted = true
+					return true, nil
+				}
 			}
-		}
-
-		if isBeingEvicted { // skip the waiting if marked
-			break
-		}
-		time.Sleep(time.Second * 1)
-	}
+			return false, nil
+		},
+	)
 
 	if !isBeingEvicted {
 		return false, nil

--- a/internal/controller/humiocluster_pods.go
+++ b/internal/controller/humiocluster_pods.go
@@ -35,6 +35,7 @@ import (
 	"github.com/humio/humio-operator/internal/kubernetes"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -699,24 +700,32 @@ func (r *HumioClusterReconciler) waitForNewPods(ctx context.Context, hnp *HumioN
 	// This will account for the newly created pods
 	expectedPodCount += len(expectedPods)
 
-	for i := 0; i < waitForPodTimeoutSeconds; i++ {
-		var podsMatchingRevisionCount int
-		latestPodList, err := kubernetes.ListPods(ctx, r, hnp.GetNamespace(), hnp.GetNodePoolLabels())
-		if err != nil {
-			return err
-		}
-		for _, pod := range latestPodList {
-			if pod.Annotations[PodHashAnnotation] == expectedPods[0].Annotations[PodHashAnnotation] {
-				podsMatchingRevisionCount++
+	// See issue #1060: poll honors ctx so operator drain / leader-election
+	// handoff / pod eviction don't get held hostage by this loop.
+	pollErr := wait.PollUntilContextTimeout(
+		ctx,
+		time.Second,
+		time.Duration(waitForPodTimeoutSeconds)*time.Second,
+		true, // immediate: do the first check before the first sleep
+		func(ctx context.Context) (bool, error) {
+			latestPodList, err := kubernetes.ListPods(ctx, r, hnp.GetNamespace(), hnp.GetNodePoolLabels())
+			if err != nil {
+				return false, err
 			}
-		}
-		r.Log.Info(fmt.Sprintf("validating new pods were created. expected pod count %d, current pod count %d", expectedPodCount, podsMatchingRevisionCount))
-		if podsMatchingRevisionCount >= expectedPodCount {
-			return nil
-		}
-		time.Sleep(time.Second * 1)
+			var podsMatchingRevisionCount int
+			for _, pod := range latestPodList {
+				if pod.Annotations[PodHashAnnotation] == expectedPods[0].Annotations[PodHashAnnotation] {
+					podsMatchingRevisionCount++
+				}
+			}
+			r.Log.Info(fmt.Sprintf("validating new pods were created. expected pod count %d, current pod count %d", expectedPodCount, podsMatchingRevisionCount))
+			return podsMatchingRevisionCount >= expectedPodCount, nil
+		},
+	)
+	if pollErr != nil {
+		return fmt.Errorf("timed out waiting to validate new pods was created: %w", pollErr)
 	}
-	return fmt.Errorf("timed out waiting to validate new pods was created")
+	return nil
 }
 
 func (r *HumioClusterReconciler) getPodDesiredLifecycleState(ctx context.Context, hnp *HumioNodePool, foundPodList []corev1.Pod, attachments *podAttachments, podsWithErrorsFoundSoBypassZoneAwareness bool) (PodLifeCycleState, *corev1.Pod, error) {

--- a/internal/controller/humiocluster_pods.go
+++ b/internal/controller/humiocluster_pods.go
@@ -723,7 +723,14 @@ func (r *HumioClusterReconciler) waitForNewPods(ctx context.Context, hnp *HumioN
 		},
 	)
 	if pollErr != nil {
-		return fmt.Errorf("timed out waiting to validate new pods was created: %w", pollErr)
+		// Distinguish timeout/cancel (canned message, preserves the old
+		// "timed out waiting" wording) from a propagated ListPods error
+		// (returned raw, matching the pre-#1060 behavior of surfacing
+		// the underlying API error to the caller without re-wrapping).
+		if errors.Is(pollErr, context.DeadlineExceeded) || errors.Is(pollErr, context.Canceled) {
+			return fmt.Errorf("timed out waiting to validate new pods was created: %w", pollErr)
+		}
+		return pollErr
 	}
 	return nil
 }

--- a/internal/controller/humiocluster_pods_test.go
+++ b/internal/controller/humiocluster_pods_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2020 Humio https://humio.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	humiov1alpha1 "github.com/humio/humio-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// Tests for waitForNewPods — the loop converted in issue #1060 from a
+// fixed-iteration time.Sleep into wait.PollUntilContextTimeout. The new
+// contract: (1) returns nil promptly when the expected pods are visible,
+// (2) honors ctx cancellation rather than running the full 10s, (3) returns
+// a timeout error when pods never appear.
+
+const testPodHash = "test-hash-abc"
+
+func newWaitForPodsReconciler(initial ...client.Object) *HumioClusterReconciler {
+	builder := fake.NewClientBuilder()
+	if len(initial) > 0 {
+		builder = builder.WithObjects(initial...)
+	}
+	return &HumioClusterReconciler{
+		Client: builder.Build(),
+		Log:    logr.Discard(),
+	}
+}
+
+func newHumioNodePoolForTest(t *testing.T, namespace, name string) *HumioNodePool {
+	t.Helper()
+	hc := &humiov1alpha1.HumioCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	return NewHumioNodeManagerFromHumioCluster(hc)
+}
+
+func podWithHash(namespace, name string, labels map[string]string, hash string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      labels,
+			Annotations: map[string]string{PodHashAnnotation: hash},
+		},
+	}
+}
+
+func TestWaitForNewPods_ReturnsWhenExpectedPodsExist(t *testing.T) {
+	hnp := newHumioNodePoolForTest(t, "ns", "cluster-a")
+	labels := hnp.GetNodePoolLabels()
+
+	// Pre-populate the fake client with one pod matching the expected hash.
+	existing := podWithHash("ns", "existing-pod", labels, testPodHash)
+	r := newWaitForPodsReconciler(existing)
+
+	expectedPods := []corev1.Pod{*podWithHash("ns", "new-pod", labels, testPodHash)}
+
+	start := time.Now()
+	err := r.waitForNewPods(context.Background(), hnp, nil, expectedPods)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	// `immediate: true` means the first check fires before the first sleep.
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("expected immediate return, took %v", elapsed)
+	}
+}
+
+func TestWaitForNewPods_RespectsContextCancellation(t *testing.T) {
+	hnp := newHumioNodePoolForTest(t, "ns", "cluster-b")
+	r := newWaitForPodsReconciler() // no pods exist — would loop full 10s
+
+	expectedPods := []corev1.Pod{*podWithHash("ns", "wanted-pod", hnp.GetNodePoolLabels(), testPodHash)}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := r.waitForNewPods(ctx, hnp, nil, expectedPods)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected context error, got nil")
+	}
+	// Pre-#1060 the loop would have slept the full 10s ignoring cancel.
+	// New behavior: returns promptly. Generous CI bound, well under 10s.
+	if elapsed > 3*time.Second {
+		t.Fatalf("ctx cancellation should return promptly, took %v", elapsed)
+	}
+}

--- a/internal/controller/humiocluster_pods_test.go
+++ b/internal/controller/humiocluster_pods_test.go
@@ -18,6 +18,8 @@ package controller
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -27,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 // Tests for waitForNewPods — the loop converted in issue #1060 from a
@@ -116,5 +119,42 @@ func TestWaitForNewPods_RespectsContextCancellation(t *testing.T) {
 	// New behavior: returns promptly. Generous CI bound, well under 10s.
 	if elapsed > 3*time.Second {
 		t.Fatalf("ctx cancellation should return promptly, took %v", elapsed)
+	}
+}
+
+// Regression guard: if kubernetes.ListPods returns a non-timeout error (RBAC
+// denial, network failure, etc.), waitForNewPods must propagate that error
+// raw rather than wrapping it as "timed out waiting...". The pre-#1060 code
+// returned the ListPods error directly; the first cut of the #1060 refactor
+// wrapped every pollErr as a timeout, masking the actual cause. This test
+// pins the corrected behavior.
+func TestWaitForNewPods_PropagatesListErrorWithoutTimeoutWrap(t *testing.T) {
+	hnp := newHumioNodePoolForTest(t, "ns", "cluster-c")
+
+	sentinelErr := errors.New("forbidden: list pods rbac denied")
+
+	// Build a client whose List call always fails with our sentinel.
+	rawClient := fake.NewClientBuilder().Build()
+	c := interceptor.NewClient(rawClient, interceptor.Funcs{
+		List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+			return sentinelErr
+		},
+	})
+	r := &HumioClusterReconciler{Client: c, Log: logr.Discard()}
+
+	expectedPods := []corev1.Pod{*podWithHash("ns", "p", hnp.GetNodePoolLabels(), testPodHash)}
+
+	err := r.waitForNewPods(context.Background(), hnp, nil, expectedPods)
+
+	if err == nil {
+		t.Fatal("expected error from ListPods, got nil")
+	}
+	// The underlying err must be reachable via errors.Is — not wrapped
+	// behind "timed out waiting".
+	if !errors.Is(err, sentinelErr) {
+		t.Errorf("expected errors.Is(err, sentinelErr) to be true, got err=%v", err)
+	}
+	if msg := err.Error(); strings.HasPrefix(msg, "timed out") {
+		t.Errorf("error message should NOT mention timeout for ListPods failure; got %q", msg)
 	}
 }


### PR DESCRIPTION
## Summary

Follow-on to #1055 / PR #1057. The bootstrap-token pod-wait fix in PR #1057 didn't cover three other call sites that have the same `for i := 0; i < waitForPodTimeoutSeconds; i++` / `time.Sleep(1s)` / ctx-blind pattern:

| Site | File:Line | Behavior |
|------|-----------|----------|
| `waitForNewPods` | `humiocluster_pods.go:702` | Waits 10s for new pods to appear, sleeping 1s/iter, no ctx check |
| `checkEvictionStatusForPod` | `humiocluster_controller.go:2488` | Loops 10 times calling `getClusterNodesStatus`, no ctx check between iters |
| `updateEvictionStatus` | `humiocluster_controller.go:2577` | Sleeps 1s/iter up to 10s waiting for eviction flag, no ctx honor |

## Why this matters

Same blast radius as #1055: operator drain, leader-election handoff, or pod eviction during any of these waits is held hostage by the loop. SIGTERM can wait up to 10s per call. Across multiple waits stacked in a reconcile pass, the operator can blow past the kubelet's `terminationGracePeriodSeconds` and die ungracefully.

## Approach

All three converted to `wait.PollUntilContextTimeout(ctx, time.Second, ...)`, matching the pattern from PR #1057. No behavior change on the success path; cancellation is now prompt.

## Tests

- `TestWaitForNewPods_ReturnsWhenExpectedPodsExist` — pre-populated fake client; asserts immediate (`<500ms`) return when expected pods are visible
- `TestWaitForNewPods_RespectsContextCancellation` — empty fake client; ctx cancelled at 200ms; asserts return well under the 10s timeout (`<3s`)

Tests for `checkEvictionStatusForPod` and `updateEvictionStatus` would require a fake `humio.Client` interface implementation and are left out of this PR to keep the diff focused. The conversion is mechanical and identical to the path that **is** test-covered.

## Notes for maintainers

1. **`updateEvictionStatus` has a pre-existing semantic question**: `nodesStatus` is a parameter that is never refreshed inside the loop, so the poll re-checks the same data each iteration. Behavior preserved exactly — this PR is ctx-cancellation only. Flagged inline in a comment.

2. **`isEvictedNodeAlive` at `humiocluster_controller.go:2458`** has the same outer `for i := 0; i < 10; i++` structure **with no sleep**, iterating over parameter data that is never refreshed. Either dead code or a broken-refresh bug rather than a ctx-cancellation issue. Left for a maintainer to clarify before any fix. Mentioned in #1060.

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./internal/controller/ -short` passes

Closes #1060.

Proudly Made in Nebraska. Go Big Red! 🌽 https://xkcd.com/2347/

🤖 Generated with [Claude Code](https://claude.com/claude-code)